### PR TITLE
feat: 시간표 생성 시 Google Calendar 자동 공개 설정

### DIFF
--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -95,7 +95,10 @@ export class ScheduleService {
 
     const saved = await this.scheduleRepository.save(schedule);
 
-    // 4. 생성자에게 writer 권한 부여 및 자동 구독
+    // 4. 캘린더 전체 공개 설정
+    await GoogleCalendarUtil.makeCalendarPublic(calendarId);
+
+    // 5. 생성자에게 writer 권한 부여 및 자동 구독
     if (dto.creatorEmail && dto.creatorRefreshToken) {
       await GoogleCalendarUtil.shareCalendar({
         calendarId,
@@ -108,7 +111,7 @@ export class ScheduleService {
       );
     }
 
-    // 5. Google Calendar Watch 등록
+    // 6. Google Calendar Watch 등록
     await this.registerWatch(saved.id);
 
     return saved;


### PR DESCRIPTION
- `/구독` 에서 일정 보기로 누구나 미리 일정을 볼수 있게 하기 위해서 생성 시 전체 공개 설정