### PR TITLE
chore: Socket 모드와 HTTP 모드 환경 변수 기반 전환 지원

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,8 +41,9 @@ import { StudyRoomModule } from './study-room/study-room.module';
     }),
     SlackModule.forRoot({
       token: process.env.SLACK_BOT_TOKEN,
-      socketMode: true,
+      socketMode: process.env.SLACK_SOCKET_MODE !== 'false',
       appToken: process.env.SLACK_APP_TOKEN,
+      signingSecret: process.env.SLACK_SIGNING_SECRET,
     }),
     SlackHomeModule,
     UserModule,


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 운영 환경의 슬랙 앱 HTTP 모드로 동작 시키기 위해 설정 추가
- 로드 벨런싱 적용을 위해 변경

## 주요 변경 사항

### 환경 변수 기반 모드 설정
- SLACK_SOCKET_MODE=false 설정 시 HTTP 모드로 동작
- 기본값은 Socket 모드 유지 (로컬 개발 환경 호환)
- signingSecret 환경 변수 연결 (HTTP 모드 필수)

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
