### PR TITLE
refactor: requireAdmin 헬퍼로 권한 체크 및 오류 메시지 통합

### DIFF
--- a/src/common/slack-permission.ts
+++ b/src/common/slack-permission.ts
@@ -1,0 +1,31 @@
+import type { WebClient } from '@slack/web-api';
+import { UserService } from '../user/user.service';
+
+const PERMISSION_DENIED_MSG = '이 명령어는 조교 이상 권한이 필요합니다.';
+
+export async function requireAdmin(
+  userService: UserService,
+  userId: string,
+  client: WebClient,
+  channelId?: string,
+): Promise<boolean> {
+  if (await userService.isAdmin(userId)) return true;
+
+  try {
+    if (channelId) {
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        text: PERMISSION_DENIED_MSG,
+      });
+    } else {
+      await client.chat.postMessage({
+        channel: userId,
+        text: PERMISSION_DENIED_MSG,
+      });
+    }
+  } catch {
+    // 메시지 전송 실패 시 무시
+  }
+  return false;
+}

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -12,8 +12,9 @@ import { ScheduleView } from './schedule.view';
 import { UserService } from '../user/user.service';
 import { TagService } from '../tag/tag.service';
 import { ChannelService } from '../channel/channel.service';
-import { UserRole, UserStatus, User } from '../user/user.entity';
+import { UserStatus, User } from '../user/user.entity';
 import { CMD } from '../common/slack-commands';
+import { requireAdmin } from '../common/slack-permission';
 
 @Controller()
 export class ScheduleController {
@@ -23,22 +24,6 @@ export class ScheduleController {
     private readonly tagService: TagService,
     private readonly channelService: ChannelService,
   ) {}
-
-  // 조교 이상 권한 확인 헬퍼
-  private async checkAdminPermission(
-    slackUserId: string,
-  ): Promise<{ hasPermission: boolean; user?: User; message?: string }> {
-    const user = await this.userService.findBySlackId(slackUserId);
-    const allowedRoles = [UserRole.PROFESSOR, UserRole.TA];
-
-    if (!user || !allowedRoles.includes(user.role)) {
-      return {
-        hasPermission: false,
-        message: '이 명령어는 조교 이상 권한이 필요합니다.',
-      };
-    }
-    return { hasPermission: true, user };
-  }
 
   // 활성 사용자 확인 헬퍼
   private async checkActiveUser(
@@ -115,17 +100,15 @@ export class ScheduleController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const { hasPermission, message } = await this.checkAdminPermission(userId);
-    if (!hasPermission) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: message!,
-        });
-      }
+    if (
+      !(await requireAdmin(
+        this.userService,
+        userId,
+        client,
+        'channel_id' in body ? body.channel_id : undefined,
+      ))
+    )
       return;
-    }
 
     await client.views.open({
       trigger_id: body.trigger_id,
@@ -145,17 +128,15 @@ export class ScheduleController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const { hasPermission, message } = await this.checkAdminPermission(userId);
-    if (!hasPermission) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: message!,
-        });
-      }
+    if (
+      !(await requireAdmin(
+        this.userService,
+        userId,
+        client,
+        'channel_id' in body ? body.channel_id : undefined,
+      ))
+    )
       return;
-    }
 
     const tags = await this.tagService.findDisplayTags();
 
@@ -355,8 +336,7 @@ export class ScheduleController {
     AllMiddlewareArgs) {
     await ack();
 
-    const userId =
-      'user_id' in body ? body.user_id : body.user.id;
+    const userId = 'user_id' in body ? body.user_id : body.user.id;
 
     const { isActive, message } = await this.checkActiveUser(userId);
     if (!isActive) {
@@ -762,17 +742,15 @@ export class ScheduleController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const { hasPermission, message } = await this.checkAdminPermission(userId);
-    if (!hasPermission) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: message!,
-        });
-      }
+    if (
+      !(await requireAdmin(
+        this.userService,
+        userId,
+        client,
+        'channel_id' in body ? body.channel_id : undefined,
+      ))
+    )
       return;
-    }
 
     const schedules = await this.scheduleService.findActiveSchedules();
 
@@ -898,17 +876,15 @@ export class ScheduleController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const { hasPermission, message } = await this.checkAdminPermission(userId);
-    if (!hasPermission) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: message!,
-        });
-      }
+    if (
+      !(await requireAdmin(
+        this.userService,
+        userId,
+        client,
+        'channel_id' in body ? body.channel_id : undefined,
+      ))
+    )
       return;
-    }
 
     const groups = await this.scheduleService.findAllRecurrenceGroups();
 
@@ -977,17 +953,15 @@ export class ScheduleController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const { hasPermission, message } = await this.checkAdminPermission(userId);
-    if (!hasPermission) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: message!,
-        });
-      }
+    if (
+      !(await requireAdmin(
+        this.userService,
+        userId,
+        client,
+        'channel_id' in body ? body.channel_id : undefined,
+      ))
+    )
       return;
