### PR TITLE
feat: 태그 시간표 기능 추가

### DIFF
--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -11,10 +11,17 @@ import { ScheduleService } from './schedule.service';
 import { ScheduleView } from './schedule.view';
 import { UserService } from '../user/user.service';
 import { TagService } from '../tag/tag.service';
+import { TagView } from '../tag/tag.view';
 import { ChannelService } from '../channel/channel.service';
 import { UserStatus, User } from '../user/user.entity';
 import { CMD } from '../common/slack-commands';
 import { PermissionService } from '../user/permission.service';
+
+const CALENDAR_COLORS = [
+  '%234285F4', '%23DB4437', '%230F9D58', '%23F4B400', '%239E69AF',
+  '%23F6511D', '%2300BCD4', '%23E91E63', '%23795548', '%23607D8B',
+  '%23FF5722', '%239C27B0', '%2303A9F4', '%238BC34A', '%23FF9800',
+];
 
 @Controller()
 export class ScheduleController {
@@ -910,6 +917,73 @@ export class ScheduleController {
     await client.chat.postMessage({
       channel: body.user.id,
       text: `반복 일정 수정 완료: ${updated}/${total}개`,
+    });
+  }
+
+  // 태그 시간표 — 태그별 구글 캘린더 링크 모달 열기
+  @Action('home:open-tag-schedule')
+  async openTagScheduleList({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const userId = body.user.id;
+    const { isActive, message } = await this.checkActiveUser(userId);
+    if (!isActive) {
+      await client.chat.postEphemeral({
+        channel: userId,
+        user: userId,
+        text: message!,
+      });
+      return;
+    }
+
+    const displayTags = await this.tagService.findDisplayTags(true);
+
+    // 태그별 활성 시간표 병렬 조회 → 구글 캘린더 통합 URL 생성
+    const tagItems = (
+      await Promise.all(
+        displayTags.map(async (tag) => {
+          const schedules =
+            await this.scheduleService.findActiveSchedulesByTagId(tag.id);
+          if (schedules.length === 0) return null;
+
+          const calendarUrl =
+            'https://calendar.google.com/calendar/embed?' +
+            schedules
+              .map(
+                (s, i) =>
+                  `src=${encodeURIComponent(s.calendarId)}&color=${CALENDAR_COLORS[i % CALENDAR_COLORS.length]}`,
+              )
+              .join('&') +
+            '&ctz=Asia%2FSeoul&mode=WEEK';
+
+          return { id: tag.id, name: tag.name, calendarUrl };
+        }),
+      )
+    ).filter((item) => item !== null);
+
+    // 태그 없는 시간표도 통합해서 추가
+    const untaggedSchedules =
+      await this.scheduleService.findActiveSchedulesWithoutTags();
+    if (untaggedSchedules.length > 0) {
+      const calendarUrl =
+        'https://calendar.google.com/calendar/embed?' +
+        untaggedSchedules
+          .map(
+            (s, i) =>
+              `src=${encodeURIComponent(s.calendarId)}&color=${CALENDAR_COLORS[i % CALENDAR_COLORS.length]}`,
+          )
+          .join('&') +
+        '&ctz=Asia%2FSeoul&mode=WEEK';
+      tagItems.push({ id: -1, name: '태그 없음', calendarUrl });
+    }
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: TagView.tagScheduleListModal(tagItems),
     });
   }
 }

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -148,6 +148,39 @@ export class ScheduleService {
     });
   }
 
+  // 특정 태그를 가진 활성 스케줄 목록 조회 (태그 시간표용)
+  async findActiveSchedulesByTagId(tagId: number): Promise<Schedule[]> {
+    const ids = await this.scheduleRepository
+      .createQueryBuilder('schedule')
+      .innerJoin('schedule.tags', 'tag')
+      .where('tag.id = :tagId', { tagId })
+      .andWhere('schedule.status = :status', { status: ScheduleStatus.ACTIVE })
+      .andWhere('schedule.deletedAt IS NULL')
+      .select('schedule.id')
+      .getRawMany()
+      .then((rows: { schedule_id: number }[]) => rows.map((r) => r.schedule_id));
+
+    if (ids.length === 0) return [];
+
+    return this.scheduleRepository.find({
+      where: { id: In(ids) },
+      order: { name: 'ASC' },
+    });
+  }
+
+  // 태그가 없는 활성 스케줄 목록 조회
+  async findActiveSchedulesWithoutTags(): Promise<Schedule[]> {
+    return this.scheduleRepository
+      .createQueryBuilder('schedule')
+      .leftJoin('schedule.tags', 'tag')
+      .where('schedule.status = :status', { status: ScheduleStatus.ACTIVE })
+      .andWhere('schedule.deletedAt IS NULL')
+      .groupBy('schedule.id')
+      .having('COUNT(tag.id) = 0')
+      .orderBy('schedule.name', 'ASC')
+      .getMany();
+  }
+
   // 모든 스케줄 목록 조회 (관리용)
   async findAllSchedules(): Promise<Schedule[]> {
     return this.scheduleRepository.find({

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -88,7 +88,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '수업 일정을 *Google Calendar* 에서 받아보거나, 교실별 일정을 확인할 수 있어요.',
+              text: '수업 일정을 *Google Calendar* 에서 받아보거나, 교실별/태그별 일정을 모아볼 수 있어요.',
             },
           ],
         },
