### PR TITLE
fix: 서버 listen 완료 후 watch 갱신 실행으로 초기 webhook 502 방지

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { httpReceiver } from './slack-receiver';
+import { ScheduleCronService } from './schedule/schedule-cron.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -10,5 +11,13 @@ async function bootstrap() {
   }
 
   await app.listen(process.env.PORT ?? 3000);
+
+  // 서버가 포트를 열고 난 뒤 watch 갱신
+  app
+    .get(ScheduleCronService)
+    .renewOnBootstrap()
+    .catch((err: Error) => {
+      console.error('Bootstrap watch renewal failed:', err.message);
+    });
 }
 bootstrap();

--- a/src/schedule/schedule-cron.service.ts
+++ b/src/schedule/schedule-cron.service.ts
@@ -1,15 +1,15 @@
-import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { ScheduleService } from './schedule.service';
 
 @Injectable()
-export class ScheduleCronService implements OnApplicationBootstrap {
+export class ScheduleCronService {
   private readonly logger = new Logger(ScheduleCronService.name);
 
   constructor(private readonly scheduleService: ScheduleService) {}
 
-  // 서버 시작 시 — watch 갱신 (서버 재시작으로 만료된 watch 복구)
-  async onApplicationBootstrap(): Promise<void> {
+  // listen() 완료 후 main.ts에서 직접 호출
+  async renewOnBootstrap(): Promise<void> {
     this.logger.log('Starting watch renewal on bootstrap...');
     await this.scheduleService.renewAllActiveWatches();
     this.logger.log('Bootstrap watch renewal completed');


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 서버가 listen을 하기 전에 webhook이 먼저 실행되어 webhook 등록에 대해 응답을 못하는 현상 발생
- webhook이 모두 끝나기 전에는 서버가 listen 하지 않는 초기 딜레이도 발생

## 주요 변경 사항

### 실행 순서 변경
- listen() 완료 후 renewOnBootstrap()을 비동기로 호출하도록 변경.
- onApplicationBootstrap에서 갱신 시 서버가 아직 포트를 열기 전이라 Google webhook이 502를 반환하는 문제 수정.

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
