### PR TITLE
Feat: 태그 및 학급 관리 모달 학년 표시 기능 추가

### DIFF
--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -63,18 +63,20 @@ export class ScheduleController {
       status === 'all' ? undefined : (status as 'active' | 'inactive');
     const tagFilter = tagIds.length > 0 ? tagIds : undefined;
 
-    const [{ schedules, total }, allTags] = await Promise.all([
+    const [{ schedules, total }, displayTags] = await Promise.all([
       this.scheduleService.findSchedulesPaginated({
         page,
         pageSize: this.SCHEDULE_PAGE_SIZE,
         status: statusFilter,
         tagIds: tagFilter,
       }),
-      this.tagService.findAllTags(),
+      this.tagService.findDisplayTags(),
     ]);
 
     const totalPages = Math.max(1, Math.ceil(total / this.SCHEDULE_PAGE_SIZE));
     const safePage = Math.min(page, totalPages - 1);
+
+    const displayTagMap = new Map(displayTags.map((t) => [t.id, t.name]));
 
     return ScheduleView.listModal(
       schedules.map((s) => ({
@@ -82,11 +84,14 @@ export class ScheduleController {
         name: s.name,
         description: s.description,
         status: s.status,
-        tags: s.tags.map((t) => ({ id: t.id, name: t.name })),
+        tags: s.tags.map((t) => ({
+          id: t.id,
+          name: displayTagMap.get(t.id) ?? t.name,
+        })),
         createdBy: { name: s.createdBy?.name ?? '알 수 없음' },
         createdAt: s.createdAt,
       })),
-      allTags.map((t) => ({ id: t.id, name: t.name, status: t.status })),
+      displayTags,
       {
         page: safePage,
         totalPages,
@@ -145,17 +150,11 @@ export class ScheduleController {
       return;
     }
 
-    const tags = await this.tagService.findAllTags();
+    const tags = await this.tagService.findDisplayTags();
 
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: ScheduleView.createModal(
-        tags.map((t) => ({
-          id: t.id,
-          name: t.name,
-          status: t.status,
-        })),
-      ),
+      view: ScheduleView.createModal(tags),
     });
   }
 
@@ -351,17 +350,11 @@ export class ScheduleController {
       return;
     }
 
-    const tags = await this.tagService.findAllTags();
+    const tags = await this.tagService.findDisplayTags();
 
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: ScheduleView.subscribeSearchModal(
-        tags.map((t) => ({
-          id: t.id,
-          name: t.name,
-          status: t.status,
-        })),
-      ),
+      view: ScheduleView.subscribeSearchModal(tags),
     });
   }
 