@@ -105,6 +105,11 @@ export class HomeView {
               type: 'button',
               text: { type: 'plain_text', text: '교실 시간표' },
               action_id: 'home:open-classroom-schedule',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '태그 시간표' },
+              action_id: 'home:open-tag-schedule',
             },
           ],
         },
@@ -199,7 +204,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '시간표를 *구독* 하거나 *생성·수정* 할 수 있어요. 교실별 일정도 확인할 수 있어요.',
+              text: '시간표를 *구독* 하거나 *생성·수정* 할 수 있어요. 교실별/태그별 일정도 모아볼 수 있어요.',
             },
           ],
         },
@@ -216,6 +221,11 @@ export class HomeView {
               type: 'button',
               text: { type: 'plain_text', text: '교실 시간표' },
               action_id: 'home:open-classroom-schedule',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '태그 시간표' },
+              action_id: 'home:open-tag-schedule',
             },
             {
               type: 'button',

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -95,6 +95,14 @@ export class TagController {
     logger.info(`Tag created: ${name}`);
   }
 
+  // 태그 시간표 — 구글 캘린더 URL 버튼 ack
+  @Action('tag:schedule:open-calendar')
+  async ackTagCalendarLink({
+    ack,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+  }
+
   // 태그 상태 토글 (활성화/비활성화)
   @Action(/^tag:list:toggle:/)
   async handleToggle({

--- a/src/tag/tag.view.ts
+++ b/src/tag/tag.view.ts
@@ -8,6 +8,13 @@ export interface TagListItem {
   isClassTag: boolean; // 반에서 자동 생성된 태그 여부
 }
 
+// 태그 시간표 선택 모달용 아이템
+export interface TagScheduleItem {
+  id: number;
+  name: string;
+  calendarUrl: string; // 해당 태그 소속 시간표들의 통합 구글 캘린더 URL
+}
+
 const STATUS_LABELS: Record<TagStatus, string> = {
   [TagStatus.ACTIVE]: '활성',
   [TagStatus.INACTIVE]: '비활성',
@@ -75,6 +82,56 @@ export class TagView {
         type: 'plain_text',
         text: '닫기',
       },
+      blocks,
+    };
+  }
+
+  // 태그 시간표 — 태그별 구글 캘린더 링크 모달
+  static tagScheduleListModal(tags: TagScheduleItem[]): View {
+    const blocks: View['blocks'] = [];
+
+    if (tags.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '활성 시간표가 연결된 태그가 없습니다.',
+        },
+      });
+    } else {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: '태그에 속한 시간표를 *구글 캘린더* 에서 모아서 볼 수 있어요.',
+          },
+        ],
+      });
+      blocks.push({ type: 'divider' });
+
+      for (const tag of tags) {
+        blocks.push(
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: `*${tag.name}*` },
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: '일정 보기 ❐' },
+              url: tag.calendarUrl,
+              action_id: 'tag:schedule:open-calendar',
+            },
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'tag:modal:schedule-list',
+      title: { type: 'plain_text', text: '태그 시간표' },
+      close: { type: 'plain_text', text: '닫기' },
       blocks,
     };
   }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 특정 반, 교수, 특강 등 태그 시간표를 모아볼 수 있는 `태그 시간표` 기능 제공

## 주요 변경 사항

### 태그 시간표
- 홈 탭 시간표 섹션에 '태그 시간표' 버튼 추가 (student/staff 공통)
- 태그별 활성 시간표를 통합한 구글 캘린더 embed URL 생성
- 태그 없는 시간표도 '태그 없음' 항목으로 통합 제공
- 시간표마다 색상을 달리해 캘린더에서 구분 가능 (15색 팔레트)
- findActiveSchedulesByTagId / findActiveSchedulesWithoutTags 쿼리 추가

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
<img width="1002" height="254" alt="CleanShot 2026-04-15 at 12 15 39@2x" src="https://github.com/user-attachments/assets/77b46ba4-788f-4945-99eb-895008db29d6" />
