### PR TITLE
Feat: Slack 헬스체크 메시지 핸들러 추가

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,7 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
-import { Event, Message } from 'nestjs-slack-bolt';
-import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from '@slack/bolt';
+import { Message } from 'nestjs-slack-bolt';
+import type { SlackEventMiddlewareArgs } from '@slack/bolt';
+import * as os from 'os';
+
+const SERVER_START_TIME = new Date();
 
 @Controller()
 export class AppController {
@@ -13,7 +16,24 @@ export class AppController {
   }
 
   @Message('hi')
+  @Message('test')
+  @Message('health')
+  @Message('ping')
   message({ say }: SlackEventMiddlewareArgs<'message'>) {
-    say('Hello');
+    const hostname = os.hostname();
+    const networkInterfaces = os.networkInterfaces();
+    const ip =
+      Object.values(networkInterfaces)
+        .flat()
+        .find((iface) => iface?.family === 'IPv4' && !iface.internal)
+        ?.address || 'unknown';
+
+    const startedAtUtc = SERVER_START_TIME.toISOString();
+    const startedAtKr = SERVER_START_TIME.toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul',
+    });
+    say(
+      `Hello from ${hostname} (${ip})\nStarted at: ${startedAtUtc} (${startedAtKr})`,
+    );
   }
 }


### PR DESCRIPTION
- hi, test, health, ping 메시지에 서버 상태 응답
- 호스트명, IP 주소, 서버 시작 시각(UTC/KST) 반환