### PR TITLE
feat: 일일 미러 동기화 크론 추가 및 취소된 미러 재생성 처리

### DIFF
--- a/src/google/google-calendar.util.ts
+++ b/src/google/google-calendar.util.ts
@@ -364,6 +364,36 @@ export class GoogleCalendarUtil {
     return response.data.items ?? [];
   }
 
+  // 특정 기간의 이벤트 전체 조회 (동기화용)
+  static async listEventsInRange(
+    calendarId: string,
+    timeMin: Date,
+    timeMax: Date,
+  ): Promise<calendar_v3.Schema$Event[]> {
+    const calendar = this.getCalendarClient();
+    const events: calendar_v3.Schema$Event[] = [];
+    let pageToken: string | undefined;
+
+    while (true) {
+      const response = await calendar.events.list({
+        calendarId,
+        timeMin: timeMin.toISOString(),
+        timeMax: timeMax.toISOString(),
+        showDeleted: false,
+        singleEvents: true,
+        maxResults: 2500,
+        ...(pageToken ? { pageToken } : {}),
+      });
+
+      events.push(...(response.data.items ?? []));
+
+      if (!response.data.nextPageToken) break;
+      pageToken = response.data.nextPageToken;
+    }
+
+    return events;
+  }
+
   // 단일 이벤트 조회 (디바운스 발송 시점에 최신 상태 확인용)
   static async getEventById(
     calendarId: string,
@@ -513,6 +543,37 @@ export class GoogleCalendarUtil {
       showDeleted: false,
     });
     return response.data.items ?? [];
+  }
+
+  // 특정 기간의 미러 이벤트 전체 조회 (mirroredBy=gsc-bot 필터)
+  static async listMirrorEventsInRange(
+    calendarId: string,
+    timeMin: Date,
+    timeMax: Date,
+  ): Promise<calendar_v3.Schema$Event[]> {
+    const calendar = this.getCalendarClient();
+    const events: calendar_v3.Schema$Event[] = [];
+    let pageToken: string | undefined;
+
+    while (true) {
+      const response = await calendar.events.list({
+        calendarId,
+        timeMin: timeMin.toISOString(),
+        timeMax: timeMax.toISOString(),
+        privateExtendedProperty: ['mirroredBy=gsc-bot'],
+        showDeleted: false,
+        singleEvents: true,
+        maxResults: 2500,
+        ...(pageToken ? { pageToken } : {}),
+      });
+
+      events.push(...(response.data.items ?? []));
+
+      if (!response.data.nextPageToken) break;
+      pageToken = response.data.nextPageToken;
+    }
+
+    return events;
   }
 
   // 서비스 계정으로 미러 이벤트 생성 (extendedProperties 포함)

