### PR TITLE
perf: GoogleCalendarUtil을 Injectable 서비스로 전환 및 ACL Redis 캐싱 추가

### DIFF
--- a/src/google/google-calendar.service.ts
+++ b/src/google/google-calendar.service.ts
@@ -1,3 +1,6 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { google, calendar_v3 } from 'googleapis';
 
 const SCOPES = ['https://www.googleapis.com/auth/calendar'];
@@ -18,9 +21,15 @@ export interface CalendarAclEntry {
   role: 'reader' | 'writer' | 'owner';
 }
 
-export class GoogleCalendarUtil {
+@Injectable()
+export class GoogleCalendarService {
+  private readonly ACL_CACHE_KEY = (id: string) => `google:acl:${id}`;
+  private readonly ACL_TTL_MS = 15 * 60 * 1000; // 15분
+
+  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+
   // Service Account 인증 (캘린더 생성/관리용)
-  private static getServiceAccountAuth() {
+  private getServiceAccountAuth() {
     const email = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
     const privateKey = process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY?.replace(
       /\\n/g,
@@ -42,7 +51,7 @@ export class GoogleCalendarUtil {
   }
 
   // 사용자 OAuth 인증 (사용자 캘린더 목록 관리용)
-  private static getUserAuth(refreshToken: string) {
+  private getUserAuth(refreshToken: string) {
     const clientId = process.env.GOOGLE_CLIENT_ID;
     const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -59,20 +68,18 @@ export class GoogleCalendarUtil {
     return oauth2Client;
   }
 
-  private static getCalendarClient(): calendar_v3.Calendar {
+  private getCalendarClient(): calendar_v3.Calendar {
     const auth = this.getServiceAccountAuth();
     return google.calendar({ version: 'v3', auth });
   }
 
-  private static getUserCalendarClient(
-    refreshToken: string,
-  ): calendar_v3.Calendar {
+  private getUserCalendarClient(refreshToken: string): calendar_v3.Calendar {
     const auth = this.getUserAuth(refreshToken);
     return google.calendar({ version: 'v3', auth });
   }
 
   // 캘린더 생성
-  static async createCalendar(
+  async createCalendar(
     summary: string,
     description?: string,
   ): Promise<CreateCalendarResult> {
@@ -97,13 +104,13 @@ export class GoogleCalendarUtil {
   }
 
   // 캘린더 삭제
-  static async deleteCalendar(calendarId: string): Promise<void> {
+  async deleteCalendar(calendarId: string): Promise<void> {
     const calendar = this.getCalendarClient();
     await calendar.calendars.delete({ calendarId });
   }
 
   // 캘린더 공유 (유저에게 권한 부여)
-  static async shareCalendar(options: ShareCalendarOptions): Promise<void> {
+  async shareCalendar(options: ShareCalendarOptions): Promise<void> {
     const calendar = this.getCalendarClient();
 
     await calendar.acl.insert({
@@ -116,13 +123,12 @@ export class GoogleCalendarUtil {
         },
       },
     });
+
+    await this.cache.del(this.ACL_CACHE_KEY(options.calendarId));
   }
 
   // 캘린더 공유 제거 (권한 삭제)
-  static async unshareCalendar(
-    calendarId: string,
-    email: string,
-  ): Promise<void> {
+  async unshareCalendar(calendarId: string, email: string): Promise<void> {
     const calendar = this.getCalendarClient();
 
     // 구글 캘린더 ACL에서 유저 권한의 ruleId는 보통 "user:이메일주소" 형식
@@ -135,14 +141,17 @@ export class GoogleCalendarUtil {
       });
     } catch (error: any) {
       if (error.code === 404) {
+        await this.cache.del(this.ACL_CACHE_KEY(calendarId));
         return;
       }
       throw error;
     }
+
+    await this.cache.del(this.ACL_CACHE_KEY(calendarId));
   }
 
   // 캘린더 공개 설정 (읽기 전용)
-  static async makeCalendarPublic(calendarId: string): Promise<void> {
+  async makeCalendarPublic(calendarId: string): Promise<void> {
     const calendar = this.getCalendarClient();
 
     await calendar.acl.insert({
@@ -157,7 +166,7 @@ export class GoogleCalendarUtil {
   }
 
   // 캘린더 정보 조회
-  static async getCalendar(
+  async getCalendar(
     calendarId: string,
   ): Promise<calendar_v3.Schema$Calendar | null> {
     const calendar = this.getCalendarClient();
@@ -174,7 +183,7 @@ export class GoogleCalendarUtil {
   }
 
   // 캘린더 이름 변경
-  static async updateCalendar(
+  async updateCalendar(
     calendarId: string,
     summary: string,
     description?: string,
@@ -190,8 +199,20 @@ export class GoogleCalendarUtil {
     });
   }
 
-  // 캘린더 ACL 조회 (권한 목록)
-  static async getCalendarAcl(calendarId: string): Promise<CalendarAclEntry[]> {
+  // 캘린더 ACL 조회 (권한 목록) — Redis 15분 캐싱
+  async getCalendarAcl(calendarId: string): Promise<CalendarAclEntry[]> {
+    const key = this.ACL_CACHE_KEY(calendarId);
+    const cached = await this.cache.get<CalendarAclEntry[]>(key);
+    if (cached) return cached;
+
+    const data = await this.fetchCalendarAcl(calendarId);
+    await this.cache.set(key, data, this.ACL_TTL_MS);
+    return data;
+  }
+
+  private async fetchCalendarAcl(
+    calendarId: string,
+  ): Promise<CalendarAclEntry[]> {
     const calendar = this.getCalendarClient();
 
     const response = await calendar.acl.list({ calendarId });
@@ -214,7 +235,7 @@ export class GoogleCalendarUtil {
   // ========== 사용자 캘린더 목록 관리 (OAuth 토큰 사용) ==========
 
   // 사용자 캘린더 목록에 캘린더 추가
-  static async addCalendarToUserList(
+  async addCalendarToUserList(
     calendarId: string,
     userRefreshToken: string,
   ): Promise<void> {
@@ -238,12 +259,12 @@ export class GoogleCalendarUtil {
 
   // ========== Google Calendar Watch (Push Notification) ==========
 
-  static isWatchConfigured(): boolean {
+  isWatchConfigured(): boolean {
     return !!process.env.GOOGLE_WEBHOOK_URL;
   }
 
   // 캘린더 이벤트 변경 watch 등록
-  static async watchCalendarEvents(
+  async watchCalendarEvents(
     calendarId: string,
     channelId: string,
   ): Promise<{ resourceId: string }> {
@@ -271,7 +292,7 @@ export class GoogleCalendarUtil {
   }
 
   // watch 해제
-  static async stopCalendarWatch(
+  async stopCalendarWatch(
     channelId: string,
     resourceId: string,
   ): Promise<void> {
@@ -291,7 +312,7 @@ export class GoogleCalendarUtil {
   }
 
   // 초기 syncToken 발급 (watch 등록 시 호출)
-  static async getInitialSyncToken(calendarId: string): Promise<string> {
+  async getInitialSyncToken(calendarId: string): Promise<string> {
     const calendar = this.getCalendarClient();
     let pageToken: string | undefined;
 
@@ -318,7 +339,7 @@ export class GoogleCalendarUtil {
 
   // syncToken으로 변경된 이벤트 조회 (웹훅 수신 후 사용)
   // 410 Gone 시 getInitialSyncToken으로 fallback → { events: [], nextSyncToken }
-  static async getChangedEventsBySyncToken(
+  async getChangedEventsBySyncToken(
     calendarId: string,
     syncToken: string,
   ): Promise<{ events: calendar_v3.Schema$Event[]; nextSyncToken: string }> {
@@ -347,7 +368,7 @@ export class GoogleCalendarUtil {
   }
 
   // 최근 변경된 이벤트 조회 (레거시 — syncToken 없는 경우 fallback용)
-  static async getRecentChangedEvents(
+  async getRecentChangedEvents(
     calendarId: string,
   ): Promise<calendar_v3.Schema$Event[]> {
     const calendar = this.getCalendarClient();
@@ -365,7 +386,7 @@ export class GoogleCalendarUtil {
   }
 
   // 특정 기간의 이벤트 전체 조회 (동기화용)
-  static async listEventsInRange(
+  async listEventsInRange(
     calendarId: string,
     timeMin: Date,
     timeMax: Date,
@@ -395,7 +416,7 @@ export class GoogleCalendarUtil {
   }
 
   // 단일 이벤트 조회 (디바운스 발송 시점에 최신 상태 확인용)
-  static async getEventById(
+  async getEventById(
     calendarId: string,
     eventId: string,
   ): Promise<calendar_v3.Schema$Event | null> {
@@ -413,7 +434,7 @@ export class GoogleCalendarUtil {
   // ========== 반복 일정 (서비스 계정 기반) ==========
 
   // 서비스 계정으로 이벤트 생성 (groupId extendedProperties 포함)
-  static async createEventAsServiceAccount(
+  async createEventAsServiceAccount(
     calendarId: string,
     params: {
       summary: string;
@@ -449,7 +470,7 @@ export class GoogleCalendarUtil {
   }
 
   // groupId로 이벤트 목록 조회 (전체 삭제/수정용)
-  static async listEventsByGroupId(
+  async listEventsByGroupId(
     calendarId: string,
     groupId: string,
   ): Promise<calendar_v3.Schema$Event[]> {
@@ -475,7 +496,7 @@ export class GoogleCalendarUtil {
   }
 
   // 서비스 계정으로 이벤트 삭제
-  static async deleteEventAsServiceAccount(
+  async deleteEventAsServiceAccount(
     calendarId: string,
     eventId: string,
   ): Promise<void> {
@@ -484,7 +505,7 @@ export class GoogleCalendarUtil {
   }
 
   // 서비스 계정으로 이벤트 수정 (patch: undefined 필드는 변경 안 함)
-  static async updateEventAsServiceAccount(
+  async updateEventAsServiceAccount(
     calendarId: string,
     eventId: string,
     params: {
@@ -513,7 +534,7 @@ export class GoogleCalendarUtil {
   }
 
   // 서비스 계정으로 이벤트의 private extendedProperties 일부 패치
-  static async patchEventPrivateExtendedProperty(
+  async patchEventPrivateExtendedProperty(
     calendarId: string,
     eventId: string,
     privateProps: Record<string, string>,
@@ -530,7 +551,7 @@ export class GoogleCalendarUtil {
   }
 
   // extendedProperties.private 필터로 이벤트 검색 (미러 이벤트 추적용)
-  static async searchByExtendedProperty(
+  async searchByExtendedProperty(
     calendarId: string,
     key: string,
     value: string,
@@ -546,7 +567,7 @@ export class GoogleCalendarUtil {
   }
 
   // 특정 기간의 미러 이벤트 전체 조회 (mirroredBy=gsc-bot 필터)
-  static async listMirrorEventsInRange(
+  async listMirrorEventsInRange(
     calendarId: string,
     timeMin: Date,
     timeMax: Date,
@@ -577,7 +598,7 @@ export class GoogleCalendarUtil {
   }
 
   // 서비스 계정으로 미러 이벤트 생성 (extendedProperties 포함)
-  static async createMirrorEventAsServiceAccount(
+  async createMirrorEventAsServiceAccount(
     calendarId: string,
     params: {
       summary: string;
@@ -608,7 +629,7 @@ export class GoogleCalendarUtil {
   }
 
   // 서비스 계정으로 미러 이벤트 수정 (extendedProperties 포함)
-  static async updateMirrorEventAsServiceAccount(
+  async updateMirrorEventAsServiceAccount(
     calendarId: string,
     eventId: string,
     params: {
@@ -642,7 +663,7 @@ export class GoogleCalendarUtil {
   // ========== 스터디룸 예약 ==========
 
   // 이벤트 생성 (참석자 포함, 메일 발송 없음)
-  static async createEvent(
+  async createEvent(
     calendarId: string,
     refreshToken: string,
     params: {
@@ -683,7 +704,7 @@ export class GoogleCalendarUtil {
   }
 
   // FreeBusy API로 시간대 사용 여부 확인
-  static async isTimeSlotBusy(
+  async isTimeSlotBusy(
     calendarId: string,
     refreshToken: string,
     startTime: Date,
@@ -705,7 +726,7 @@ export class GoogleCalendarUtil {
   }
 
   // 특정 사용자가 참석자인 이벤트 목록 조회 (여러 캘린더, 서비스 계정 사용)
-  static async getUserBookings(
+  async getUserBookings(
     calendarIds: string[],
     userEmail: string,
   ): Promise<Array<{ calendarId: string; event: calendar_v3.Schema$Event }>> {
@@ -748,7 +769,7 @@ export class GoogleCalendarUtil {
   }
 
   // 이벤트 삭제
-  static async deleteEvent(
+  async deleteEvent(
     calendarId: string,
     refreshToken: string,
     eventId: string,
@@ -758,7 +779,7 @@ export class GoogleCalendarUtil {
   }
 
   // 이벤트 수정 (부분 업데이트)
-  static async updateEvent(
+  async updateEvent(
     calendarId: string,
     refreshToken: string,
     eventId: string,
@@ -803,7 +824,7 @@ export class GoogleCalendarUtil {
   }
 
   // 사용자 캘린더 목록에서 캘린더 제거
-  static async removeCalendarFromUserList(
+  async removeCalendarFromUserList(
     calendarId: string,
     userRefreshToken: string,
   ): Promise<void> {
@@ -821,9 +842,7 @@ export class GoogleCalendarUtil {
     }
   }
 
-  static async getUserCalendarIds(
-    userRefreshToken: string,
-  ): Promise<Set<string>> {
+  async getUserCalendarIds(userRefreshToken: string): Promise<Set<string>> {
     const calendar = this.getUserCalendarClient(userRefreshToken);
     const ids = new Set<string>();
     let pageToken: string | undefined;

--- a/src/google/google.module.ts
+++ b/src/google/google.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { GoogleCalendarService } from './google-calendar.service';
+
+@Module({
+  providers: [GoogleCalendarService],
+  exports: [GoogleCalendarService],
+})
+export class GoogleModule {}

--- a/src/schedule/schedule-cron.service.ts
+++ b/src/schedule/schedule-cron.service.ts
@@ -2,10 +2,11 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
+import { calendar_v3 } from 'googleapis';
 import { ScheduleService } from './schedule.service';
 import { SpaceMirrorService } from '../space/space-mirror.service';
 import { SpaceService } from '../space/space.service';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 
 const CRON_SUPPRESS_KEY = 'suppress:cron:sync';
 
@@ -17,6 +18,7 @@ export class ScheduleCronService {
     private readonly scheduleService: ScheduleService,
     private readonly spaceMirrorService: SpaceMirrorService,
     private readonly spaceService: SpaceService,
+    private readonly googleCalendarService: GoogleCalendarService,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
   ) {}
 
@@ -54,11 +56,9 @@ export class ScheduleCronService {
       const validMirrorEventIds = new Set<string>();
 
       for (const schedule of schedules) {
-        let events: Awaited<
-          ReturnType<typeof GoogleCalendarUtil.listEventsInRange>
-        >;
+        let events: calendar_v3.Schema$Event[];
         try {
-          events = await GoogleCalendarUtil.listEventsInRange(
+          events = await this.googleCalendarService.listEventsInRange(
             schedule.calendarId,
             timeMin,
             timeMax,
@@ -102,11 +102,9 @@ export class ScheduleCronService {
       const spaces = await this.spaceService.findAll(true);
 
       for (const space of spaces) {
-        let mirrorEvents: Awaited<
-          ReturnType<typeof GoogleCalendarUtil.listMirrorEventsInRange>
-        >;
+        let mirrorEvents: calendar_v3.Schema$Event[];
         try {
-          mirrorEvents = await GoogleCalendarUtil.listMirrorEventsInRange(
+          mirrorEvents = await this.googleCalendarService.listMirrorEventsInRange(
             space.calendarId,
             timeMin,
             timeMax,
@@ -122,7 +120,7 @@ export class ScheduleCronService {
           if (!mirror.id) continue;
 
           if (!validMirrorEventIds.has(mirror.id)) {
-            await GoogleCalendarUtil.deleteEventAsServiceAccount(
+            await this.googleCalendarService.deleteEventAsServiceAccount(
               space.calendarId,
               mirror.id,
             )

--- a/src/schedule/schedule-notification.service.ts
+++ b/src/schedule/schedule-notification.service.ts
@@ -4,7 +4,7 @@ import type { Cache } from 'cache-manager';
 import { WebClient } from '@slack/web-api';
 import { ChannelService } from '../channel/channel.service';
 import { UserService } from '../user/user.service';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 import {
   buildCalendarNotificationBlocks,
   hasRelevantChanges,
@@ -40,6 +40,7 @@ export class ScheduleNotificationService {
     @Inject(CACHE_MANAGER) private cache: Cache,
     private readonly channelService: ChannelService,
     private readonly userService: UserService,
+    private readonly googleCalendarService: GoogleCalendarService,
   ) {}
 
   // 웹훅 수신 시: Redis 저장 + 타이머 예약 (타이머 리셋)
@@ -86,7 +87,7 @@ export class ScheduleNotificationService {
     await this.cache.del(pendingKey(key));
 
     // 최신 이벤트 조회 (미러 메타데이터 포함)
-    const event = await GoogleCalendarUtil.getEventById(
+    const event = await this.googleCalendarService.getEventById(
       entry.calendarId,
       entry.eventId,
     );
@@ -152,7 +153,7 @@ export class ScheduleNotificationService {
     calendarId: string,
   ): Promise<string | undefined> {
     try {
-      const acl = await GoogleCalendarUtil.getCalendarAcl(calendarId);
+      const acl = await this.googleCalendarService.getCalendarAcl(calendarId);
       const writerEmails = acl
         .filter((e) => e.role === 'writer' || e.role === 'owner')
         .map((e) => e.email);

--- a/src/schedule/schedule-watch.controller.ts
+++ b/src/schedule/schedule-watch.controller.ts
@@ -9,7 +9,7 @@ import {
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { ChannelService } from '../channel/channel.service';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 import { ScheduleService } from './schedule.service';
 import {
   ScheduleNotificationService,
@@ -28,6 +28,7 @@ export class ScheduleWatchController {
     private readonly channelService: ChannelService,
     private readonly notificationService: ScheduleNotificationService,
     private readonly spaceMirrorService: SpaceMirrorService,
+    private readonly googleCalendarService: GoogleCalendarService,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
   ) {}
 
@@ -65,7 +66,7 @@ export class ScheduleWatchController {
     }
 
     const { events, nextSyncToken } =
-      await GoogleCalendarUtil.getChangedEventsBySyncToken(
+      await this.googleCalendarService.getChangedEventsBySyncToken(
         schedule.calendarId,
         schedule.syncToken,
       );

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -16,7 +16,7 @@ import { ChannelService } from '../channel/channel.service';
 import { UserStatus, User } from '../user/user.entity';
 import { CMD } from '../common/slack-commands';
 import { PermissionService } from '../user/permission.service';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 
 const CALENDAR_COLORS = [
   '%234285F4', '%23DB4437', '%230F9D58', '%23F4B400', '%239E69AF',
@@ -32,6 +32,7 @@ export class ScheduleController {
     private readonly tagService: TagService,
     private readonly channelService: ChannelService,
     private readonly permissionService: PermissionService,
+    private readonly googleCalendarService: GoogleCalendarService,
   ) {}
 
   // 활성 사용자 확인 헬퍼
@@ -77,7 +78,7 @@ export class ScheduleController {
       schedules.map(async (s) => {
         const [channels, acl] = await Promise.all([
           this.channelService.getSlackChannelIds(s.id),
-          GoogleCalendarUtil.getCalendarAcl(s.calendarId).catch(() => []),
+          this.googleCalendarService.getCalendarAcl(s.calendarId).catch(() => []),
         ]);
 
         const writerEmails = acl
@@ -373,7 +374,7 @@ export class ScheduleController {
       schedules.map(async (s) => {
         const [channels, acl] = await Promise.all([
           this.channelService.getSlackChannelIds(s.id),
-          GoogleCalendarUtil.getCalendarAcl(s.calendarId).catch(() => []),
+          this.googleCalendarService.getCalendarAcl(s.calendarId).catch(() => []),
         ]);
 
         const writerEmails = acl

--- a/src/schedule/schedule.module.ts
+++ b/src/schedule/schedule.module.ts
@@ -12,6 +12,7 @@ import { TagModule } from '../tag/tag.module';
 import { Tag } from '../tag/tag.entity';
 import { ChannelModule } from '../channel/channel.module';
 import { SpaceModule } from '../space/space.module';
+import { GoogleModule } from '../google/google.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { SpaceModule } from '../space/space.module';
     forwardRef(() => TagModule),
     ChannelModule,
     SpaceModule,
+    GoogleModule,
   ],
   controllers: [ScheduleController, ScheduleWatchController],
   providers: [ScheduleService, ScheduleCronService, ScheduleNotificationService],

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -6,7 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
 import { Schedule, ScheduleStatus } from './schedule.entity';
 import { RecurrenceGroup } from './recurrence-group.entity';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 import { Tag } from '../tag/tag.entity';
 import { ChannelService } from '../channel/channel.service';
 import { WebClient } from '@slack/web-api';
@@ -66,12 +66,13 @@ export class ScheduleService {
     private recurrenceGroupRepository: Repository<RecurrenceGroup>,
     @Inject(CACHE_MANAGER) private cache: Cache,
     private readonly channelService: ChannelService,
+    private readonly googleCalendarService: GoogleCalendarService,
   ) {}
 
   // 스케줄 생성 (Google Calendar도 함께 생성)
   async createSchedule(dto: CreateScheduleDto): Promise<Schedule> {
     // 1. Google Calendar 생성
-    const { calendarId } = await GoogleCalendarUtil.createCalendar(
+    const { calendarId } = await this.googleCalendarService.createCalendar(
       dto.name,
       dto.description,
     );
@@ -97,16 +98,16 @@ export class ScheduleService {
     const saved = await this.scheduleRepository.save(schedule);
 
     // 4. 캘린더 전체 공개 설정
-    await GoogleCalendarUtil.makeCalendarPublic(calendarId);
+    await this.googleCalendarService.makeCalendarPublic(calendarId);
 
     // 5. 생성자에게 writer 권한 부여 및 자동 구독
     if (dto.creatorEmail && dto.creatorRefreshToken) {
-      await GoogleCalendarUtil.shareCalendar({
+      await this.googleCalendarService.shareCalendar({
         calendarId,
         email: dto.creatorEmail,
         role: 'writer',
       });
-      await GoogleCalendarUtil.addCalendarToUserList(
+      await this.googleCalendarService.addCalendarToUserList(
         calendarId,
         dto.creatorRefreshToken,
       );
@@ -266,7 +267,7 @@ export class ScheduleService {
 
     // Google Calendar 업데이트
     if (dto.name || dto.description !== undefined) {
-      await GoogleCalendarUtil.updateCalendar(
+      await this.googleCalendarService.updateCalendar(
         schedule.calendarId,
         dto.name ?? schedule.name,
         dto.description ?? schedule.description,
@@ -316,7 +317,7 @@ export class ScheduleService {
 
     // Google Calendar 삭제
     try {
-      await GoogleCalendarUtil.deleteCalendar(schedule.calendarId);
+      await this.googleCalendarService.deleteCalendar(schedule.calendarId);
     } catch (error) {
       // Calendar가 이미 삭제된 경우 무시
       this.logger.warn(
@@ -334,7 +335,7 @@ export class ScheduleService {
     const schedule = await this.scheduleRepository.findOne({ where: { id } });
     if (!schedule) return;
 
-    if (!GoogleCalendarUtil.isWatchConfigured()) {
+    if (!this.googleCalendarService.isWatchConfigured()) {
       this.logger.warn(
         'GOOGLE_WEBHOOK_URL not set, skipping watch registration',
       );
@@ -344,7 +345,7 @@ export class ScheduleService {
     // 기존 watch가 있으면 먼저 해제
     if (schedule.watchChannelId && schedule.watchResourceId) {
       try {
-        await GoogleCalendarUtil.stopCalendarWatch(
+        await this.googleCalendarService.stopCalendarWatch(
           schedule.watchChannelId,
           schedule.watchResourceId,
         );
@@ -358,12 +359,12 @@ export class ScheduleService {
     const channelId = randomUUID();
 
     try {
-      const { resourceId } = await GoogleCalendarUtil.watchCalendarEvents(
+      const { resourceId } = await this.googleCalendarService.watchCalendarEvents(
         schedule.calendarId,
         channelId,
       );
 
-      const syncToken = await GoogleCalendarUtil.getInitialSyncToken(
+      const syncToken = await this.googleCalendarService.getInitialSyncToken(
         schedule.calendarId,
       );
 
@@ -389,7 +390,7 @@ export class ScheduleService {
     if (!schedule?.watchChannelId || !schedule?.watchResourceId) return;
 
     try {
-      await GoogleCalendarUtil.stopCalendarWatch(
+      await this.googleCalendarService.stopCalendarWatch(
         schedule.watchChannelId,
         schedule.watchResourceId,
       );
@@ -438,7 +439,7 @@ export class ScheduleService {
     const schedule = await this.findById(id);
     if (!schedule) return null;
 
-    return GoogleCalendarUtil.getCalendarAcl(schedule.calendarId);
+    return this.googleCalendarService.getCalendarAcl(schedule.calendarId);
   }
 
   // 캘린더 권한 부여
@@ -450,7 +451,7 @@ export class ScheduleService {
     const schedule = await this.findById(id);
     if (!schedule) throw new BusinessError(ErrorCode.SCHEDULE_NOT_FOUND);
 
-    await GoogleCalendarUtil.shareCalendar({
+    await this.googleCalendarService.shareCalendar({
       calendarId: schedule.calendarId,
       email,
       role,
@@ -462,7 +463,7 @@ export class ScheduleService {
     const schedule = await this.findById(id);
     if (!schedule) throw new BusinessError(ErrorCode.SCHEDULE_NOT_FOUND);
 
-    await GoogleCalendarUtil.unshareCalendar(schedule.calendarId, email);
+    await this.googleCalendarService.unshareCalendar(schedule.calendarId, email);
   }
 
   // 구독 (사용자 캘린더 목록에 추가)
@@ -470,7 +471,7 @@ export class ScheduleService {
     const schedule = await this.findById(id);
     if (!schedule) throw new BusinessError(ErrorCode.SCHEDULE_NOT_FOUND);
 
-    await GoogleCalendarUtil.addCalendarToUserList(
+    await this.googleCalendarService.addCalendarToUserList(
       schedule.calendarId,
       userRefreshToken,
     );
@@ -481,7 +482,7 @@ export class ScheduleService {
     const schedule = await this.findById(id);
     if (!schedule) throw new BusinessError(ErrorCode.SCHEDULE_NOT_FOUND);
 
-    await GoogleCalendarUtil.removeCalendarFromUserList(
+    await this.googleCalendarService.removeCalendarFromUserList(
       schedule.calendarId,
       userRefreshToken,
     );
@@ -491,7 +492,7 @@ export class ScheduleService {
   async getSubscribedCalendarIds(
     userRefreshToken: string,
   ): Promise<Set<string>> {
-    return GoogleCalendarUtil.getUserCalendarIds(userRefreshToken);
+    return this.googleCalendarService.getUserCalendarIds(userRefreshToken);
   }
 
   // ========== 반복 일정 ==========
@@ -511,7 +512,7 @@ export class ScheduleService {
 
     // 3. 이벤트 10개씩 청크 생성 (Rate Limit 방지)
     const results = await runInChunks(dates, ({ startDateTime, endDateTime }) =>
-      GoogleCalendarUtil.createEventAsServiceAccount(schedule.calendarId, {
+      this.googleCalendarService.createEventAsServiceAccount(schedule.calendarId, {
         summary: dto.title,
         startDateTime,
         endDateTime,
@@ -617,7 +618,7 @@ export class ScheduleService {
       3 * 60 * 1000,
     );
 
-    let events = await GoogleCalendarUtil.listEventsByGroupId(
+    let events = await this.googleCalendarService.listEventsByGroupId(
       schedule.calendarId,
       group.groupId,
     );
@@ -630,7 +631,7 @@ export class ScheduleService {
     }
 
     const results = await runInChunks(events, (e) =>
-      GoogleCalendarUtil.deleteEventAsServiceAccount(
+      this.googleCalendarService.deleteEventAsServiceAccount(
         schedule.calendarId,
         e.id!,
       ),
@@ -693,7 +694,7 @@ export class ScheduleService {
       3 * 60 * 1000,
     );
 
-    let events = await GoogleCalendarUtil.listEventsByGroupId(
+    let events = await this.googleCalendarService.listEventsByGroupId(
       schedule.calendarId,
       group.groupId,
     );
@@ -718,7 +719,7 @@ export class ScheduleService {
         endDateTime = `${datePart}T${dto.endTime}:00+09:00`;
       }
 
-      return GoogleCalendarUtil.updateEventAsServiceAccount(
+      return this.googleCalendarService.updateEventAsServiceAccount(
         schedule.calendarId,
         e.id!,
         {

--- a/src/space/space-mirror.service.ts
+++ b/src/space/space-mirror.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { calendar_v3 } from 'googleapis';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 import { SpaceService } from './space.service';
 
 const MIRRORED_BY_KEY = 'mirroredBy';
@@ -14,7 +14,10 @@ const MIRRORED_EVENT_ID_KEY = 'mirroredEventId';
 export class SpaceMirrorService {
   private readonly logger = new Logger(SpaceMirrorService.name);
 
-  constructor(private readonly spaceService: SpaceService) {}
+  constructor(
+    private readonly spaceService: SpaceService,
+    private readonly googleCalendarService: GoogleCalendarService,
+  ) {}
 
   /**
    * debounce 발사 시점에 호출.
@@ -29,7 +32,7 @@ export class SpaceMirrorService {
 
     if (event.status === 'cancelled') {
       // 취소된 이벤트는 webhook payload에 extendedProperties 없을 수 있음 → source 이벤트 직접 조회
-      const sourceEvent = await GoogleCalendarUtil.getEventById(
+      const sourceEvent = await this.googleCalendarService.getEventById(
         sourceCalendarId,
         event.id!,
       );
@@ -41,7 +44,7 @@ export class SpaceMirrorService {
         sourceEvent.extendedProperties?.private?.[MIRRORED_EVENT_ID_KEY];
       if (!mirroredCalendarId || !mirroredEventId) return null;
 
-      await GoogleCalendarUtil.deleteEventAsServiceAccount(
+      await this.googleCalendarService.deleteEventAsServiceAccount(
         mirroredCalendarId,
         mirroredEventId,
       ).catch(() => {
@@ -68,11 +71,11 @@ export class SpaceMirrorService {
     if (!targetSpace) {
       // 대상 공간 없음 → 기존 미러 정리
       if (storedMirroredCalendarId && storedMirroredEventId) {
-        await GoogleCalendarUtil.deleteEventAsServiceAccount(
+        await this.googleCalendarService.deleteEventAsServiceAccount(
           storedMirroredCalendarId,
           storedMirroredEventId,
         ).catch(() => {});
-        await GoogleCalendarUtil.patchEventPrivateExtendedProperty(
+        await this.googleCalendarService.patchEventPrivateExtendedProperty(
           sourceCalendarId,
           event.id!,
           { [MIRRORED_CALENDAR_ID_KEY]: '', [MIRRORED_EVENT_ID_KEY]: '' },
@@ -90,7 +93,7 @@ export class SpaceMirrorService {
       storedMirroredCalendarId !== targetSpace.calendarId &&
       storedMirroredEventId
     ) {
-      await GoogleCalendarUtil.deleteEventAsServiceAccount(
+      await this.googleCalendarService.deleteEventAsServiceAccount(
         storedMirroredCalendarId,
         storedMirroredEventId,
       ).catch(() => {});
@@ -128,7 +131,7 @@ export class SpaceMirrorService {
       event.extendedProperties?.private?.[MIRRORED_EVENT_ID_KEY];
     if (!mirroredCalendarId || !mirroredEventId) return null;
 
-    return GoogleCalendarUtil.getEventById(mirroredCalendarId, mirroredEventId);
+    return this.googleCalendarService.getEventById(mirroredCalendarId, mirroredEventId);
   }
 
   // 미러 이벤트인지 판별 (webhook suppress용)
@@ -167,7 +170,7 @@ export class SpaceMirrorService {
 
     if (existingMirrorEventId) {
       // 현재 미러 이벤트 조회 후 동일하면 패치 없이 스킵 (불필요한 webhook 방지)
-      const currentMirror = await GoogleCalendarUtil.getEventById(
+      const currentMirror = await this.googleCalendarService.getEventById(
         spaceCalendarId,
         existingMirrorEventId,
       );
@@ -184,7 +187,7 @@ export class SpaceMirrorService {
 
       // 미러가 살아있고 내용이 달라졌으면 업데이트
       if (currentMirror && currentMirror.status !== 'cancelled') {
-        await GoogleCalendarUtil.updateMirrorEventAsServiceAccount(
+        await this.googleCalendarService.updateMirrorEventAsServiceAccount(
           spaceCalendarId,
           existingMirrorEventId,
           {
@@ -206,7 +209,7 @@ export class SpaceMirrorService {
     }
 
     const newMirrorId =
-      await GoogleCalendarUtil.createMirrorEventAsServiceAccount(
+      await this.googleCalendarService.createMirrorEventAsServiceAccount(
         spaceCalendarId,
         {
           summary: event.summary ?? '',
@@ -219,7 +222,7 @@ export class SpaceMirrorService {
       );
     // source 이벤트에 mirroredCalendarId + mirroredEventId 함께 저장
     // → 이후 events.get()으로 즉시 조회 가능 (검색 인덱스 지연 없음)
-    await GoogleCalendarUtil.patchEventPrivateExtendedProperty(
+    await this.googleCalendarService.patchEventPrivateExtendedProperty(
       sourceCalendarId,
       event.id!,
       {

--- a/src/space/space.controller.ts
+++ b/src/space/space.controller.ts
@@ -12,7 +12,7 @@ import { SpaceView } from './space.view';
 import { SpaceStatus, SpaceType } from './space.entity';
 import { UserService } from '../user/user.service';
 import { UserStatus } from '../user/user.entity';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 import { CMD } from '../common/slack-commands';
 import { PermissionService } from '../user/permission.service';
 
@@ -22,6 +22,7 @@ export class SpaceController {
     private readonly spaceService: SpaceService,
     private readonly userService: UserService,
     private readonly permissionService: PermissionService,
+    private readonly googleCalendarService: GoogleCalendarService,
   ) {}
 
   @Command(CMD.스터디룸생성)
@@ -304,7 +305,7 @@ export class SpaceController {
       endIso: string;
     };
 
-    const event = await GoogleCalendarUtil.getEventById(calendarId, eventId);
+    const event = await this.googleCalendarService.getEventById(calendarId, eventId);
     const attendeeEmails = event?.attendees?.map((a) => a.email ?? '') ?? [];
     const initialAttendeeSlackIds = (
       await Promise.all(
@@ -516,7 +517,7 @@ export class SpaceController {
     const space = await this.spaceService.findById(roomId);
     if (!space) return;
 
-    const acl = await GoogleCalendarUtil.getCalendarAcl(calendarId);
+    const acl = await this.googleCalendarService.getCalendarAcl(calendarId);
     const editorEmails = acl
       .filter((e) => e.role === 'writer')
       .map((e) => e.email);
@@ -544,7 +545,7 @@ export class SpaceController {
     const selectedIds =
       values['editors_block']?.['editors_select']?.selected_users ?? [];
 
-    const acl = await GoogleCalendarUtil.getCalendarAcl(calendarId);
+    const acl = await this.googleCalendarService.getCalendarAcl(calendarId);
     const currentEditorEmails = acl
       .filter((e) => e.role === 'writer')
       .map((e) => e.email);

--- a/src/space/space.module.ts
+++ b/src/space/space.module.ts
@@ -5,9 +5,10 @@ import { SpaceService } from './space.service';
 import { SpaceMirrorService } from './space-mirror.service';
 import { SpaceController } from './space.controller';
 import { UserModule } from '../user/user.module';
+import { GoogleModule } from '../google/google.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Space]), UserModule],
+  imports: [TypeOrmModule.forFeature([Space]), UserModule, GoogleModule],
   controllers: [SpaceController],
   providers: [SpaceService, SpaceMirrorService],
   exports: [SpaceService, SpaceMirrorService],

--- a/src/space/space.service.ts
+++ b/src/space/space.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Space, SpaceStatus, SpaceType } from './space.entity';
-import { GoogleCalendarUtil } from '../google/google-calendar.util';
+import { GoogleCalendarService } from '../google/google-calendar.service';
 import { UserService } from '../user/user.service';
 import { BusinessError, ErrorCode } from '../common/errors';
 
@@ -48,11 +48,12 @@ export class SpaceService {
     @InjectRepository(Space)
     private readonly spaceRepository: Repository<Space>,
     private readonly userService: UserService,
+    private readonly googleCalendarService: GoogleCalendarService,
   ) {}
 
   async create(dto: CreateSpaceDto): Promise<Space> {
-    const { calendarId } = await GoogleCalendarUtil.createCalendar(dto.name);
-    await GoogleCalendarUtil.makeCalendarPublic(calendarId);
+    const { calendarId } = await this.googleCalendarService.createCalendar(dto.name);
+    await this.googleCalendarService.makeCalendarPublic(calendarId);
 
     if (dto.isDefault) {
       await this.spaceRepository
@@ -129,7 +130,7 @@ export class SpaceService {
     const space = await this.findById(dto.spaceId);
     if (!space) throw new BusinessError(ErrorCode.STUDY_ROOM_NOT_FOUND);
 
-    const acl = await GoogleCalendarUtil.getCalendarAcl(space.calendarId);
+    const acl = await this.googleCalendarService.getCalendarAcl(space.calendarId);
     const editorEmails = acl
       .filter((e) => e.role === 'writer' || e.role === 'owner')
       .map((e) => e.email);
@@ -144,7 +145,7 @@ export class SpaceService {
       throw new BusinessError(ErrorCode.CALENDAR_WRITER_NO_TOKEN);
     }
 
-    const isBusy = await GoogleCalendarUtil.isTimeSlotBusy(
+    const isBusy = await this.googleCalendarService.isTimeSlotBusy(
       space.calendarId,
       refreshToken,
       dto.startTime,
@@ -173,7 +174,7 @@ export class SpaceService {
       })
       .join('\n');
 
-    const eventId = await GoogleCalendarUtil.createEvent(
+    const eventId = await this.googleCalendarService.createEvent(
       space.calendarId,
       refreshToken,
       {
@@ -194,7 +195,7 @@ export class SpaceService {
   }
 
   private async getEditorRefreshToken(calendarId: string): Promise<string> {
-    const acl = await GoogleCalendarUtil.getCalendarAcl(calendarId);
+    const acl = await this.googleCalendarService.getCalendarAcl(calendarId);
     const editorEmails = acl
       .filter((e) => e.role === 'writer' || e.role === 'owner')
       .map((e) => e.email);
@@ -219,7 +220,7 @@ export class SpaceService {
     const calendarIds = rooms.map((r) => r.calendarId);
     const roomMap = new Map(rooms.map((r) => [r.calendarId, r.name]));
 
-    const rawBookings = await GoogleCalendarUtil.getUserBookings(
+    const rawBookings = await this.googleCalendarService.getUserBookings(
       calendarIds,
       user.email,
     );
@@ -237,7 +238,7 @@ export class SpaceService {
   async rename(id: number, name: string): Promise<void> {
     const space = await this.findById(id);
     if (!space) throw new BusinessError(ErrorCode.STUDY_ROOM_NOT_FOUND);
-    await GoogleCalendarUtil.updateCalendar(space.calendarId, name);
+    await this.googleCalendarService.updateCalendar(space.calendarId, name);
     await this.spaceRepository.update(id, { name });
   }
 
@@ -251,7 +252,7 @@ export class SpaceService {
   async addEditor(id: number, email: string): Promise<void> {
     const space = await this.findById(id);
     if (!space) throw new BusinessError(ErrorCode.STUDY_ROOM_NOT_FOUND);
-    await GoogleCalendarUtil.shareCalendar({
+    await this.googleCalendarService.shareCalendar({
       calendarId: space.calendarId,
       email,
       role: 'writer',
@@ -261,19 +262,19 @@ export class SpaceService {
   async removeEditor(id: number, email: string): Promise<void> {
     const space = await this.findById(id);
     if (!space) throw new BusinessError(ErrorCode.STUDY_ROOM_NOT_FOUND);
-    await GoogleCalendarUtil.unshareCalendar(space.calendarId, email);
+    await this.googleCalendarService.unshareCalendar(space.calendarId, email);
   }
 
   async remove(id: number): Promise<void> {
     const space = await this.findById(id);
     if (!space) throw new BusinessError(ErrorCode.STUDY_ROOM_NOT_FOUND);
-    await GoogleCalendarUtil.deleteCalendar(space.calendarId);
+    await this.googleCalendarService.deleteCalendar(space.calendarId);
     await this.spaceRepository.softDelete(id);
   }
 
   async cancelBooking(calendarId: string, eventId: string): Promise<void> {
     const refreshToken = await this.getEditorRefreshToken(calendarId);
-    await GoogleCalendarUtil.deleteEvent(calendarId, refreshToken, eventId);
+    await this.googleCalendarService.deleteEvent(calendarId, refreshToken, eventId);
   }
 
   async modifyBooking(
@@ -308,7 +309,7 @@ export class SpaceService {
       })
       .join('\n');
 
-    await GoogleCalendarUtil.updateEvent(calendarId, refreshToken, eventId, {
+    await this.googleCalendarService.updateEvent(calendarId, refreshToken, eventId, {
       summary: dto.title,
       startTime: dto.startTime,
       endTime: dto.endTime,


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 과목 캘린더의 ACL은 자주 변경되지 않으면 과목 시간표 조회할때 마다 ACL을 조회하기에 Redis에 캐싱 처리
- 테스트의 용이성을 위해 기존의 정적 메소드를 모듈의 서비스로 변경

## 주요 변경 사항

### Google Calendar API 모듈화
- GoogleCalendarUtil(static class) → GoogleCalendarService(@Injectable)로 전환
- GoogleModule 추가 (ScheduleModule, SpaceModule에서 import)
- 8개 파일에서 DI 주입 방식으로 전환 (테스트 mock 용이)

### ACL 조회 캐싱
- getCalendarAcl에 Redis TTL 캐싱 적용 (15분)
- shareCalendar/unshareCalendar 완료 후 ACL 캐시 자동 무효화

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
