### PR TITLE
Feat/notification: 과목 시간표 변경 알림 조건 및 UI 스타일 수정

### DIFF
--- a/src/schedule/schedule-notification.service.ts
+++ b/src/schedule/schedule-notification.service.ts
@@ -6,6 +6,7 @@ import { ChannelService } from '../channel/channel.service';
 import { GoogleCalendarUtil } from '../google/google-calendar.util';
 import {
   buildCalendarNotificationBlocks,
+  hasRelevantChanges,
   EventChangeType,
   EventSnapshot,
 } from './schedule-watch.view';
@@ -93,6 +94,18 @@ export class ScheduleNotificationService {
     if (entry.originalType === 'added' && event.status === 'cancelled') {
       this.logger.log(
         `Skipping notification: new event was cancelled (${key})`,
+      );
+      return;
+    }
+
+    // updated인데 발송 시점 최신 상태가 변경 전과 동일하면 발송 안 함 (되돌린 경우)
+    if (
+      entry.originalType === 'updated' &&
+      entry.beforeSnapshot &&
+      !hasRelevantChanges(entry.beforeSnapshot, event)
+    ) {
+      this.logger.log(
+        `Skipping notification: event reverted to original state (${key})`,
       );
       return;
     }

--- a/src/schedule/schedule-notification.service.ts
+++ b/src/schedule/schedule-notification.service.ts
@@ -3,6 +3,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { WebClient } from '@slack/web-api';
 import { ChannelService } from '../channel/channel.service';
+import { UserService } from '../user/user.service';
 import { GoogleCalendarUtil } from '../google/google-calendar.util';
 import {
   buildCalendarNotificationBlocks,
@@ -38,6 +39,7 @@ export class ScheduleNotificationService {
   constructor(
     @Inject(CACHE_MANAGER) private cache: Cache,
     private readonly channelService: ChannelService,
+    private readonly userService: UserService,
   ) {}
 
   // 웹훅 수신 시: Redis 저장 + 타이머 예약 (타이머 리셋)
@@ -119,11 +121,15 @@ export class ScheduleNotificationService {
     const finalType: EventChangeType =
       event.status === 'cancelled' ? 'cancelled' : entry.originalType;
 
+    // 캘린더 writer/owner 목록 → Slack 멘션으로 변환
+    const writerDisplay = await this.resolveWriterDisplay(entry.calendarId);
+
     const blocks = buildCalendarNotificationBlocks(
       entry.scheduleName,
       event,
       finalType,
       finalType === 'updated' ? entry.beforeSnapshot : undefined,
+      writerDisplay,
     );
 
     await Promise.allSettled(
@@ -139,6 +145,25 @@ export class ScheduleNotificationService {
     this.logger.log(
       `Notification sent: ${key} (type: ${finalType}, channels: ${slackChannelIds.length})`,
     );
+  }
+
+  // 캘린더 writer/owner → Slack 멘션 문자열 변환 (서비스 가입자만)
+  private async resolveWriterDisplay(
+    calendarId: string,
+  ): Promise<string | undefined> {
+    try {
+      const acl = await GoogleCalendarUtil.getCalendarAcl(calendarId);
+      const writerEmails = acl
+        .filter((e) => e.role === 'writer' || e.role === 'owner')
+        .map((e) => e.email);
+
+      const slackIds = await this.userService.mapEmailsToSlackIds(writerEmails);
+      const mentions = slackIds.map((id) => `<@${id}>`);
+
+      return mentions.length > 0 ? mentions.join('  ') : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   // 외부에서 현재 대기 entry 조회 (컨트롤러에서 중복 확인용)

--- a/src/schedule/schedule-watch.controller.ts
+++ b/src/schedule/schedule-watch.controller.ts
@@ -15,7 +15,7 @@ import {
   ScheduleNotificationService,
   DebounceEntry,
 } from './schedule-notification.service';
-import { detectChangeType } from './schedule-watch.view';
+import { detectChangeType, hasRelevantChanges } from './schedule-watch.view';
 import { SpaceMirrorService } from '../space/space-mirror.service';
 import { EventSnapshot } from './schedule-notification.service';
 
@@ -109,6 +109,7 @@ export class ScheduleWatchController {
               startDateTime: before.start?.dateTime,
               endDateTime: before.end?.dateTime,
               location: before.location,
+              description: before.description,
             };
           }
         }
@@ -123,16 +124,25 @@ export class ScheduleWatchController {
           });
 
         if (!notificationSuppressed) {
-          const entry: DebounceEntry = {
-            originalType: currentType,
-            calendarId: schedule.calendarId,
-            scheduleId: schedule.id,
-            scheduleName: schedule.name,
-            eventId: event.id,
-            dueAt: Date.now() + 3 * 60 * 1000,
-            beforeSnapshot,
-          };
-          await this.notificationService.enqueue(key, entry);
+          // updated인데 추적 필드 변경 없으면 알림 스킵
+          if (
+            currentType === 'updated' &&
+            beforeSnapshot &&
+            !hasRelevantChanges(beforeSnapshot, event)
+          ) {
+            // no-op
+          } else {
+            const entry: DebounceEntry = {
+              originalType: currentType,
+              calendarId: schedule.calendarId,
+              scheduleId: schedule.id,
+              scheduleName: schedule.name,
+              eventId: event.id,
+              dueAt: Date.now() + 3 * 60 * 1000,
+              beforeSnapshot,
+            };
+            await this.notificationService.enqueue(key, entry);
+          }
         }
       } else {
         // 두 번째 이후 webhook — 미러 업데이트만, beforeSnapshot은 유지

--- a/src/schedule/schedule-watch.view.ts
+++ b/src/schedule/schedule-watch.view.ts
@@ -86,6 +86,7 @@ export function buildCalendarNotificationBlocks(
   event: calendar_v3.Schema$Event,
   changeType: EventChangeType,
   beforeEvent?: EventSnapshot,
+  writerDisplay?: string,
 ): KnownBlock[] {
   const headerMap: Record<EventChangeType, string> = {
     cancelled: `🚫 [${scheduleName}] 일정 취소 안내`,
@@ -141,7 +142,8 @@ export function buildCalendarNotificationBlocks(
 
   // 설명
   const afterDescription = event.description ?? '';
-  const descriptionChanged = diff && (diff.description ?? '') !== afterDescription;
+  const descriptionChanged =
+    diff && (diff.description ?? '') !== afterDescription;
   const descriptionText = descriptionChanged
     ? `📝 *추가 정보* ✏️\n~${diff!.description || '(없음)'}~ → ${afterDescription || '_(없음)_'}`
     : `📝 *추가 정보*\n${afterDescription || '_추가 정보가 없습니다._'}`;
@@ -185,7 +187,7 @@ export function buildCalendarNotificationBlocks(
         },
         {
           type: 'mrkdwn',
-          text: `👤 *담당자*\n${event.creator?.email ?? '알 수 없음'}`,
+          text: `👤 *담당자*\n${writerDisplay ?? '알 수 없음'}`,
         },
       ],
     },

--- a/src/schedule/schedule-watch.view.ts
+++ b/src/schedule/schedule-watch.view.ts
@@ -8,6 +8,7 @@ export interface EventSnapshot {
   startDateTime?: string | null;
   endDateTime?: string | null;
   location?: string | null;
+  description?: string | null;
 }
 
 export function detectChangeType(
@@ -54,50 +55,30 @@ function formatDateTimeFromEvent(event: calendar_v3.Schema$Event): string {
   const endDt = event.end?.dateTime ?? event.end?.date;
   if (!startDt || !endDt) return '날짜 정보 없음';
   if (!event.start?.dateTime) return `${formatDate(startDt)} (종일)`;
-  return `${formatDate(startDt)} ${formatTime(startDt)} ~ ${formatTime(endDt)}`;
+  return `${formatDate(startDt)} ${formatTime(startDt)} - ${formatTime(endDt)}`;
 }
 
 function formatDateTimeFromSnapshot(snapshot: EventSnapshot): string {
   const { startDateTime, endDateTime } = snapshot;
   if (!startDateTime || !endDateTime) return '날짜 정보 없음';
-  return `${formatDate(startDateTime)} ${formatTime(startDateTime)} ~ ${formatTime(endDateTime)}`;
+  return `${formatDate(startDateTime)} ${formatTime(startDateTime)} - ${formatTime(endDateTime)}`;
 }
 
-function buildDiffBlock(
+export function hasRelevantChanges(
   before: EventSnapshot,
   after: calendar_v3.Schema$Event,
-): KnownBlock | null {
-  const lines: string[] = [];
+): boolean {
+  if ((before.summary ?? '') !== (after.summary ?? '')) return true;
+  if ((before.location ?? '') !== (after.location ?? '')) return true;
+  if ((before.description ?? '') !== (after.description ?? '')) return true;
 
-  const beforeTitle = before.summary ?? '';
-  const afterTitle = after.summary ?? '';
-  if (beforeTitle !== afterTitle) {
-    lines.push(`📌 *제목* : ~${beforeTitle || '(없음)'}~ → *${afterTitle || '(없음)'}*`);
-  }
+  const beforeStart = before.startDateTime ?? '';
+  const beforeEnd = before.endDateTime ?? '';
+  const afterStart = after.start?.dateTime ?? after.start?.date ?? '';
+  const afterEnd = after.end?.dateTime ?? after.end?.date ?? '';
+  if (beforeStart !== afterStart || beforeEnd !== afterEnd) return true;
 
-  const beforeTime = formatDateTimeFromSnapshot(before);
-  const afterTime = formatDateTimeFromEvent(after);
-  if (beforeTime !== afterTime) {
-    lines.push(`🗓️ *일시* : ~${beforeTime}~ → *${afterTime}*`);
-  }
-
-  const beforeLocation = before.location ?? '';
-  const afterLocation = after.location ?? '';
-  if (beforeLocation !== afterLocation) {
-    lines.push(
-      `📍 *장소* : ~${beforeLocation || '미지정'}~ → *${afterLocation || '미지정'}*`,
-    );
-  }
-
-  if (lines.length === 0) return null;
-
-  return {
-    type: 'section',
-    text: {
-      type: 'mrkdwn',
-      text: `*변경 내용*\n${lines.join('\n')}`,
-    },
-  } as KnownBlock;
+  return false;
 }
 
 export function buildCalendarNotificationBlocks(
@@ -112,23 +93,58 @@ export function buildCalendarNotificationBlocks(
     updated: `🔄 [${scheduleName}] 일정 변경 안내`,
   };
 
+  const diff = changeType === 'updated' && beforeEvent ? beforeEvent : null;
+
+  // 제목
+  const afterTitle = event.summary ?? '(제목 없음)';
+  const titleChanged = diff && (diff.summary ?? '') !== (event.summary ?? '');
+  let titleText: string;
+  if (titleChanged) {
+    titleText = `📌 *일정 제목* ✏️\n~${diff!.summary || '(없음)'}~ → *${afterTitle}*`;
+  } else {
+    titleText = `📌 *일정 제목*\n*${afterTitle}*`;
+  }
+
+  // 일시
   const startDt = event.start?.dateTime ?? event.start?.date;
   const endDt = event.end?.dateTime ?? event.end?.date;
   const isAllDay = !event.start?.dateTime;
+  const afterTime = formatDateTimeFromEvent(event);
 
   let dateTimeText: string;
   if (!startDt || !endDt) {
     dateTimeText = '🗓️ *일시*\n_날짜 정보 없음_';
+  } else if (diff) {
+    const beforeTime = formatDateTimeFromSnapshot(diff);
+    if (beforeTime !== afterTime) {
+      dateTimeText = `🗓️ *일시* ✏️\n~${beforeTime}~\n→ *${afterTime}*`;
+    } else if (isAllDay) {
+      dateTimeText = `🗓️ *일시*\n${formatDate(startDt)} *(종일)*`;
+    } else {
+      dateTimeText = `🗓️ *일시*\n${formatDate(startDt)} *${formatTime(startDt)} - ${formatTime(endDt)}*`;
+    }
   } else if (isAllDay) {
     dateTimeText = `🗓️ *일시*\n${formatDate(startDt)} *(종일)*`;
   } else {
-    dateTimeText = `🗓️ *일시*\n${formatDate(startDt)} *${formatTime(startDt)} ~ ${formatTime(endDt)}*`;
+    dateTimeText = `🗓️ *일시*\n${formatDate(startDt)} *${formatTime(startDt)} - ${formatTime(endDt)}*`;
   }
 
-  const diffBlock =
-    changeType === 'updated' && beforeEvent
-      ? buildDiffBlock(beforeEvent, event)
-      : null;
+  // 장소
+  const afterLocation = event.location ?? '';
+  const locationChanged = diff && (diff.location ?? '') !== afterLocation;
+  let locationText: string;
+  if (locationChanged) {
+    locationText = `📍 *장소* ✏️\n~${diff!.location || '미지정'}~ → *${afterLocation || '미지정'}*`;
+  } else {
+    locationText = `📍 *장소*\n${afterLocation || '_장소 미지정_'}`;
+  }
+
+  // 설명
+  const afterDescription = event.description ?? '';
+  const descriptionChanged = diff && (diff.description ?? '') !== afterDescription;
+  const descriptionText = descriptionChanged
+    ? `📝 *추가 정보* ✏️\n~${diff!.description || '(없음)'}~ → ${afterDescription || '_(없음)_'}`
+    : `📝 *추가 정보*\n${afterDescription || '_추가 정보가 없습니다._'}`;
 
   return [
     {
@@ -140,12 +156,11 @@ export function buildCalendarNotificationBlocks(
       },
     },
     { type: 'divider' },
-    ...(diffBlock ? [diffBlock, { type: 'divider' } as KnownBlock] : []),
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `📌 *일정 제목*\n*${event.summary ?? '(제목 없음)'}*`,
+        text: titleText,
       },
     },
     {
@@ -157,7 +172,7 @@ export function buildCalendarNotificationBlocks(
         },
         {
           type: 'mrkdwn',
-          text: `📍 *장소*\n${event.location ?? '_장소 미지정_'}`,
+          text: locationText,
         },
       ],
     },
@@ -166,7 +181,7 @@ export function buildCalendarNotificationBlocks(
       fields: [
         {
           type: 'mrkdwn',
-          text: `📝 *추가 정보*\n${event.description ?? '_추가 정보가 없습니다._'}`,
+          text: descriptionText,
         },
         {
           type: 'mrkdwn',
@@ -188,6 +203,7 @@ export function buildCalendarNotificationBlocks(
                   emoji: true,
                 },
                 url: event.htmlLink,
+                action_id: 'notification:open-calendar',
               },
             ],
           },
@@ -198,7 +214,7 @@ export function buildCalendarNotificationBlocks(
       elements: [
         {
           type: 'mrkdwn',
-          text: `🕒 *최종 수정 시각:* ${event.updated ? formatUpdated(event.updated) : '알 수 없음'} | *Bannote Bot*`,
+          text: `*최종 수정 시각:* ${event.updated ? formatUpdated(event.updated) : '알 수 없음'} | *Bannote Bot*`,
         },
       ],
     },

--- a/src/schedule/schedule-watch.view.ts
+++ b/src/schedule/schedule-watch.view.ts
@@ -201,7 +201,7 @@ export function buildCalendarNotificationBlocks(
                 type: 'button',
                 text: {
                   type: 'plain_text',
-                  text: '구글 캘린더에서 보기',
+                  text: '구글 캘린더에서 보기 ❐',
                   emoji: true,
                 },
                 url: event.htmlLink,

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -986,4 +986,12 @@ export class ScheduleController {
       view: TagView.tagScheduleListModal(tagItems),
     });
   }
+
+  // 알림 메시지의 구글 캘린더 URL 버튼 ack
+  @Action('notification:open-calendar')
+  async ackNotificationCalendarLink({
+    ack,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+  }
 }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 과목 시간표 변경 알림 조건 및 UI 스타일 수정

## 주요 변경 사항

### 알림 조건 개선
- 추적 필드(제목/일시/장소/설명) 변경이 없으면 알림 발송 안함
- webhook 수신 시 diff 체크 -> 변경 없으면 debounce 안함 (1차)
- 알림 발송 직전 최신 상태 재확인 -> 되돌린 경우 발송 암함 (2차)

### 알림 UI 개선
- 변경 내용을 별도 블록 대신 각 필드에 인라인으로 표시
- 변경된 항목에 ✏️ 표시 추가
- 설명(description) diff 추적 추가
- `구글 캘린더에서 보기` 버튼 action_id 누락으로 인한 ack 에러 수정

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->
Closes #58 

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] 이벤트 변경 후 되돌린 경우 알림 미발송 확인
- [x] 변경된 필드 표시 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

<img width="1104" height="692" alt="CleanShot 2026-04-15 at 20 57 42@2x" src="https://github.com/user-attachments/assets/31f5b693-9557-4bba-ad5f-902efdefd245" />