--- a/src/schedule/schedule-cron.service.ts
+++ b/src/schedule/schedule-cron.service.ts
@@ -1,12 +1,24 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { ScheduleService } from './schedule.service';
+import { SpaceMirrorService } from '../space/space-mirror.service';
+import { SpaceService } from '../space/space.service';
+import { GoogleCalendarUtil } from '../google/google-calendar.util';
+
+const CRON_SUPPRESS_KEY = 'suppress:cron:sync';
 
 @Injectable()
 export class ScheduleCronService {
   private readonly logger = new Logger(ScheduleCronService.name);
 
-  constructor(private readonly scheduleService: ScheduleService) {}
+  constructor(
+    private readonly scheduleService: ScheduleService,
+    private readonly spaceMirrorService: SpaceMirrorService,
+    private readonly spaceService: SpaceService,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+  ) {}
 
   // listen() 완료 후 main.ts에서 직접 호출
   async renewOnBootstrap(): Promise<void> {
@@ -22,5 +34,114 @@ export class ScheduleCronService {
     this.logger.log('Starting weekly watch renewal...');
     await this.scheduleService.renewAllActiveWatches();
     this.logger.log('Weekly watch renewal completed');
+  }
+
+  // 매일 새벽 3시 — 오늘부터 30일 이내 이벤트 미러링 동기화
+  @Cron('0 3 * * *', { timeZone: 'Asia/Seoul' })
+  async syncMirrors(): Promise<void> {
+    try {
+      this.logger.log('Starting daily mirror sync...');
+      await this.cache.set(CRON_SUPPRESS_KEY, 1, 60 * 60 * 1000); // 1시간 failsafe TTL
+
+      const schedules = await this.scheduleService.findActiveSchedules();
+      const timeMin = new Date();
+      const timeMax = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+      let synced = 0;
+      let failed = 0;
+
+      // 전방 패스: 소스 이벤트 미러링 + 유효한 미러 이벤트 ID 수집
+      const validMirrorEventIds = new Set<string>();
+
+      for (const schedule of schedules) {
+        let events: Awaited<
+          ReturnType<typeof GoogleCalendarUtil.listEventsInRange>
+        >;
+        try {
+          events = await GoogleCalendarUtil.listEventsInRange(
+            schedule.calendarId,
+            timeMin,
+            timeMax,
+          );
+        } catch (err: any) {
+          this.logger.warn(
+            `Failed to list events for schedule ${schedule.id}: ${err.message}`,
+          );
+          continue;
+        }
+
+        for (const event of events) {
+          if (!event.id) continue;
+          if (this.spaceMirrorService.isMirroredEvent(event)) continue;
+          if (event.recurringEventId) continue;
+
+          // 잘못된 mirror가 삭제되지 않는것 보다, 정상적인 mirror를 삭제하는 것이 더 큰 문제라고 판단하여 원본과 연결된 미러 id 선보존
+          const existingId =
+            event.extendedProperties?.private?.['mirroredEventId'];
+          if (existingId) validMirrorEventIds.add(existingId);
+
+          const mirrorId = await this.spaceMirrorService
+            .mirrorEvent(event, schedule.calendarId)
+            .catch((err: Error) => {
+              failed++;
+              this.logger.warn(
+                `Mirror sync failed for event ${event.id}: ${err.message}`,
+              );
+              return null;
+            });
+
+          if (mirrorId) {
+            validMirrorEventIds.add(mirrorId);
+            synced++;
+          }
+        }
+      }
+
+      // 역방향 패스: 소스가 사라진 미러 이벤트 삭제
+      let removed = 0;
+      const spaces = await this.spaceService.findAll(true);
+
+      for (const space of spaces) {
+        let mirrorEvents: Awaited<
+          ReturnType<typeof GoogleCalendarUtil.listMirrorEventsInRange>
+        >;
+        try {
+          mirrorEvents = await GoogleCalendarUtil.listMirrorEventsInRange(
+            space.calendarId,
+            timeMin,
+            timeMax,
+          );
+        } catch (err: any) {
+          this.logger.warn(
+            `Failed to list mirror events for space ${space.id}: ${err.message}`,
+          );
+          continue;
+        }
+
+        for (const mirror of mirrorEvents) {
+          if (!mirror.id) continue;
+
+          if (!validMirrorEventIds.has(mirror.id)) {
+            await GoogleCalendarUtil.deleteEventAsServiceAccount(
+              space.calendarId,
+              mirror.id,
+            )
+              .then(() => removed++)
+              .catch((err: Error) => {
+                this.logger.warn(
+                  `Failed to delete stale mirror ${mirror.id}: ${err.message}`,
+                );
+              });
+          }
+        }
+      }
+
+      this.logger.log(
+        `Daily mirror sync completed: ${synced} synced, ${removed} removed, ${failed} failed`,
+      );
+    } finally {
+      // 동기화 직후 발생하는 지연 웹훅들을 무시하기 위해 suppress 상태를 3분간 유지
+      await this.cache.set(CRON_SUPPRESS_KEY, 1, 3 * 60 * 1000);
+    }
   }
 }

--- a/src/schedule/schedule-watch.controller.ts
+++ b/src/schedule/schedule-watch.controller.ts
@@ -72,6 +72,12 @@ export class ScheduleWatchController {
 
     await this.scheduleService.updateSyncToken(schedule.id, nextSyncToken);
 
+    // cron 동기화 중 — syncToken은 소비하되 알림/미러링은 스킵
+    if (await this.cache.get('suppress:cron:sync')) {
+      this.logger.log('Webhook suppressed during cron sync');
+      return;
+    }
+
     if (events.length === 0) return;
 
     for (const event of events) {

--- a/src/space/space-mirror.service.ts
+++ b/src/space/space-mirror.service.ts
@@ -20,11 +20,15 @@ export class SpaceMirrorService {
    * debounce 발사 시점에 호출.
    * sourceCalendarId: 과목 캘린더 ID (source 이벤트 메타데이터 패치용)
    */
+  // 미러 이벤트 ID 반환 (생성/업데이트된 미러 ID, 삭제/스킵 시 null)
   async mirrorEvent(
     event: calendar_v3.Schema$Event,
     sourceCalendarId: string,
-  ): Promise<void> {
-    if (event.recurringEventId) return; // 반복 이벤트 스킵
+  ): Promise<string | null> {
+    if (event.recurringEventId) return null; // 반복 이벤트 스킵
+    console.log(
+      `mirrorEvent: sourceEventId: ${event.id} ${event.status} ${event.start?.dateTime}`,
+    );
 
     if (event.status === 'cancelled') {
       // 취소된 이벤트는 webhook payload에 extendedProperties 없을 수 있음 → source 이벤트 직접 조회
@@ -32,13 +36,13 @@ export class SpaceMirrorService {
         sourceCalendarId,
         event.id!,
       );
-      if (!sourceEvent) return;
+      if (!sourceEvent) return null;
 
       const mirroredCalendarId =
         sourceEvent.extendedProperties?.private?.[MIRRORED_CALENDAR_ID_KEY];
       const mirroredEventId =
         sourceEvent.extendedProperties?.private?.[MIRRORED_EVENT_ID_KEY];
-      if (!mirroredCalendarId || !mirroredEventId) return;
+      if (!mirroredCalendarId || !mirroredEventId) return null;
 
       await GoogleCalendarUtil.deleteEventAsServiceAccount(
         mirroredCalendarId,
@@ -47,13 +51,17 @@ export class SpaceMirrorService {
         // 이미 삭제됐어도 무시
       });
       this.logger.log(`Mirror deleted: ${event.id} from ${mirroredCalendarId}`);
-      return;
+      return null;
     }
 
     const storedMirroredCalendarId =
       event.extendedProperties?.private?.[MIRRORED_CALENDAR_ID_KEY];
     const storedMirroredEventId =
       event.extendedProperties?.private?.[MIRRORED_EVENT_ID_KEY];
+
+    console.log(
+      `storedMirroredCalendarId: ${storedMirroredCalendarId}\nstoredMirroredEventId: ${storedMirroredEventId}`,
+    );
 
     // 대상 공간 결정: alias 매칭 → 없으면 기본 공간 → 없으면 스킵
     const location = event.location?.trim();
@@ -63,6 +71,8 @@ export class SpaceMirrorService {
     if (!targetSpace) {
       targetSpace = await this.spaceService.findDefault();
     }
+
+    console.log(`targetSpace: ${targetSpace?.id}`);
 
     if (!targetSpace) {
       // 대상 공간 없음 → 기존 미러 정리
@@ -80,7 +90,7 @@ export class SpaceMirrorService {
           `Mirror deleted (no target space): ${event.id} from ${storedMirroredCalendarId}`,
         );
       }
-      return;
+      return null;
     }
 
     // 공간이 변경된 경우 이전 캘린더에서 미러 삭제
@@ -89,6 +99,7 @@ export class SpaceMirrorService {
       storedMirroredCalendarId !== targetSpace.calendarId &&
       storedMirroredEventId
     ) {
+      console.log('공간 변경');
       await GoogleCalendarUtil.deleteEventAsServiceAccount(
         storedMirroredCalendarId,
         storedMirroredEventId,
@@ -104,7 +115,7 @@ export class SpaceMirrorService {
         ? (storedMirroredEventId ?? null)
         : null;
 
-    await this.upsertMirror(
+    return this.upsertMirror(
       targetSpace.calendarId,
       event,
       sourceCalendarId,
@@ -137,12 +148,26 @@ export class SpaceMirrorService {
     );
   }
 
+  private isInSync(
+    source: calendar_v3.Schema$Event,
+    mirror: calendar_v3.Schema$Event,
+  ): boolean {
+    return (
+      (source.summary ?? '') === (mirror.summary ?? '') &&
+      (source.start?.dateTime ?? source.start?.date ?? '') ===
+        (mirror.start?.dateTime ?? mirror.start?.date ?? '') &&
+      (source.end?.dateTime ?? '') === (mirror.end?.dateTime ?? '') &&
+      (source.location ?? '') === (mirror.location ?? '') &&
+      (source.description ?? '') === (mirror.description ?? '')
+    );
+  }
+
   private async upsertMirror(
     spaceCalendarId: string,
     event: calendar_v3.Schema$Event,
     sourceCalendarId: string,
     existingMirrorEventId: string | null,
-  ): Promise<void> {
+  ): Promise<string> {
     const extendedProperties: calendar_v3.Schema$Event['extendedProperties'] = {
       private: {
         [SOURCE_EVENT_ID_KEY]: event.id!,
@@ -150,24 +175,32 @@ export class SpaceMirrorService {
       },
     };
 
+    console.log(
+      `upsertMirror: spaceCalendarId: ${spaceCalendarId}\nevent: ${event.id}\nsourceCalendarId: ${sourceCalendarId}\nexistingMirrorEventId: ${existingMirrorEventId}`,
+    );
+
     if (existingMirrorEventId) {
-      await GoogleCalendarUtil.updateMirrorEventAsServiceAccount(
+      // 현재 미러 이벤트 조회 후 동일하면 패치 없이 스킵 (불필요한 webhook 방지)
+      const currentMirror = await GoogleCalendarUtil.getEventById(
         spaceCalendarId,
         existingMirrorEventId,
-        {
-          summary: event.summary ?? '',
-          startDateTime: event.start?.dateTime ?? '',
-          endDateTime: event.end?.dateTime ?? '',
-          location: event.location ?? undefined,
-          description: event.description ?? undefined,
-          extendedProperties,
-        },
       );
-      this.logger.log(`Mirror updated: ${event.id} → ${spaceCalendarId}`);
-    } else {
-      const newMirrorId =
-        await GoogleCalendarUtil.createMirrorEventAsServiceAccount(
+
+      // 미러가 살아있고 내용도 동일하면 스킵
+      if (
+        currentMirror &&
+        currentMirror.status !== 'cancelled' &&
+        this.isInSync(event, currentMirror)
+      ) {
+        this.logger.log(`Mirror in sync, skipping: ${event.id}`);
+        return existingMirrorEventId;
+      }
+
+      // 미러가 살아있고 내용이 달라졌으면 업데이트
+      if (currentMirror && currentMirror.status !== 'cancelled') {
+        await GoogleCalendarUtil.updateMirrorEventAsServiceAccount(
           spaceCalendarId,
+          existingMirrorEventId,
           {
             summary: event.summary ?? '',
             startDateTime: event.start?.dateTime ?? '',
@@ -177,17 +210,41 @@ export class SpaceMirrorService {
             extendedProperties,
           },
         );
-      // source 이벤트에 mirroredCalendarId + mirroredEventId 함께 저장
-      // → 이후 events.get()으로 즉시 조회 가능 (검색 인덱스 지연 없음)
-      await GoogleCalendarUtil.patchEventPrivateExtendedProperty(
-        sourceCalendarId,
-        event.id!,
+        this.logger.log(`Mirror updated: ${event.id} → ${spaceCalendarId}`);
+        return existingMirrorEventId;
+      }
+
+      // 미러가 삭제(null)됐거나 cancelled 상태 → 새로 생성
+      this.logger.log(
+        `Mirror missing or cancelled, recreating: ${event.id} (old: ${existingMirrorEventId})`,
+      );
+    }
+
+    const newMirrorId =
+      await GoogleCalendarUtil.createMirrorEventAsServiceAccount(
+        spaceCalendarId,
         {
-          [MIRRORED_CALENDAR_ID_KEY]: spaceCalendarId,
-          [MIRRORED_EVENT_ID_KEY]: newMirrorId,
+          summary: event.summary ?? '',
+          startDateTime: event.start?.dateTime ?? '',
+          endDateTime: event.end?.dateTime ?? '',
+          location: event.location ?? undefined,
+          description: event.description ?? undefined,
+          extendedProperties,
         },
       );
-      this.logger.log(`Mirror created: ${event.id} → ${spaceCalendarId}`);
-    }
+    // source 이벤트에 mirroredCalendarId + mirroredEventId 함께 저장
+    // → 이후 events.get()으로 즉시 조회 가능 (검색 인덱스 지연 없음)
+    await GoogleCalendarUtil.patchEventPrivateExtendedProperty(
+      sourceCalendarId,
+      event.id!,
+      {
+        [MIRRORED_CALENDAR_ID_KEY]: spaceCalendarId,
+        [MIRRORED_EVENT_ID_KEY]: newMirrorId,
+      },
+    );
+    this.logger.log(
+      `Mirror created: ${event.id} → ${spaceCalendarId}\nMirror Id: ${newMirrorId}`,
+    );
+    return newMirrorId;
   }
 }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 반복 일정을 대량으로 생성 시 구글 캘린더 API의 Limit을 초과하여 미러 이벤트가 제대로 생성되지 않는 경우 발생
- 매일 새벽 3시에 해당 날짜 기준 30일 이내의 미러링 이벤트 동기화 기능 추가

## 주요 변경 사항

### 미러링 동기화
- syncMirrors: 매일 03:00 KST, 30일 이내 이벤트 전방/역방향 패스 실행
  - 전방 패스: 소스 이벤트 미러링 + 유효 미러 ID 수집
  - 역방향 패스: 소스 사라진 미러 삭제
- 크론 실행 중 suppress:cron:sync 캐시 키로 웹훅 알림/미러링 차단
- upsertMirror: 기존 미러가 null/cancelled일 때 업데이트 시도 대신 새로 생성
- mirrorEvent 반환 타입 void → string | null (미러 ID 추적용)
- isInSync 메서드로 내용 동일한 미러 불필요한 패치 방지
- listEventsInRange / listMirrorEventsInRange 페이지네이션 조회 헬퍼 추가

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->
Closes #59 

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] 미러링 이벤트 제거 후 동기화 시 생성 확인
- [x] 동기화 시 소스가 없는 미러링 이벤트 제거 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
