### PR TITLE
refactor: 컨트롤러 try/catch 제거 및 에러 처리 글로벌 미들웨어로 위임

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -28,9 +28,9 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
     '구독 기능을 사용하려면 Google 계정 재연동이 필요합니다. 회원정보를 다시 등록해주세요.',
   [ErrorCode.BOOKING_CONFLICT]: '해당 시간대에 이미 예약이 있습니다.',
   [ErrorCode.CALENDAR_WRITER_NOT_FOUND]:
-    '캘린더 수정 권한을 가진 활성 유저를 찾을 수 없습니다.',
+    '캘린더 수정 권한을 가진 활성 유저를 찾을 수 없습니다. \n관리자에게 문의해주세요.',
   [ErrorCode.CALENDAR_WRITER_NO_TOKEN]:
-    '캘린더 수정 권한자의 인증 정보가 없습니다.',
+    '캘린더 수정 권한자의 인증 정보가 없습니다. \n관리자에게 문의해주세요.',
 };
 
 export class BusinessError extends Error {

--- a/src/student-class/student-class.controller.ts
+++ b/src/student-class/student-class.controller.ts
@@ -104,59 +104,46 @@ export class StudentClassController {
     // 3초 제한 내 ack — 이후 작업은 DM으로 결과 전달
     await ack();
 
-    try {
-      const savedClass = await this.studentClassService.createClass({
-        admissionYear,
-        section,
-        graduationYear,
-      });
+    const savedClass = await this.studentClassService.createClass({
+      admissionYear,
+      section,
+      graduationYear,
+    });
 
-      // Slack 채널 생성 (채널명: "2024-a" 형식, ASCII 규칙 준수)
-      const channelName = StudentClassService.buildChannelName(
-        admissionYear,
-        section,
+    // Slack 채널 생성 (채널명: "2024-a" 형식, ASCII 규칙 준수)
+    const channelName = StudentClassService.buildChannelName(
+      admissionYear,
+      section,
+    );
+    const channelResult = await client.conversations.create({
+      name: channelName,
+      is_private: false,
+    });
+
+    const channelId = channelResult.channel?.id;
+    if (channelId) {
+      // 채널 topic에 반 이름 표시 (한국어 가능)
+      await client.conversations.setTopic({
+        channel: channelId,
+        topic: savedClass.name,
+      });
+      await this.studentClassService.updateSlackChannel(
+        savedClass.id,
+        channelId,
       );
-      const channelResult = await client.conversations.create({
-        name: channelName,
-        is_private: false,
-      });
-
-      const channelId = channelResult.channel?.id;
-      if (channelId) {
-        // 채널 topic에 반 이름 표시 (한국어 가능)
-        await client.conversations.setTopic({
-          channel: channelId,
-          topic: savedClass.name,
-        });
-        await this.studentClassService.updateSlackChannel(
-          savedClass.id,
-          channelId,
-        );
-      }
-
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text:
-          `반 "${savedClass.name}"이(가) 생성되었습니다.\n` +
-          `• 태그 자동 생성 완료\n` +
-          `• Slack 채널 ${channelId ? `<#${channelId}>` : `\`${channelName}\``} 생성 완료`,
-      });
-
-      logger.info(
-        `StudentClass created: ${savedClass.name}, channelId: ${channelId ?? 'none'}`,
-      );
-    } catch (error: any) {
-      logger.error('Create class error:', error);
-
-      const isDuplicate =
-        error.code === '23505' || error.data?.error === 'name_taken';
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: isDuplicate
-          ? `이미 존재하는 반 또는 채널입니다.`
-          : `반 생성 중 오류가 발생했습니다: ${error.message ?? '알 수 없는 오류'}`,
-      });
     }
+
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text:
+        `반 "${savedClass.name}"이(가) 생성되었습니다.\n` +
+        `• 태그 자동 생성 완료\n` +
+        `• Slack 채널 ${channelId ? `<#${channelId}>` : `\`${channelName}\``} 생성 완료`,
+    });
+
+    logger.info(
+      `StudentClass created: ${savedClass.name}, channelId: ${channelId ?? 'none'}`,
+    );
   }
 
   // 반 상태 토글 (활성화/졸업)
