### PR TITLE
Fix: Release 후 트리거 비작동 문제 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create GitHub Release
         if: steps.check-tag.outputs.exists == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh release create "v${{ steps.version.outputs.version }}" \
             --title "v${{ steps.version.outputs.version }}" \


### PR DESCRIPTION
- 깃허브의 기본 토큰인 `secrets.GITHUB_TOKEN`을 이용할 경우 무한 루프를 방지하기 위해서, 이벤트가 다른 워크플로우를 트리거 하지 않음
- 릴리즈 시 docker-publish 워크플로우를 트리거 하기 위해 별도의 `RELEASE_TOKEN` 주입
- secrets: `RELEASE_TOKEN` 추가