### PR TITLE
fix: 시간표 생성 시 알림 채널이 등록되지 않던 문제 수정

### DIFF
--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -203,7 +203,7 @@ export class ScheduleController {
       const creatorRefreshToken =
         this.userService.getDecryptedRefreshToken(user);
 
-      await this.scheduleService.createSchedule({
+      const created = await this.scheduleService.createSchedule({
         name: name.trim(),
         description: description?.trim(),
         tagIds,
@@ -211,6 +211,12 @@ export class ScheduleController {
         creatorEmail: user.email,
         creatorRefreshToken: creatorRefreshToken ?? undefined,
       });
+
+      // 학반 태그 기반 알림 채널 자동 등록
+      const studentClassIds = (created.tags ?? [])
+        .filter((t) => t.studentClassId)
+        .map((t) => t.studentClassId!);
+      await this.channelService.syncClassChannels(created.id, studentClassIds);
 
       await client.chat.postMessage({
         channel: body.user.id,


### PR DESCRIPTION
- 시간표 생성 시 학반의 태그를 등록하여도 알림 채널이 등록 되지 않은 문제 발생
- 생성 시 syncClassChannels 함수 호출 하여 알림 채널 자동 등록

closes #32 