### PR TITLE
feat: 시간표 목록 및 구독 모달에 알림 채널·담당자 표시

### DIFF
--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -16,6 +16,7 @@ import { ChannelService } from '../channel/channel.service';
 import { UserStatus, User } from '../user/user.entity';
 import { CMD } from '../common/slack-commands';
 import { PermissionService } from '../user/permission.service';
+import { GoogleCalendarUtil } from '../google/google-calendar.util';
 
 const CALENDAR_COLORS = [
   '%234285F4', '%23DB4437', '%230F9D58', '%23F4B400', '%239E69AF',
@@ -72,19 +73,37 @@ export class ScheduleController {
 
     const displayTagMap = new Map(displayTags.map((t) => [t.id, t.name]));
 
+    const schedulesWithMeta = await Promise.all(
+      schedules.map(async (s) => {
+        const [channels, acl] = await Promise.all([
+          this.channelService.getSlackChannelIds(s.id),
+          GoogleCalendarUtil.getCalendarAcl(s.calendarId).catch(() => []),
+        ]);
+
+        const writerEmails = acl
+          .filter((e) => e.role === 'writer' || e.role === 'owner')
+          .map((e) => e.email);
+        const writers = await this.userService.mapEmailsToSlackIds(writerEmails);
+
+        return {
+          id: s.id,
+          name: s.name,
+          description: s.description,
+          status: s.status,
+          tags: s.tags.map((t) => ({
+            id: t.id,
+            name: displayTagMap.get(t.id) ?? t.name,
+          })),
+          createdBy: { name: s.createdBy?.name ?? '알 수 없음' },
+          channels,
+          writers,
+          createdAt: s.createdAt,
+        };
+      }),
+    );
+
     return ScheduleView.listModal(
-      schedules.map((s) => ({
-        id: s.id,
-        name: s.name,
-        description: s.description,
-        status: s.status,
-        tags: s.tags.map((t) => ({
-          id: t.id,
-          name: displayTagMap.get(t.id) ?? t.name,
-        })),
-        createdBy: { name: s.createdBy?.name ?? '알 수 없음' },
-        createdAt: s.createdAt,
-      })),
+      schedulesWithMeta,
       displayTags,
       {
         page: safePage,
@@ -350,19 +369,33 @@ export class ScheduleController {
       displayActiveTags.map((t) => [t.id, t.name]),
     );
 
-    const schedulesWithSubscription = schedules.map((s) => ({
-      id: s.id,
-      name: s.name,
-      description: s.description,
-      calendarId: s.calendarId,
-      tags: s.tags.map((t) => ({
-        id: t.id,
-        name: displayActiveTagMap.get(t.id) ?? t.name,
-      })),
-      createdBy: { name: s.createdBy?.name ?? '알 수 없음' },
-      createdAt: s.createdAt,
-      isSubscribed: subscribedIds.has(s.calendarId),
-    }));
+    const schedulesWithSubscription = await Promise.all(
+      schedules.map(async (s) => {
+        const [channels, acl] = await Promise.all([
+          this.channelService.getSlackChannelIds(s.id),
+          GoogleCalendarUtil.getCalendarAcl(s.calendarId).catch(() => []),
+        ]);
+
+        const writerEmails = acl
+          .filter((e) => e.role === 'writer' || e.role === 'owner')
+          .map((e) => e.email);
+        const writers = await this.userService.mapEmailsToSlackIds(writerEmails);
+
+        return {
+          id: s.id,
+          name: s.name,
+          description: s.description,
+          calendarId: s.calendarId,
+          tags: s.tags.map((t) => ({
+            id: t.id,
+            name: displayActiveTagMap.get(t.id) ?? t.name,
+          })),
+          channels,
+          writers,
+          isSubscribed: subscribedIds.has(s.calendarId),
+        };
+      }),
+    );
 
     return ScheduleView.subscribeSearchModal(
       displayActiveTags,

--- a/src/schedule/schedule.view.ts
+++ b/src/schedule/schedule.view.ts
@@ -10,6 +10,8 @@ export interface ScheduleListItem {
   status: ScheduleStatus;
   tags: { id: number; name: string }[];
   createdBy: { name: string };
+  channels: string[]; // Slack 채널 ID 목록
+  writers: string[]; // 담당자 Slack 유저 ID 목록
   createdAt: Date;
 }
 
@@ -26,7 +28,8 @@ export interface SubscribeScheduleItem {
   description?: string;
   calendarId: string;
   tags: { id: number; name: string }[];
-  createdBy: { name: string };
+  channels: string[]; // Slack 채널 ID 목록
+  writers: string[]; // 담당자 Slack 유저 ID 목록
   isSubscribed: boolean;
 }
 
@@ -144,12 +147,21 @@ export class ScheduleView {
         ? `\n${schedule.description}`
         : '';
 
+      const channelText =
+        schedule.channels.length > 0
+          ? `\n알림 채널: ${schedule.channels.map((id) => `<#${id}>`).join('  ')}`
+          : '';
+      const writerText =
+        schedule.writers.length > 0
+          ? `\n담당자: ${schedule.writers.map((id) => `<@${id}>`).join('  ')}`
+          : '';
+
       blocks.push(
         {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `${statusEmoji} *${schedule.name}*${description}\n태그: ${tagNames}\n상태: ${STATUS_LABELS[schedule.status]} | 생성자: ${schedule.createdBy.name} | 생성일: ${schedule.createdAt.toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' })}`,
+            text: `${statusEmoji} *${schedule.name}*${description}\n태그: ${tagNames}\n상태: ${STATUS_LABELS[schedule.status]} | 생성자: ${schedule.createdBy.name} | 생성일: ${schedule.createdAt.toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' })}${channelText}${writerText}`,
           },
         },
         {
@@ -594,13 +606,22 @@ export class ScheduleView {
             ? `\n${schedule.description}`
             : '';
 
+          const channelText =
+            schedule.channels.length > 0
+              ? `\n알림 채널: ${schedule.channels.map((id) => `<#${id}>`).join('  ')}`
+              : '';
+          const writerText =
+            schedule.writers.length > 0
+              ? `\n담당자: ${schedule.writers.map((id) => `<@${id}>`).join('  ')}`
+              : '';
+
           const calendarUrl = `https://calendar.google.com/calendar/embed?src=${encodeURIComponent(schedule.calendarId)}&ctz=Asia%2FSeoul&mode=WEEK`;
           blocks.push(
             {
               type: 'section',
               text: {
                 type: 'mrkdwn',
-                text: `*${schedule.name}*${descriptionText}\n태그: ${tagNames}\n생성자: ${schedule.createdBy.name}`,
+                text: `*${schedule.name}*${descriptionText}\n태그: ${tagNames}${channelText}${writerText}`,
               },
             },
             {


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
시간표 목록 및 구독 모달에서 해당 시간표의 담당자 및 알림 채널을 바로 알수 있도록 UI 수정

## 주요 변경 사항

### 과목 시간표 구독 모달
- 시간표 관리에 알림 채널(<#채널>)과 캘린더 편집자 슬랙 멘션(<@유저>)을 추가로 표시
- 구독 모달에 생성자 표시 제거

### 시간표 관리 목록
- 시간표 관리에 알림 채널(<#채널>)과 캘린더 편집자 슬랙 멘션(<@유저>)을 추가로 표시

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

### 구독 모달

<details><summary> 이전 </summary>
<p>

<img width="976" height="300" alt="CleanShot 2026-04-16 at 10 08 30@2x" src="https://github.com/user-attachments/assets/082c01f4-9a19-4520-b89c-b7370a7a4498" />

</p>
</details> 

<details><summary> 이후 </summary>
<p>

<img width="976" height="348" alt="CleanShot 2026-04-16 at 10 03 44@2x" src="https://github.com/user-attachments/assets/3cd70085-7cac-4483-b985-500eb497a85b" />

</p>
</details> 

### 시간표 관리 목록

<details><summary> 이전 </summary>
<p>

<img width="976" height="302" alt="CleanShot 2026-04-16 at 10 09 05@2x" src="https://github.com/user-attachments/assets/724b145e-c51f-4ee7-a8d0-533cd81aaa02" />

</p>
</details> 

<details><summary> 이후 </summary>
<p>

<img width="976" height="386" alt="CleanShot 2026-04-16 at 10 06 09@2x" src="https://github.com/user-attachments/assets/bfc0bb26-b69e-42d2-ac1c-696406670827" />

</p>
</details> 