### PR TITLE
fix: HTTP 모드 정상 동작 확인

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { TagModule } from './tag/tag.module';
 import { ScheduleModule } from './schedule/schedule.module';
 import { ChannelModule } from './channel/channel.module';
 import { StudyRoomModule } from './study-room/study-room.module';
+import { httpReceiver } from './slack-receiver';
 
 @Module({
   imports: [
@@ -39,12 +40,16 @@ import { StudyRoomModule } from './study-room/study-room.module';
       autoLoadEntities: true,
       synchronize: process.env.DB_SYNCHRONIZE === 'true',
     }),
-    SlackModule.forRoot({
-      token: process.env.SLACK_BOT_TOKEN,
-      socketMode: process.env.SLACK_SOCKET_MODE !== 'false',
-      appToken: process.env.SLACK_APP_TOKEN,
-      signingSecret: process.env.SLACK_SIGNING_SECRET,
-    }),
+    SlackModule.forRoot(
+      httpReceiver
+        ? { token: process.env.SLACK_BOT_TOKEN, receiver: httpReceiver, socketMode: false }
+        : {
+            token: process.env.SLACK_BOT_TOKEN,
+            socketMode: true,
+            appToken: process.env.SLACK_APP_TOKEN,
+            signingSecret: process.env.SLACK_SIGNING_SECRET,
+          },
+    ),
     SlackHomeModule,
     UserModule,
     StudentClassModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { httpReceiver } from './slack-receiver';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  if (httpReceiver) {
+    app.use(httpReceiver.router);
+  }
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/slack-receiver.ts
+++ b/src/slack-receiver.ts
@@ -1,0 +1,9 @@
+import { ExpressReceiver } from '@slack/bolt';
+
+const isSocketMode = process.env.SLACK_SOCKET_MODE !== 'false';
+
+export const httpReceiver = !isSocketMode
+  ? new ExpressReceiver({
+      signingSecret: process.env.SLACK_SIGNING_SECRET ?? '',
+    })
+  : undefined;


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->

## 주요 변경 사항

### 포트 충돌 해결
- ExpressReceiver를 NestJS에 마운트하여 동일 포트로 열리게 설정
- https://docs.slack.dev/tools/bolt-js/concepts/receiver/

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 
- [x] 로컬에서 HTTP 모드 및 Socket 모드 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->