### PR TITLE
feat: 기본 공간 도입 및 미매핑 이벤트 자동 미러링 지원

### DIFF
--- a/src/space/space-mirror.service.ts
+++ b/src/space/space-mirror.service.ts
@@ -55,31 +55,17 @@ export class SpaceMirrorService {
     const storedMirroredEventId =
       event.extendedProperties?.private?.[MIRRORED_EVENT_ID_KEY];
 
+    // 대상 공간 결정: alias 매칭 → 없으면 기본 공간 → 없으면 스킵
     const location = event.location?.trim();
-
-    if (!location) {
-      // location 제거됨 → 이전에 미러된 이벤트 삭제
-      if (storedMirroredCalendarId && storedMirroredEventId) {
-        await GoogleCalendarUtil.deleteEventAsServiceAccount(
-          storedMirroredCalendarId,
-          storedMirroredEventId,
-        ).catch(() => {});
-        await GoogleCalendarUtil.patchEventPrivateExtendedProperty(
-          sourceCalendarId,
-          event.id!,
-          { [MIRRORED_CALENDAR_ID_KEY]: '', [MIRRORED_EVENT_ID_KEY]: '' },
-        );
-        this.logger.log(
-          `Mirror deleted (location removed): ${event.id} from ${storedMirroredCalendarId}`,
-        );
-      }
-      return;
+    let targetSpace = location
+      ? await this.spaceService.findByAlias(location)
+      : null;
+    if (!targetSpace) {
+      targetSpace = await this.spaceService.findDefault();
     }
 
-    const space = await this.spaceService.findByAlias(location);
-
-    if (!space) {
-      // 매핑되는 공간 없음 → 이전 미러만 정리
+    if (!targetSpace) {
+      // 대상 공간 없음 → 기존 미러 정리
       if (storedMirroredCalendarId && storedMirroredEventId) {
         await GoogleCalendarUtil.deleteEventAsServiceAccount(
           storedMirroredCalendarId,
@@ -91,7 +77,7 @@ export class SpaceMirrorService {
           { [MIRRORED_CALENDAR_ID_KEY]: '', [MIRRORED_EVENT_ID_KEY]: '' },
         );
         this.logger.log(
-          `Mirror deleted (no space match): ${event.id} from ${storedMirroredCalendarId}`,
+          `Mirror deleted (no target space): ${event.id} from ${storedMirroredCalendarId}`,
         );
       }
       return;
@@ -100,7 +86,7 @@ export class SpaceMirrorService {
     // 공간이 변경된 경우 이전 캘린더에서 미러 삭제
     if (
       storedMirroredCalendarId &&
-      storedMirroredCalendarId !== space.calendarId &&
+      storedMirroredCalendarId !== targetSpace.calendarId &&
       storedMirroredEventId
     ) {
       await GoogleCalendarUtil.deleteEventAsServiceAccount(
@@ -114,12 +100,12 @@ export class SpaceMirrorService {
 
     // 같은 공간이면 기존 mirroredEventId 재사용, 아니면 null(새로 생성)
     const existingMirrorEventId =
-      storedMirroredCalendarId === space.calendarId
+      storedMirroredCalendarId === targetSpace.calendarId
         ? (storedMirroredEventId ?? null)
         : null;
 
     await this.upsertMirror(
-      space.calendarId,
+      targetSpace.calendarId,
       event,
       sourceCalendarId,
       existingMirrorEventId,

--- a/src/space/space.controller.ts
+++ b/src/space/space.controller.ts
@@ -61,8 +61,10 @@ export class SpaceController {
       .map((a) => a.trim())
       .filter(Boolean);
     const description = values.description_block.description_input.value ?? undefined;
+    const isDefault =
+      (values.is_default_block?.is_default_checkbox?.selected_options ?? []).length > 0;
 
-    const space = await this.spaceService.create({ name, type, aliases, description });
+    const space = await this.spaceService.create({ name, type, aliases, description, isDefault });
     const typeLabel = type === SpaceType.CLASSROOM ? '교실' : '스터디룸';
     await client.chat.postMessage({
       channel: body.user.id,
@@ -568,6 +570,39 @@ export class SpaceController {
         }
       }),
     ]);
+  }
+
+  @Action('study-room:admin:toggle-default')
+  async adminToggleDefault({
+    ack,
+    client,
+    body,
+    action,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+    const { roomId, roomName } = JSON.parse(
+      (action as { value: string }).value,
+    ) as { roomId: number; roomName: string };
+
+    const space = await this.spaceService.findById(roomId);
+    if (!space) return;
+
+    if (space.isDefault) {
+      await this.spaceService.unsetDefault(roomId);
+    } else {
+      await this.spaceService.setDefault(roomId);
+    }
+
+    const spaces = await this.spaceService.findAll();
+    await client.views.update({
+      view_id: body.view?.id ?? '',
+      view: SpaceView.manageModal(spaces),
+    });
+    const label = space.isDefault ? '기본 공간 해제' : '기본 공간으로 지정';
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: `✅ *${roomName}* 이 ${label}되었습니다.`,
+    });
   }
 
   @Action('study-room:admin:toggle-status')

--- a/src/space/space.entity.ts
+++ b/src/space/space.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   DeleteDateColumn,
+  Index,
 } from 'typeorm';
 
 export enum SpaceType {
@@ -17,6 +18,10 @@ export enum SpaceStatus {
   INACTIVE = 'inactive',
 }
 
+@Index('unique_default_space', ['isDefault'], {
+  unique: true,
+  where: '"isDefault" = true',
+})
 @Entity('space')
 export class Space {
   @PrimaryGeneratedColumn()
@@ -47,6 +52,9 @@ export class Space {
     default: SpaceStatus.ACTIVE,
   })
   status: SpaceStatus;
+
+  @Column({ default: false })
+  isDefault: boolean = false;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/space/space.service.ts
+++ b/src/space/space.service.ts
@@ -11,6 +11,7 @@ export interface CreateSpaceDto {
   type?: SpaceType;
   aliases?: string[];
   description?: string;
+  isDefault?: boolean;
 }
 
 export interface BookSpaceDto {
@@ -53,12 +54,22 @@ export class SpaceService {
     const { calendarId } = await GoogleCalendarUtil.createCalendar(dto.name);
     await GoogleCalendarUtil.makeCalendarPublic(calendarId);
 
+    if (dto.isDefault) {
+      await this.spaceRepository
+        .createQueryBuilder()
+        .update()
+        .set({ isDefault: false })
+        .where('1=1')
+        .execute();
+    }
+
     const space = this.spaceRepository.create({
       name: dto.name,
       calendarId,
       type: dto.type ?? SpaceType.STUDY_ROOM,
       aliases: dto.aliases ?? [],
       description: dto.description,
+      isDefault: dto.isDefault ?? false,
     });
     return this.spaceRepository.save(space);
   }
@@ -82,6 +93,24 @@ export class SpaceService {
 
   async findById(id: number): Promise<Space | null> {
     return this.spaceRepository.findOne({ where: { id } });
+  }
+
+  async findDefault(): Promise<Space | null> {
+    return this.spaceRepository.findOne({ where: { isDefault: true } });
+  }
+
+  async setDefault(id: number): Promise<void> {
+    await this.spaceRepository
+      .createQueryBuilder()
+      .update()
+      .set({ isDefault: false })
+      .where('1=1')
+      .execute();
+    await this.spaceRepository.update(id, { isDefault: true });
+  }
+
+  async unsetDefault(id: number): Promise<void> {
+    await this.spaceRepository.update(id, { isDefault: false });
   }
 
   // location 문자열이 어떤 공간의 alias와 일치하면 해당 공간 반환

--- a/src/space/space.view.ts
+++ b/src/space/space.view.ts
@@ -187,6 +187,26 @@ export class SpaceView {
             },
           },
         },
+        {
+          type: 'input',
+          block_id: 'is_default_block',
+          label: { type: 'plain_text', text: '기본 공간' },
+          optional: true,
+          hint: {
+            type: 'plain_text',
+            text: '선택 시 alias가 없는 이벤트가 이 공간의 시간표에 자동으로 미러링됩니다.',
+          },
+          element: {
+            type: 'checkboxes',
+            action_id: 'is_default_checkbox',
+            options: [
+              {
+                text: { type: 'plain_text', text: '기본 공간으로 지정' },
+                value: 'true',
+              },
+            ],
+          },
+        },
       ],
     };
   }
@@ -487,13 +507,14 @@ export class SpaceView {
         });
         const statusLabel =
           space.status === SpaceStatus.ACTIVE ? '활성' : '비활성';
+        const defaultLabel = space.isDefault ? ' `기본 공간`' : '';
 
         blocks.push(
           {
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `*${space.name}* \`${statusLabel}\`${space.description ? `\n${space.description}` : ''}`,
+              text: `*${space.name}* \`${statusLabel}\`${defaultLabel}${space.description ? `\n${space.description}` : ''}`,
             },
           },
           {
@@ -509,6 +530,16 @@ export class SpaceView {
                 type: 'button',
                 text: { type: 'plain_text', text: '수정자 관리' },
                 action_id: 'study-room:admin:open-editors',
+                value: meta,
+              },
+              {
+                type: 'button',
+                text: {
+                  type: 'plain_text',
+                  text: space.isDefault ? '기본 공간 해제' : '기본 공간 지정',
+                },
+                action_id: 'study-room:admin:toggle-default',
+                style: space.isDefault ? undefined : 'primary',
                 value: meta,
               },
               {


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
alias가 없거나 매핑되는 공간이 없는 이벤트를 기본 공간 시간표에 자동으로 미러링하도록 구현.

## 주요 변경 사항

### 기본 공간
- Space 엔티티에 isDefault 컬럼 추가 (partial unique index로 단일 보장)
- SpaceMirrorService: alias 매칭 실패 시 기본 공간으로 fallback
- 공간 등록 모달에 기본 공간 지정 체크박스 추가
- 공간 관리 모달에 기본 공간 뱃지 및 지정/해제 버튼 추가

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [ ] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