-    }
 
     const groups = await this.scheduleService.findAllRecurrenceGroups();
 

--- a/src/student-class/student-class.controller.ts
+++ b/src/student-class/student-class.controller.ts
@@ -10,9 +10,9 @@ import type {
 import { StudentClassService } from './student-class.service';
 import { StudentClassView } from './student-class.view';
 import { UserService } from '../user/user.service';
-import { UserRole } from '../user/user.entity';
 import { ClassSection } from './student-class.entity';
 import { CMD } from '../common/slack-commands';
+import { requireAdmin } from '../common/slack-permission';
 
 @Controller()
 export class StudentClassController {
@@ -20,22 +20,6 @@ export class StudentClassController {
     private readonly studentClassService: StudentClassService,
     private readonly userService: UserService,
   ) {}
-
-  // 권한 확인 헬퍼
-  private async checkPermission(
-    slackUserId: string,
-  ): Promise<{ hasPermission: boolean; message?: string }> {
-    const user = await this.userService.findBySlackId(slackUserId);
-    const allowedRoles = [UserRole.PROFESSOR, UserRole.TA];
-
-    if (!user || !allowedRoles.includes(user.role)) {
-      return {
-        hasPermission: false,
-        message: '이 명령어는 조교 이상 권한이 필요합니다.',
-      };
-    }
-    return { hasPermission: true };
-  }
 
   // /반 - 반 목록 조회
   @Command(CMD.반)
@@ -46,15 +30,15 @@ export class StudentClassController {
   }: SlackCommandMiddlewareArgs & AllMiddlewareArgs) {
     await ack();
 
-    const { hasPermission, message } = await this.checkPermission(body.user_id);
-    if (!hasPermission) {
-      await client.chat.postEphemeral({
-        channel: body.channel_id,
-        user: body.user_id,
-        text: message!,
-      });
+    if (
+      !(await requireAdmin(
+        this.userService,
+        body.user_id,
+        client,
+        body.channel_id,
+      ))
+    )
       return;
-    }
 
     const classes = await this.studentClassService.findAllClasses();
 
@@ -82,15 +66,15 @@ export class StudentClassController {
   }: SlackCommandMiddlewareArgs & AllMiddlewareArgs) {
     await ack();
 
-    const { hasPermission, message } = await this.checkPermission(body.user_id);
-    if (!hasPermission) {
-      await client.chat.postEphemeral({
-        channel: body.channel_id,
-        user: body.user_id,
-        text: message!,
-      });
+    if (
+      !(await requireAdmin(
+        this.userService,
+        body.user_id,
+        client,
+        body.channel_id,
+      ))
+    )
       return;
-    }
 
     await client.views.open({
       trigger_id: body.trigger_id,

--- a/src/study-room/study-room.controller.ts
+++ b/src/study-room/study-room.controller.ts
@@ -11,9 +11,10 @@ import { StudyRoomService } from './study-room.service';
 import { StudyRoomView } from './study-room.view';
 import { StudyRoomStatus } from './study-room.entity';
 import { UserService } from '../user/user.service';
-import { UserRole, UserStatus } from '../user/user.entity';
+import { UserStatus } from '../user/user.entity';
 import { GoogleCalendarUtil } from '../google/google-calendar.util';
 import { CMD } from '../common/slack-commands';
+import { requireAdmin } from '../common/slack-permission';
 
 @Controller()
 export class StudyRoomController {
@@ -35,23 +36,15 @@ export class StudyRoomController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const user = await this.userService.findBySlackId(userId);
-    // TODO 스케줄 서비스의 조교 이상 권한 확인 메소드랑 통합 필요
-    const allowed = [UserRole.PROFESSOR, UserRole.TA];
     if (
-      !user ||
-      user.status !== UserStatus.ACTIVE ||
-      !allowed.includes(user.role)
-    ) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: '조교 이상 권한이 필요합니다.',
-        });
-      }
+      !(await requireAdmin(
+        this.userService,
+        userId,
+        client,
+        'channel_id' in body ? body.channel_id : undefined,
+      ))
+    )
       return;
-    }
 
     await client.views.open({
       trigger_id: body.trigger_id,
@@ -429,7 +422,6 @@ export class StudyRoomController {
 
   // ========== 스터디룸 관리 (어드민) ==========
 
-
   @Command(CMD.스터디룸)
   @Action('home:open-study-room-manage')
   async openManageModal({
@@ -441,22 +433,15 @@ export class StudyRoomController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const user = await this.userService.findBySlackId(userId);
-    const allowed = [UserRole.PROFESSOR, UserRole.TA];
     if (
-      !user ||
-      user.status !== UserStatus.ACTIVE ||
-      !allowed.includes(user.role)
-    ) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: '조교 이상 권한이 필요합니다.',
-        });
-      }
+      !(await requireAdmin(
+        this.userService,
+        userId,
+        client,
+        'channel_id' in body ? body.channel_id : undefined,
+      ))
+    )
       return;
-    }
 
     const rooms = await this.studyRoomService.findAll();
     await client.views.open({

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -10,8 +10,8 @@ import type {
 import { TagService } from './tag.service';
 import { TagView } from './tag.view';
 import { UserService } from '../user/user.service';
-import { UserRole } from '../user/user.entity';
 import { CMD } from '../common/slack-commands';
+import { requireAdmin } from '../common/slack-permission';
 
 @Controller()
 export class TagController {
@@ -19,22 +19,6 @@ export class TagController {
     private readonly tagService: TagService,
     private readonly userService: UserService,
   ) {}
-
-  // 권한 확인 헬퍼
-  private async checkPermission(
-    slackUserId: string,
-  ): Promise<{ hasPermission: boolean; message?: string }> {
-    const user = await this.userService.findBySlackId(slackUserId);
-    const allowedRoles = [UserRole.PROFESSOR, UserRole.TA];
-
-    if (!user || !allowedRoles.includes(user.role)) {
-      return {
-        hasPermission: false,
-        message: '이 명령어는 조교 이상 권한이 필요합니다.',
-      };
-    }
-    return { hasPermission: true };
-  }
 
   // /태그 - 태그 목록 조회
   @Command(CMD.태그)
@@ -48,17 +32,7 @@ export class TagController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const { hasPermission, message } = await this.checkPermission(userId);
-    if (!hasPermission) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: message!,
-        });
-      }
-      return;
-    }
+    if (!await requireAdmin(this.userService, userId, client, 'channel_id' in body ? body.channel_id : undefined)) return;
 
     const tags = await this.tagService.findDisplayTags();
 