@@ -169,39 +156,35 @@ export class StudentClassController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    try {
-      const action = body.actions[0] as { action_id: string; value: string };
-      const classId = parseInt(action.action_id.split(':').pop()!, 10);
-      const toggleAction = action.value;
+    const action = body.actions[0] as { action_id: string; value: string };
+    const classId = parseInt(action.action_id.split(':').pop()!, 10);
+    const toggleAction = action.value;
 
-      if (toggleAction === 'graduate') {
-        await this.studentClassService.graduateClass(classId);
-      } else if (toggleAction === 'activate') {
-        await this.studentClassService.activateClass(classId);
-      }
-
-      // 목록 새로고침
-      const classes = await this.studentClassService.findAllClasses();
-
-      if (body.view?.id) {
-        await client.views.update({
-          view_id: body.view.id,
-          view: StudentClassView.listModal(
-            classes.map((c) => ({
-              id: c.id,
-              name: c.name,
-              admissionYear: c.admissionYear,
-              graduationYear: c.graduationYear,
-              status: c.status,
-              slackChannelId: c.slackChannelId ?? undefined,
-            })),
-          ),
-        });
-      }
-
-      logger.info(`StudentClass ${classId} toggled to ${toggleAction}`);
-    } catch (error) {
-      logger.error('Toggle class error:', error);
+    if (toggleAction === 'graduate') {
+      await this.studentClassService.graduateClass(classId);
+    } else if (toggleAction === 'activate') {
+      await this.studentClassService.activateClass(classId);
     }
+
+    // 목록 새로고침
+    const classes = await this.studentClassService.findAllClasses();
+
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: StudentClassView.listModal(
+          classes.map((c) => ({
+            id: c.id,
+            name: c.name,
+            admissionYear: c.admissionYear,
+            graduationYear: c.graduationYear,
+            status: c.status,
+            slackChannelId: c.slackChannelId ?? undefined,
+          })),
+        ),
+      });
+    }
+
+    logger.info(`StudentClass ${classId} toggled to ${toggleAction}`);
   }
 }

--- a/src/study-room/study-room.controller.ts
+++ b/src/study-room/study-room.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Logger } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { Action, Command, View } from 'nestjs-slack-bolt';
 import type {
   AllMiddlewareArgs,
@@ -18,8 +18,6 @@ import { PermissionService } from '../user/permission.service';
 
 @Controller()
 export class StudyRoomController {
-  private readonly logger = new Logger(StudyRoomController.name);
-
   constructor(
     private readonly studyRoomService: StudyRoomService,
     private readonly userService: UserService,
@@ -56,21 +54,11 @@ export class StudyRoomController {
     const values = body.view.state.values;
     const name = values.name_block.name_input.value ?? '';
 
-    try {
-      const room = await this.studyRoomService.create({ name });
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `✅ 스터디룸이 등록되었습니다.\n*${room.name}*`,
-      });
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : '등록 중 오류가 발생했습니다.';
-      this.logger.error(`Study room create failed: ${message}`);
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ 등록에 실패했습니다: ${message}`,
-      });
-    }
+    const room = await this.studyRoomService.create({ name });
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `✅ 스터디룸이 등록되었습니다.\n*${room.name}*`,
+    });
   }
 
   @Command(CMD.예약)
@@ -231,30 +219,19 @@ export class StudyRoomController {
     const startTime = new Date(`${date}T${startTimeStr}:00+09:00`);
     const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
 
-    try {
-      await this.studyRoomService.bookStudyRoom({
-        studyRoomId: roomId,
-        title,
-        startTime,
-        endTime,
-        bookerSlackId: body.user.id,
-        attendeeSlackIds,
-      });
+    await this.studyRoomService.bookStudyRoom({
+      studyRoomId: roomId,
+      title,
+      startTime,
+      endTime,
+      bookerSlackId: body.user.id,
+      attendeeSlackIds,
+    });
 
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `✅ 예약이 완료되었습니다.\n*${title}* | ${date} ${startTimeStr} (${durationMinutes}분)`,
-      });
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : '예약 중 오류가 발생했습니다.';
-      this.logger.error(`Study room booking failed: ${message}`);
-
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ 예약에 실패했습니다: ${message}`,
-      });
-    }
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `✅ 예약이 완료되었습니다.\n*${title}* | ${date} ${startTimeStr} (${durationMinutes}분)`,
+    });
   }
 
   @Command(CMD.내예약)
