### PR TITLE
fix: 예약의 참석자 0명일 경우 자동 취소

### DIFF
--- a/src/study-room/study-room.controller.ts
+++ b/src/study-room/study-room.controller.ts
@@ -389,26 +389,27 @@ export class StudyRoomController {
     const startTime = new Date(`${date}T${startTimeStr}:00+09:00`);
     const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
 
-    try {
-      await this.studyRoomService.modifyBooking(calendarId, eventId, {
+    const result = await this.studyRoomService.modifyBooking(
+      calendarId,
+      eventId,
+      {
         title,
         startTime,
         endTime,
         attendeeSlackIds,
         roomName,
-      });
+      },
+    );
 
+    if (result === 'cancelled') {
+      await client.chat.postMessage({
+        channel: body.user.id,
+        text: `🗑️ 참석자가 없어 *${roomName}* 예약이 취소되었습니다.\n${date} ${startTimeStr} (${durationMinutes}분)`,
+      });
+    } else {
       await client.chat.postMessage({
         channel: body.user.id,
         text: `✅ *${roomName}* 예약이 수정되었습니다.\n${date} ${startTimeStr} (${durationMinutes}분)`,
-      });
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : '수정 중 오류가 발생했습니다.';
-      this.logger.error(`Study room modify failed: ${message}`);
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ 예약 수정에 실패했습니다: ${message}`,
       });
     }
   }

--- a/src/study-room/study-room.service.ts
+++ b/src/study-room/study-room.service.ts
@@ -229,7 +229,12 @@ export class StudyRoomService {
     calendarId: string,
     eventId: string,
     dto: ModifyBookingDto,
-  ): Promise<void> {
+  ): Promise<'cancelled' | 'modified'> {
+    if (dto.attendeeSlackIds.length === 0) {
+      await this.cancelBooking(calendarId, eventId);
+      return 'cancelled';
+    }
+
     const refreshToken = await this.getEditorRefreshToken(calendarId);
 
     const attendees = (
@@ -260,5 +265,7 @@ export class StudyRoomService {
       location: dto.roomName,
       description,
     });
+
+    return 'modified';
   }
 }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 스터디룸 예약을 수정하여 참석자를 0명으로 설정할 경우 아무도 수정할수 없으나 캘린더에 예약은 남아 있는 버그 발생

## 주요 변경 사항

### 예약 수정 시 참석자 0명일 경우 자동 취소
- 스터디룸 예약을 수정하여 참석자를 0명으로 설정할 경우 자동 취소
- modifyBooking 에서 `수정`, `취소`를 구분하기 위해 결과 반환
- modifyBooking의 결과에 따라 유저에게 DM 발송

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [ ] 로컬에서 Slack 봇 실행 후 동작 확인
- [ ] 예약의 참석자를 0명으로 설정하여 예약 취소 메시지 오는지 확인
- [ ] 예약의 참석자를 1명 이상으로 설정 후 시간을 변경 하여 예약 수정 메시지 오는지 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