@@ -80,17 +54,7 @@ export class TagController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const { hasPermission, message } = await this.checkPermission(userId);
-    if (!hasPermission) {
-      if ('channel_id' in body) {
-        await client.chat.postEphemeral({
-          channel: body.channel_id,
-          user: userId,
-          text: message!,
-        });
-      }
-      return;
-    }
+    if (!await requireAdmin(this.userService, userId, client, 'channel_id' in body ? body.channel_id : undefined)) return;
 
     await client.views.open({
       trigger_id: body.trigger_id,

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -14,6 +14,7 @@ import { OAuthUtil } from './google-oauth.util';
 import { UserRole } from './user.entity';
 import { StudentClassService } from '../student-class/student-class.service';
 import { CMD } from '../common/slack-commands';
+import { requireAdmin } from '../common/slack-permission';
 
 @Controller()
 export class UserController {
@@ -216,22 +217,15 @@ export class UserController {
 
       const userId = 'user_id' in body ? body.user_id : body.user.id;
 
-      // 조교 이상 권한 확인
-      const currentUser = await this.userService.findBySlackId(userId);
-      const allowedRoles = [UserRole.PROFESSOR, UserRole.TA];
-      const hasPermission =
-        currentUser && allowedRoles.includes(currentUser.role);
-
-      if (!hasPermission) {
-        if ('channel_id' in body) {
-          await client.chat.postEphemeral({
-            channel: body.channel_id,
-            user: userId,
-            text: '이 명령어는 조교 이상 권한이 필요합니다.',
-          });
-        }
+      if (
+        !(await requireAdmin(
+          this.userService,
+          userId,
+          client,
+          'channel_id' in body ? body.channel_id : undefined,
+        ))
+      )
         return;
-      }
 
       // 승인 대기 유저 목록 조회
       const pendingUsers = await this.userService.findPendingApproval();

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -43,6 +43,14 @@ export class UserService {
     return this.userRepository.findOne({ where: { email } });
   }
 
+  async isAdmin(slackUserId: string): Promise<boolean> {
+    const user = await this.findBySlackId(slackUserId);
+    const allowed = [UserRole.PROFESSOR, UserRole.TA];
+    return (
+      !!user && user.status === UserStatus.ACTIVE && allowed.includes(user.role)
+    );
+  }
+
   async mapEmailsToSlackIds(emails: string[]): Promise<string[]> {
     const users = await Promise.all(emails.map((e) => this.findByEmail(e)));
     return users.filter((u): u is User => u !== null).map((u) => u.slackId);


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 컨트롤러마다 권한 체크를 다르게 수행하여, 응답 메시지를 변경할 때 하나하나 변경해야 하는 번거로움이 발생

## 주요 변경 사항

### 권한 체크 로직 공통화
- requireAdmin 이라는 별도의 함수를 만들어서 모든 컨트롤러가 해당 함수를 이용
- requireAdmin 내부에서 만약 권한이 없는 경우 채널 또는 DM 으로 알람

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