@@ -288,21 +265,11 @@ export class StudyRoomController {
       (action as { value: string }).value,
     ) as { calendarId: string; eventId: string; roomName: string };
 
-    try {
-      await this.studyRoomService.cancelBooking(calendarId, eventId);
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `✅ *${roomName}* 예약이 취소되었습니다.`,
-      });
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : '취소 중 오류가 발생했습니다.';
-      this.logger.error(`Study room cancel failed: ${message}`);
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ 예약 취소에 실패했습니다: ${message}`,
-      });
-    }
+    await this.studyRoomService.cancelBooking(calendarId, eventId);
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `✅ *${roomName}* 예약이 취소되었습니다.`,
+    });
   }
 
   @Action('study-room:action:modify')
@@ -485,22 +452,12 @@ export class StudyRoomController {
     const status = values.status_block.status_select.selected_option
       ?.value as import('./study-room.entity').StudyRoomStatus;
 
-    try {
-      await this.studyRoomService.rename(roomId, name);
-      await this.studyRoomService.updateInfo(roomId, { description, status });
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `✅ *${name}* 정보가 수정되었습니다.`,
-      });
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : '수정 중 오류가 발생했습니다.';
-      this.logger.error(`Study room edit failed: ${message}`);
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ 수정에 실패했습니다: ${message}`,
-      });
-    }
+    await this.studyRoomService.rename(roomId, name);
+    await this.studyRoomService.updateInfo(roomId, { description, status });
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `✅ *${name}* 정보가 수정되었습니다.`,
+    });
   }
 
   @Action('study-room:admin:open-editors')