@@ -373,25 +366,29 @@ export class ScheduleController {
   ) {
     const tagFilter = tagIds.length > 0 ? tagIds : undefined;
 
-    const [{ schedules, total }, activeTags] = await Promise.all([
+    const [{ schedules, total }, displayActiveTags] = await Promise.all([
       this.scheduleService.findSchedulesPaginated({
         page,
         pageSize: this.SCHEDULE_PAGE_SIZE,
         status: 'active',
         tagIds: tagFilter,
       }),
-      this.tagService.findActiveTags(),
+      this.tagService.findDisplayTags(true),
     ]);
 
     const totalPages = Math.max(1, Math.ceil(total / this.SCHEDULE_PAGE_SIZE));
     const safePage = Math.min(page, totalPages - 1);
+    const displayActiveTagMap = new Map(displayActiveTags.map((t) => [t.id, t.name]));
 
     const schedulesWithSubscription = await Promise.all(
       schedules.map(async (s) => ({
         id: s.id,
         name: s.name,
         description: s.description,
-        tags: s.tags.map((t) => ({ id: t.id, name: t.name })),
+        tags: s.tags.map((t) => ({
+          id: t.id,
+          name: displayActiveTagMap.get(t.id) ?? t.name,
+        })),
         createdBy: { name: s.createdBy?.name ?? '알 수 없음' },
         createdAt: s.createdAt,
         isSubscribed: await this.scheduleService.isSubscribed(s.id, userEmail),
@@ -399,7 +396,7 @@ export class ScheduleController {
     );
 
     return ScheduleView.subscribeSearchModal(
-      activeTags.map((t) => ({ id: t.id, name: t.name, status: t.status })),
+      displayActiveTags,
       schedulesWithSubscription,
       tagIds,
       { page: safePage, totalPages, total },
@@ -495,10 +492,10 @@ export class ScheduleController {
       const action = body.actions[0] as { action_id: string };
       const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
 
-      const [schedule, allTags, permissions, notifChannelIds] =
+      const [schedule, displayTags, permissions, notifChannelIds] =
         await Promise.all([
           this.scheduleService.findById(scheduleId),
-          this.tagService.findAllTags(),
+          this.tagService.findDisplayTags(),
           this.scheduleService.getCalendarPermissions(scheduleId),
           this.channelService.getSlackChannelIds(scheduleId),
         ]);
@@ -522,7 +519,7 @@ export class ScheduleController {
             description: schedule.description,
             tags: schedule.tags,
           },
-          allTags,
+          displayTags,
           writers,
           notifChannelIds,
         ),
@@ -590,7 +587,9 @@ export class ScheduleController {
         (id) => !newStudentClassIds.includes(id),
       );
       const removedChannelIds =
-        await this.channelService.getClassSlackChannelIds(removedStudentClassIds);
+        await this.channelService.getClassSlackChannelIds(
+          removedStudentClassIds,
+        );
       const filteredChannelIds = selectedChannelIds.filter(
         (id) => !removedChannelIds.includes(id),
       );
@@ -599,7 +598,10 @@ export class ScheduleController {
         scheduleId,
         filteredChannelIds,
       );
-      await this.channelService.syncClassChannels(scheduleId, newStudentClassIds);
+      await this.channelService.syncClassChannels(
+        scheduleId,
+        newStudentClassIds,
+      );
 
       await client.chat.postMessage({
         channel: body.user.id,
@@ -663,10 +665,10 @@ export class ScheduleController {
       const currentTagOptions =
         currentValues['tags_block']?.['tags_input']?.selected_options;
 
-      const [schedule, allTags, permissions, notifChannelIds] =
+      const [schedule, displayTags, permissions, notifChannelIds] =
         await Promise.all([
           this.scheduleService.findById(scheduleId),
-          this.tagService.findAllTags(),
+          this.tagService.findDisplayTags(),
           this.scheduleService.getCalendarPermissions(scheduleId),
           this.channelService.getSlackChannelIds(scheduleId),
         ]);
@@ -694,7 +696,7 @@ export class ScheduleController {
                 }))
               : schedule.tags,
           },
-          allTags,
+          displayTags,
           writers,
           notifChannelIds,
         ),
@@ -789,9 +791,9 @@ export class ScheduleController {
       await this.scheduleService.shareCalendar(scheduleId, email, 'writer');
 
       // 편집자 추가 후 수정 모달 갱신
-      const [schedule, allTags, permissions] = await Promise.all([
+      const [schedule, displayTags, permissions] = await Promise.all([
         this.scheduleService.findById(scheduleId),
-        this.tagService.findAllTags(),
+        this.tagService.findDisplayTags(),
         this.scheduleService.getCalendarPermissions(scheduleId),
       ]);
 
@@ -812,7 +814,7 @@ export class ScheduleController {
               description: schedule.description,
               tags: schedule.tags,
             },
-            allTags,
+            displayTags,
             writers,
           ),
         });

--- a/src/student-class/student-class.controller.ts
+++ b/src/student-class/student-class.controller.ts
@@ -63,8 +63,10 @@ export class StudentClassController {
         classes.map((c) => ({
           id: c.id,
           name: c.name,
+          admissionYear: c.admissionYear,
           graduationYear: c.graduationYear,
           status: c.status,
+          slackChannelId: c.slackChannelId ?? undefined,
         })),
       ),
     });
@@ -220,8 +222,10 @@ export class StudentClassController {
             classes.map((c) => ({
               id: c.id,
               name: c.name,
+              admissionYear: c.admissionYear,
               graduationYear: c.graduationYear,
               status: c.status,
+              slackChannelId: c.slackChannelId ?? undefined,
             })),
           ),
         });

--- a/src/student-class/student-class.view.ts
+++ b/src/student-class/student-class.view.ts
@@ -4,8 +4,10 @@ import { StudentClassStatus } from './student-class.entity';
 export interface StudentClassListItem {
   id: number;
   name: string;
+  admissionYear: number;
   graduationYear: number;
   status: StudentClassStatus;
+  slackChannelId?: string;
 }
 
 const STATUS_LABELS: Record<StudentClassStatus, string> = {
@@ -45,11 +47,19 @@ export class StudentClassView {
         const toggleValue =
           cls.status === StudentClassStatus.ACTIVE ? 'graduate' : 'activate';
 
+        const gradeInfo =
+          cls.status === StudentClassStatus.GRADUATED
+            ? '졸업'
+            : `${new Date().getFullYear() - cls.admissionYear + 1}학년`;
+        const channelInfo = cls.slackChannelId
+          ? ` | 채널: <#${cls.slackChannelId}>`
+          : '';
+
         blocks.push({
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `${statusEmoji} *${cls.name}*\n졸업 연도: ${cls.graduationYear} | 상태: ${STATUS_LABELS[cls.status]}`,
+            text: `${statusEmoji} *${cls.name}* (${gradeInfo})\n졸업 연도: ${cls.graduationYear} | 상태: ${STATUS_LABELS[cls.status]}${channelInfo}`,
           },
           accessory: {
             type: 'button',

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -54,18 +54,11 @@ export class TagController {
       return;
     }
 
-    const tags = await this.tagService.findAllTags();
+    const tags = await this.tagService.findDisplayTags();
 
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: TagView.listModal(
-        tags.map((t) => ({
-          id: t.id,
-          name: t.name,
-          status: t.status,
-          isClassTag: t.studentClassId !== null,
-        })),
-      ),
+      view: TagView.listModal(tags),
     });
   }
 
@@ -167,19 +160,12 @@ export class TagController {
       }
 
       // 목록 새로고침
-      const tags = await this.tagService.findAllTags();
+      const tags = await this.tagService.findDisplayTags();
 
       if (body.view?.id) {
         await client.views.update({
           view_id: body.view.id,
-          view: TagView.listModal(
-            tags.map((t) => ({
-              id: t.id,
-              name: t.name,
-              status: t.status,
-              isClassTag: t.studentClassId !== null,
-            })),
-          ),
+          view: TagView.listModal(tags),
         });
       }
 

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -2,10 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Tag, TagStatus } from './tag.entity';
+import { StudentClassStatus } from '../student-class/student-class.entity';
 
 export interface CreateTagDto {
   name: string;
   studentClassId?: number;
+}
+
+export interface TagDisplayItem {
+  id: number;
+  name: string;
+  status: TagStatus;
+  isClassTag: boolean;
 }
 
 @Injectable()
@@ -53,6 +61,7 @@ export class TagService {
   async findActiveTags(): Promise<Tag[]> {
     return this.tagRepository.find({
       where: { status: TagStatus.ACTIVE },
+      relations: ['studentClass'],
       order: { name: 'ASC' },
     });
   }
@@ -60,6 +69,7 @@ export class TagService {
   // 모든 태그 목록 조회 (관리용)
   async findAllTags(): Promise<Tag[]> {
     return this.tagRepository.find({
+      relations: ['studentClass'],
       order: { status: 'ASC', name: 'ASC' },
     });
   }
@@ -79,5 +89,28 @@ export class TagService {
   // 태그 삭제 (soft delete)
   async deleteTag(id: number): Promise<void> {
     await this.tagRepository.softDelete({ id });
+  }
+
+  // 표시용 태그 목록 조회 (학년 정보 포함)
+  async findDisplayTags(activeOnly = false): Promise<TagDisplayItem[]> {
+    const tags = activeOnly
+      ? await this.findActiveTags()
+      : await this.findAllTags();
+    return tags.map((t) => ({
+      id: t.id,
+      name: TagService.buildDisplayName(t),
+      status: t.status,
+      isClassTag: t.studentClassId !== null,
+    }));
+  }
+
+  // 표시용 이름 생성 (반 태그에 학년 정보 추가)
+  static buildDisplayName(tag: Tag): string {
+    if (!tag.studentClass) return tag.name;
+    if (tag.studentClass.status === StudentClassStatus.GRADUATED) {
+      return `${tag.name} (졸업)`;
+    }
+    const grade = new Date().getFullYear() - tag.studentClass.admissionYear + 1;
+    return `${tag.name} (${grade}학년)`;
   }
 }


### PR DESCRIPTION
- TagService.buildDisplayName() 추가: 반 태그에 현재 학년 표시
  - 학년 계산: 현재연도 - admissionYear + 1
  - 졸업반(GRADUATED)은 '(졸업)' 표시
- findAllTags(), findActiveTags()에 relations: ['studentClass'] 추가
- TagDisplayItem 인터페이스 및 findDisplayTags(activeOnly?) 추가
  - 컨트롤러에서 buildDisplayName 매핑 없이 학년 포함 태그 목록 조회 가능
- tag.controller, schedule.controller에 findDisplayTags() 일괄 적용
  - 중복 map(buildDisplayName) 코드 제거
  - handleOpenEdit, handleRemoveWriter의 수정 모달 학년 미표시 버그 수정
- student-class.view.ts: 학급 목록에 학년 및 Slack 채널 정보 표시
  - StudentClassListItem에 admissionYear, slackChannelId 필드 추가
- student-class.controller.ts: 학급 목록 매핑에 admissionYear, slackChannelId 추가