@@ -534,7 +491,6 @@ export class StudyRoomController {
   @View('study-room:modal:editors')
   async submitEditors({
     ack,
-    client,
     body,
   }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
     await ack();
@@ -547,42 +503,32 @@ export class StudyRoomController {
     const selectedIds =
       values['editors_block']?.['editors_select']?.selected_users ?? [];
 
-    try {
-      const acl = await GoogleCalendarUtil.getCalendarAcl(calendarId);
-      const currentEditorEmails = acl
-        .filter((e) => e.role === 'writer')
-        .map((e) => e.email);
-      const currentEditorSlackIds =
-        await this.userService.mapEmailsToSlackIds(currentEditorEmails);
+    const acl = await GoogleCalendarUtil.getCalendarAcl(calendarId);
+    const currentEditorEmails = acl
+      .filter((e) => e.role === 'writer')
+      .map((e) => e.email);
+    const currentEditorSlackIds =
+      await this.userService.mapEmailsToSlackIds(currentEditorEmails);
 
-      const oldSet = new Set(currentEditorSlackIds);
-      const newSet = new Set(selectedIds);
-      const toAdd = selectedIds.filter((id) => !oldSet.has(id));
-      const toRemove = currentEditorSlackIds.filter((id) => !newSet.has(id));
+    const oldSet = new Set(currentEditorSlackIds);
+    const newSet = new Set(selectedIds);
+    const toAdd = selectedIds.filter((id) => !oldSet.has(id));
+    const toRemove = currentEditorSlackIds.filter((id) => !newSet.has(id));
 
-      await Promise.all([
-        ...toAdd.map(async (slackId) => {
-          const user = await this.userService.findBySlackId(slackId);
-          if (user?.email) {
-            await this.studyRoomService.addEditor(roomId, user.email);
-          }
-        }),
-        ...toRemove.map(async (slackId) => {
-          const user = await this.userService.findBySlackId(slackId);
-          if (user?.email) {
-            await this.studyRoomService.removeEditor(roomId, user.email);
-          }
-        }),
-      ]);
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : '오류가 발생했습니다.';
-      this.logger.error(`Study room editors update failed: ${message}`);
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ 수정자 변경에 실패했습니다: ${message}`,
-      });
-    }
+    await Promise.all([
+      ...toAdd.map(async (slackId) => {
+        const user = await this.userService.findBySlackId(slackId);
+        if (user?.email) {
+          await this.studyRoomService.addEditor(roomId, user.email);
+        }
+      }),
+      ...toRemove.map(async (slackId) => {
+        const user = await this.userService.findBySlackId(slackId);
+        if (user?.email) {
+          await this.studyRoomService.removeEditor(roomId, user.email);
+        }
+      }),
+    ]);
   }
 
   @Action('study-room:admin:toggle-status')
@@ -605,30 +551,17 @@ export class StudyRoomController {
         ? StudyRoomStatus.INACTIVE
         : StudyRoomStatus.ACTIVE;
 
-    try {
-      await this.studyRoomService.updateInfo(roomId, { status: newStatus });
+    await this.studyRoomService.updateInfo(roomId, { status: newStatus });
 
-      const rooms = await this.studyRoomService.findAll();
-      await client.views.update({
-        view_id: body.view?.id ?? '',
-        view: StudyRoomView.manageModal(rooms),
-      });
-      const label =
-        newStatus === StudyRoomStatus.ACTIVE ? '활성화' : '비활성화';
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `✅ *${roomName}* 이 ${label}되었습니다.`,
-      });
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : '상태 변경 중 오류가 발생했습니다.';
-      this.logger.error(`Study room toggle-status failed: ${message}`);
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `❌ 상태 변경에 실패했습니다: ${message}`,
-      });
-    }
+    const rooms = await this.studyRoomService.findAll();
+    await client.views.update({
+      view_id: body.view?.id ?? '',
+      view: StudyRoomView.manageModal(rooms),
+    });
+    const label = newStatus === StudyRoomStatus.ACTIVE ? '활성화' : '비활성화';
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `✅ *${roomName}* 이 ${label}되었습니다.`,
+    });
   }
 }

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -70,46 +70,29 @@ export class TagController {
     client,
     logger,
   }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
-    try {
-      const values = view.state.values;
-      const name = values.name_block.name_input.value ?? '';
+    const values = view.state.values;
+    const name = values.name_block.name_input.value ?? '';
 
-      // 유효성 검사
-      if (!name.trim()) {
-        await ack({
-          response_action: 'errors',
-          errors: { name_block: '태그 이름을 입력해주세요.' },
-        });
-        return;
-      }
-
-      await this.tagService.createTag({ name: name.trim() });
-
-      await ack();
-
-      // 생성 완료 메시지
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `태그 "${name}"이(가) 생성되었습니다.`,
+    // 유효성 검사
+    if (!name.trim()) {
+      await ack({
+        response_action: 'errors',
+        errors: { name_block: '태그 이름을 입력해주세요.' },
       });
-
-      logger.info(`Tag created: ${name}`);
-    } catch (error: any) {
-      logger.error('Create tag error:', error);
-
-      if (error.code === '23505') {
-        // unique violation
-        await ack({
-          response_action: 'errors',
-          errors: { name_block: '이미 존재하는 태그 이름입니다.' },
-        });
-      } else {
-        await ack({
-          response_action: 'errors',
-          errors: { name_block: '태그 생성 중 오류가 발생했습니다.' },
-        });
-      }
+      return;
     }
+
+    await this.tagService.createTag({ name: name.trim() });
+
+    await ack();
+
+    // 생성 완료 메시지
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `태그 "${name}"이(가) 생성되었습니다.`,
+    });
+
+    logger.info(`Tag created: ${name}`);
   }
 
   // 태그 상태 토글 (활성화/비활성화)
@@ -122,30 +105,26 @@ export class TagController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    try {
-      const action = body.actions[0] as { action_id: string; value: string };
-      const tagId = parseInt(action.action_id.split(':').pop()!, 10);
-      const toggleAction = action.value;
+    const action = body.actions[0] as { action_id: string; value: string };
+    const tagId = parseInt(action.action_id.split(':').pop()!, 10);
+    const toggleAction = action.value;
 
-      if (toggleAction === 'deactivate') {
-        await this.tagService.deactivateTag(tagId);
-      } else if (toggleAction === 'activate') {
-        await this.tagService.activateTag(tagId);
-      }
-
-      // 목록 새로고침
-      const tags = await this.tagService.findDisplayTags();
-
-      if (body.view?.id) {
-        await client.views.update({
-          view_id: body.view.id,
-          view: TagView.listModal(tags),
-        });
-      }
-
-      logger.info(`Tag ${tagId} toggled to ${toggleAction}`);
-    } catch (error) {
-      logger.error('Toggle tag error:', error);
+    if (toggleAction === 'deactivate') {
+      await this.tagService.deactivateTag(tagId);
+    } else if (toggleAction === 'activate') {
+      await this.tagService.activateTag(tagId);
     }
+
+    // 목록 새로고침
+    const tags = await this.tagService.findDisplayTags();
+
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: TagView.listModal(tags),
+      });
+    }
+
+    logger.info(`Tag ${tagId} toggled to ${toggleAction}`);
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -33,28 +33,23 @@ export class UserController {
     ack,
     client,
     body,
-    logger,
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
-    try {
-      await ack();
+    await ack();
 
-      const slackUserId = body.user.id;
+    const slackUserId = body.user.id;
 
-      // Google OAuth URL 생성
-      const state = OAuthUtil.createOAuthState(slackUserId);
-      const googleAuthUrl = OAuthUtil.getGoogleAuthUrl(state);
+    // Google OAuth URL 생성
+    const state = OAuthUtil.createOAuthState(slackUserId);
+    const googleAuthUrl = OAuthUtil.getGoogleAuthUrl(state);
 
-      const result = await client.views.open({
-        trigger_id: body.trigger_id,
-        view: UserView.registerModal(googleAuthUrl),
-      });
+    const result = await client.views.open({
+      trigger_id: body.trigger_id,
+      view: UserView.registerModal(googleAuthUrl),
+    });
 
-      // view_id 저장 (모달 업데이트용)
-      if (result.view?.id) {
-        await this.userService.saveViewId(slackUserId, result.view.id);
-      }
-    } catch (error) {
-      logger.error(error);
+    // view_id 저장 (모달 업데이트용)
+    if (result.view?.id) {
+      await this.userService.saveViewId(slackUserId, result.view.id);
     }
   }
 
@@ -210,21 +205,78 @@ export class UserController {
     ack,
     client,
     body,
-    logger,
   }: (SlackCommandMiddlewareArgs | SlackActionMiddlewareArgs<BlockAction>) &
     AllMiddlewareArgs) {
-    try {
-      await ack();
+    await ack();
 
-      const userId = 'user_id' in body ? body.user_id : body.user.id;
+    const userId = 'user_id' in body ? body.user_id : body.user.id;
 
-      await this.permissionService.requireAdmin(userId);
+    await this.permissionService.requireAdmin(userId);
 
-      // 승인 대기 유저 목록 조회
+    // 승인 대기 유저 목록 조회
+    const pendingUsers = await this.userService.findPendingApproval();
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: UserView.pendingApprovalModal(
+        pendingUsers.map((u) => ({
+          slackId: u.slackId,
+          name: u.name,
+          email: u.email,
+          code: u.code,
+          role: u.role,
+          className: u.studentClass?.name,
+        })),
+      ),
+    });
+  }
+
+  // 관리자: 승인/거절 액션 처리
+  @Action(/^user:admin:overflow:/)
+  async handleApprovalAction({
+    ack,
+    body,
+    client,
+    logger,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { selected_option: { value: string } };
+    const [actionType, targetSlackId] = action.selected_option.value.split(':');
+
+    if (actionType === 'approve') {
+      await this.userService.approveUser(targetSlackId);
+
+      const approvedUser = await this.userService.findBySlackId(targetSlackId);
+      await this.inviteToClassChannel(
+        targetSlackId,
+        approvedUser?.studentClassId,
+      );
+
+      // 승인된 유저에게 알림
+      await client.chat.postMessage({
+        channel: targetSlackId,
+        text: '가입이 승인되었습니다! 이제 서비스를 이용할 수 있습니다.',
+      });
+
+      logger.info(`User approved: ${targetSlackId}`);
+    } else if (actionType === 'reject') {
+      await this.userService.rejectUser(targetSlackId);
+
+      // 거절된 유저에게 알림
+      await client.chat.postMessage({
+        channel: targetSlackId,
+        text: '가입 신청이 거절되었습니다. 문의사항이 있으면 관리자에게 연락해주세요.',
+      });
+
+      logger.info(`User rejected: ${targetSlackId}`);
+    }
+
+    // 모달 업데이트 (목록 새로고침)
+    if (body.view?.id) {
       const pendingUsers = await this.userService.findPendingApproval();
-
-      await client.views.open({
-        trigger_id: body.trigger_id,
+      await client.views.update({
+        view_id: body.view.id,
         view: UserView.pendingApprovalModal(
           pendingUsers.map((u) => ({
             slackId: u.slackId,
@@ -236,74 +288,6 @@ export class UserController {
           })),
         ),
       });
-    } catch (error) {
-      logger.error('Open approval modal error:', error);
-    }
-  }
-
-  // 관리자: 승인/거절 액션 처리
-  @Action(/^user:admin:overflow:/)
-  async handleApprovalAction({
-    ack,
-    body,
-    client,
-    logger,
-  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
-    try {
-      await ack();
-
-      const action = body.actions[0] as { selected_option: { value: string } };
-      const [actionType, targetSlackId] =
-        action.selected_option.value.split(':');
-
-      if (actionType === 'approve') {
-        await this.userService.approveUser(targetSlackId);
-
-        const approvedUser =
-          await this.userService.findBySlackId(targetSlackId);
-        await this.inviteToClassChannel(
-          targetSlackId,
-          approvedUser?.studentClassId,
-        );
-
-        // 승인된 유저에게 알림
-        await client.chat.postMessage({
-          channel: targetSlackId,
-          text: '가입이 승인되었습니다! 이제 서비스를 이용할 수 있습니다.',
-        });
-
-        logger.info(`User approved: ${targetSlackId}`);
-      } else if (actionType === 'reject') {
-        await this.userService.rejectUser(targetSlackId);
-
-        // 거절된 유저에게 알림
-        await client.chat.postMessage({
-          channel: targetSlackId,
-          text: '가입 신청이 거절되었습니다. 문의사항이 있으면 관리자에게 연락해주세요.',
-        });
-
-        logger.info(`User rejected: ${targetSlackId}`);
-      }
-
-      // 모달 업데이트 (목록 새로고침)
-      if (body.view?.id) {
-        const pendingUsers = await this.userService.findPendingApproval();
-        await client.views.update({
-          view_id: body.view.id,
-          view: UserView.pendingApprovalModal(
-            pendingUsers.map((u) => ({
-              slackId: u.slackId,
-              name: u.name,
-              email: u.email,
-              code: u.code,
-              role: u.role,
-              className: u.studentClass?.name,
-            })),
-          ),
-        });
-      }
-    } catch (error) {
-      logger.error('Approval action error:', error);
     }
   }
 


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 에러 처리를 각 controller에서 개별적으로 잡는것이 아닌 글로벌 미들웨어에서 전역으로 처리하도록 위임

## 주요 변경 사항

### 컨트롤러 수정
- student-class, study-room, tag, user 컨트롤러의 try/catch 제거
- 글로벌 미들웨어로 에러 처리 위임

### 에러 문구 수정
- errors.ts: 캘린더의 수정자가 없는 에러의 경우 "관리자에게 문의" 문구 추가

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] 에러 처리 메시지 확인 (스터디룸 캘린더 수정 권한 관련)

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
