### PR TITLE
Feat/improve recurrence management: 반복 일정 수정/삭제 흐름 변경 및 알림 개선

### DIFF
--- a/src/schedule/recurrence-group.entity.ts
+++ b/src/schedule/recurrence-group.entity.ts
@@ -34,6 +34,12 @@ export class RecurrenceGroup {
   @Column()
   recurrenceType: string; // 'weekly' | 'biweekly' | 'monthly'
 
+  @Column()
+  startDate: string; // YYYY-MM-DD
+
+  @Column()
+  endDate: string; // YYYY-MM-DD
+
   @ManyToOne(() => Schedule, { onDelete: 'CASCADE' })
   schedule: Schedule;
 

--- a/src/schedule/recurrence-group.entity.ts
+++ b/src/schedule/recurrence-group.entity.ts
@@ -19,6 +19,21 @@ export class RecurrenceGroup {
   @Column()
   title: string;
 
+  @Column({ type: 'simple-json', nullable: true })
+  daysOfWeek: number[] | null; // [0=일, 1=월 ... 6=토] — weekly/biweekly 시 저장
+
+  @Column({ type: 'varchar', nullable: true })
+  location: string | null;
+
+  @Column()
+  startTime: string; // HH:MM
+
+  @Column()
+  endTime: string; // HH:MM
+
+  @Column()
+  recurrenceType: string; // 'weekly' | 'biweekly' | 'monthly'
+
   @ManyToOne(() => Schedule, { onDelete: 'CASCADE' })
   schedule: Schedule;
 

--- a/src/schedule/schedule-watch.view.ts
+++ b/src/schedule/schedule-watch.view.ts
@@ -187,7 +187,7 @@ export function buildCalendarNotificationBlocks(
         },
         {
           type: 'mrkdwn',
-          text: `👤 *담당자*\n${writerDisplay ?? '알 수 없음'}`,
+          text: `👥 *담당자*\n${writerDisplay ?? '알 수 없음'}`,
         },
       ],
     },

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -19,9 +19,21 @@ import { PermissionService } from '../user/permission.service';
 import { GoogleCalendarService } from '../google/google-calendar.service';
 
 const CALENDAR_COLORS = [
-  '%234285F4', '%23DB4437', '%230F9D58', '%23F4B400', '%239E69AF',
-  '%23F6511D', '%2300BCD4', '%23E91E63', '%23795548', '%23607D8B',
-  '%23FF5722', '%239C27B0', '%2303A9F4', '%238BC34A', '%23FF9800',
+  '%234285F4',
+  '%23DB4437',
+  '%230F9D58',
+  '%23F4B400',
+  '%239E69AF',
+  '%23F6511D',
+  '%2300BCD4',
+  '%23E91E63',
+  '%23795548',
+  '%23607D8B',
+  '%23FF5722',
+  '%239C27B0',
+  '%2303A9F4',
+  '%238BC34A',
+  '%23FF9800',
 ];
 
 @Controller()
@@ -78,13 +90,16 @@ export class ScheduleController {
       schedules.map(async (s) => {
         const [channels, acl] = await Promise.all([
           this.channelService.getSlackChannelIds(s.id),
-          this.googleCalendarService.getCalendarAcl(s.calendarId).catch(() => []),
+          this.googleCalendarService
+            .getCalendarAcl(s.calendarId)
+            .catch(() => []),
         ]);
 
         const writerEmails = acl
           .filter((e) => e.role === 'writer' || e.role === 'owner')
           .map((e) => e.email);
-        const writers = await this.userService.mapEmailsToSlackIds(writerEmails);
+        const writers =
+          await this.userService.mapEmailsToSlackIds(writerEmails);
 
         return {
           id: s.id,
@@ -103,17 +118,13 @@ export class ScheduleController {
       }),
     );
 
-    return ScheduleView.listModal(
-      schedulesWithMeta,
-      displayTags,
-      {
-        page: safePage,
-        totalPages,
-        total,
-        selectedStatus: status,
-        selectedTagIds: tagIds,
-      },
-    );
+    return ScheduleView.listModal(schedulesWithMeta, displayTags, {
+      page: safePage,
+      totalPages,
+      total,
+      selectedStatus: status,
+      selectedTagIds: tagIds,
+    });
   }
 
   // /시간표 - 시간표 목록 조회
@@ -374,13 +385,16 @@ export class ScheduleController {
       schedules.map(async (s) => {
         const [channels, acl] = await Promise.all([
           this.channelService.getSlackChannelIds(s.id),
-          this.googleCalendarService.getCalendarAcl(s.calendarId).catch(() => []),
+          this.googleCalendarService
+            .getCalendarAcl(s.calendarId)
+            .catch(() => []),
         ]);
 
         const writerEmails = acl
           .filter((e) => e.role === 'writer' || e.role === 'owner')
           .map((e) => e.email);
-        const writers = await this.userService.mapEmailsToSlackIds(writerEmails);
+        const writers =
+          await this.userService.mapEmailsToSlackIds(writerEmails);
 
         return {
           id: s.id,
@@ -789,18 +803,21 @@ export class ScheduleController {
 
     await ack();
 
-    await this.scheduleService.createRecurringEvents({
-      scheduleId,
-      title: title.trim(),
-      description: description?.trim(),
-      location: location?.trim(),
-      startDate,
-      endDate,
-      startTime,
-      endTime,
-      recurrenceType,
-      daysOfWeek: recurrenceType !== 'monthly' ? daysOfWeek : undefined,
-    });
+    await this.scheduleService.createRecurringEvents(
+      {
+        scheduleId,
+        title: title.trim(),
+        description: description?.trim(),
+        location: location?.trim(),
+        startDate,
+        endDate,
+        startTime,
+        endTime,
+        recurrenceType,
+        daysOfWeek: recurrenceType !== 'monthly' ? daysOfWeek : undefined,
+      },
+      body.user.id,
+    );
 
     await client.chat.postMessage({
       channel: body.user.id,
@@ -855,7 +872,10 @@ export class ScheduleController {
     );
 
     if (isNaN(scheduleId)) {
-      await ack({ response_action: 'errors', errors: { schedule_block: '시간표를 선택해주세요.' } });
+      await ack({
+        response_action: 'errors',
+        errors: { schedule_block: '시간표를 선택해주세요.' },
+      });
       return;
     }
 
@@ -863,8 +883,7 @@ export class ScheduleController {
       this.scheduleService.findRecurrenceGroupsBySchedule(scheduleId),
       this.scheduleService.findActiveSchedules(),
     ]);
-    const scheduleName =
-      schedules.find((s) => s.id === scheduleId)?.name ?? '';
+    const scheduleName = schedules.find((s) => s.id === scheduleId)?.name ?? '';
 
     if (groups.length === 0) {
       await ack({
@@ -896,8 +915,8 @@ export class ScheduleController {
     const scope = (values.scope_block.scope_input.selected_option?.value ??
       'all') as 'all' | 'future';
     const filterOriginal =
-      (values.filter_block.filter_input.selected_option?.value ?? 'original') ===
-      'original';
+      (values.filter_block.filter_input.selected_option?.value ??
+        'original') === 'original';
 
     await ack();
 
@@ -905,6 +924,7 @@ export class ScheduleController {
       groupDbId,
       scope,
       filterOriginal,
+      body.user.id,
     );
     await client.chat.postMessage({
       channel: body.user.id,
@@ -959,7 +979,10 @@ export class ScheduleController {
     );
 
     if (isNaN(scheduleId)) {
-      await ack({ response_action: 'errors', errors: { schedule_block: '시간표를 선택해주세요.' } });
+      await ack({
+        response_action: 'errors',
+        errors: { schedule_block: '시간표를 선택해주세요.' },
+      });
       return;
     }
 
@@ -967,8 +990,7 @@ export class ScheduleController {
       this.scheduleService.findRecurrenceGroupsBySchedule(scheduleId),
       this.scheduleService.findActiveSchedules(),
     ]);
-    const scheduleName =
-      schedules.find((s) => s.id === scheduleId)?.name ?? '';
+    const scheduleName = schedules.find((s) => s.id === scheduleId)?.name ?? '';
 
     if (groups.length === 0) {
       await ack({
@@ -980,7 +1002,11 @@ export class ScheduleController {
 
     await ack({
       response_action: 'push',
-      view: ScheduleView.selectGroupForEditModal(groups, scheduleName, scheduleId),
+      view: ScheduleView.selectGroupForEditModal(
+        groups,
+        scheduleName,
+        scheduleId,
+      ),
     });
   }
 
@@ -999,13 +1025,19 @@ export class ScheduleController {
     );
 
     if (isNaN(groupDbId)) {
-      await ack({ response_action: 'errors', errors: { group_block: '반복 일정을 선택해주세요.' } });
+      await ack({
+        response_action: 'errors',
+        errors: { group_block: '반복 일정을 선택해주세요.' },
+      });
       return;
     }
 
     const group = await this.scheduleService.findRecurrenceGroupById(groupDbId);
     if (!group) {
-      await ack({ response_action: 'errors', errors: { group_block: '반복 일정을 찾을 수 없습니다.' } });
+      await ack({
+        response_action: 'errors',
+        errors: { group_block: '반복 일정을 찾을 수 없습니다.' },
+      });
       return;
     }
 
@@ -1075,8 +1107,18 @@ export class ScheduleController {
 
     const { updated, total } = await this.scheduleService.updateRecurringGroup(
       groupDbId,
-      { title, description, location, startTime, endTime, daysOfWeek, startDate, endDate },
+      {
+        title,
+        description,
+        location,
+        startTime,
+        endTime,
+        daysOfWeek,
+        startDate,
+        endDate,
+      },
       scope,
+      body.user.id,
     );
     await client.chat.postMessage({
       channel: body.user.id,

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -895,12 +895,16 @@ export class ScheduleController {
     );
     const scope = (values.scope_block.scope_input.selected_option?.value ??
       'all') as 'all' | 'future';
+    const filterOriginal =
+      (values.filter_block.filter_input.selected_option?.value ?? 'original') ===
+      'original';
 
     await ack();
 
     const { deleted, total } = await this.scheduleService.deleteRecurringGroup(
       groupDbId,
       scope,
+      filterOriginal,
     );
     await client.chat.postMessage({
       channel: body.user.id,
@@ -976,7 +980,38 @@ export class ScheduleController {
 
     await ack({
       response_action: 'push',
-      view: ScheduleView.editRecurringModal(groups, scheduleName),
+      view: ScheduleView.selectGroupForEditModal(groups, scheduleName, scheduleId),
+    });
+  }
+
+  // 반복 일정 수정 - step2 (그룹 선택 후 프리필 폼 표시)
+  @View('recurring:modal:step2:edit')
+  async handleStep2EditRecurring({
+    ack,
+    view,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const { scheduleName } = JSON.parse(view.private_metadata || '{}') as {
+      scheduleName: string;
+    };
+    const groupDbId = parseInt(
+      view.state.values.group_block.group_input.selected_option?.value ?? '',
+      10,
+    );
+
+    if (isNaN(groupDbId)) {
+      await ack({ response_action: 'errors', errors: { group_block: '반복 일정을 선택해주세요.' } });
+      return;
+    }
+
+    const group = await this.scheduleService.findRecurrenceGroupById(groupDbId);
+    if (!group) {
+      await ack({ response_action: 'errors', errors: { group_block: '반복 일정을 찾을 수 없습니다.' } });
+      return;
+    }
+
+    await ack({
+      response_action: 'push',
+      view: ScheduleView.editRecurringModal(group, scheduleName),
     });
   }
 
@@ -988,11 +1023,10 @@ export class ScheduleController {
     view,
     client,
   }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const { groupDbId } = JSON.parse(view.private_metadata || '{}') as {
+      groupDbId: number;
+    };
     const values = view.state.values;
-    const groupDbId = parseInt(
-      values.group_block.group_input.selected_option?.value ?? '',
-      10,
-    );
     const title = values.title_block.title_input.value ?? undefined;
     const description =
       values.description_block.description_input.value ?? undefined;
@@ -1003,6 +1037,24 @@ export class ScheduleController {
       values.end_time_block.end_time_input.selected_time ?? undefined;
     const scope = (values.scope_block.scope_input.selected_option?.value ??
       'all') as 'all' | 'future';
+    const rawDays =
+      values.days_of_week_block?.days_of_week_input?.selected_options;
+    const daysOfWeek =
+      rawDays && rawDays.length > 0
+        ? rawDays.map((o) => parseInt(o.value, 10))
+        : undefined;
+    const startDate =
+      values.start_date_block?.start_date_input?.selected_date ?? undefined;
+    const endDate =
+      values.end_date_block?.end_date_input?.selected_date ?? undefined;
+
+    if (startDate && endDate && startDate > endDate) {
+      await ack({
+        response_action: 'errors',
+        errors: { end_date_block: '종료일이 시작일보다 앞입니다.' },
+      });
+      return;
+    }
 
     if (startTime && !endTime) {
       await ack({
@@ -1023,7 +1075,7 @@ export class ScheduleController {
 
     const { updated, total } = await this.scheduleService.updateRecurringGroup(
       groupDbId,
-      { title, description, location, startTime, endTime },
+      { title, description, location, startTime, endTime, daysOfWeek, startDate, endDate },
       scope,
     );
     await client.chat.postMessage({

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -822,9 +822,10 @@ export class ScheduleController {
     const userId = 'user_id' in body ? body.user_id : body.user.id;
     await this.permissionService.requireAdmin(userId);
 
-    const groups = await this.scheduleService.findAllRecurrenceGroups();
+    const schedules =
+      await this.scheduleService.findSchedulesWithRecurrenceGroups();
 
-    if (groups.length === 0) {
+    if (schedules.length === 0) {
       if ('channel_id' in body) {
         await client.chat.postEphemeral({
           channel: body.channel_id,
@@ -837,7 +838,45 @@ export class ScheduleController {
 
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: ScheduleView.deleteRecurringModal(groups),
+      view: ScheduleView.selectScheduleForRecurringModal(schedules, 'delete'),
+    });
+  }
+
+  // 반복 일정 삭제 - step1 (시간표 선택 후 반복 일정 목록 표시)
+  @View('recurring:modal:step1:delete')
+  async handleStep1DeleteRecurring({
+    ack,
+    view,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const values = view.state.values;
+    const scheduleId = parseInt(
+      values.schedule_block.schedule_input.selected_option?.value ?? '',
+      10,
+    );
+
+    if (isNaN(scheduleId)) {
+      await ack({ response_action: 'errors', errors: { schedule_block: '시간표를 선택해주세요.' } });
+      return;
+    }
+
+    const [groups, schedules] = await Promise.all([
+      this.scheduleService.findRecurrenceGroupsBySchedule(scheduleId),
+      this.scheduleService.findActiveSchedules(),
+    ]);
+    const scheduleName =
+      schedules.find((s) => s.id === scheduleId)?.name ?? '';
+
+    if (groups.length === 0) {
+      await ack({
+        response_action: 'errors',
+        errors: { schedule_block: '해당 시간표에 반복 일정이 없습니다.' },
+      });
+      return;
+    }
+
+    await ack({
+      response_action: 'push',
+      view: ScheduleView.deleteRecurringModal(groups, scheduleName),
     });
   }
 
@@ -883,9 +922,10 @@ export class ScheduleController {
     const userId = 'user_id' in body ? body.user_id : body.user.id;
     await this.permissionService.requireAdmin(userId);
 
-    const groups = await this.scheduleService.findAllRecurrenceGroups();
+    const schedules =
+      await this.scheduleService.findSchedulesWithRecurrenceGroups();
 
-    if (groups.length === 0) {
+    if (schedules.length === 0) {
       if ('channel_id' in body) {
         await client.chat.postEphemeral({
           channel: body.channel_id,
@@ -898,7 +938,45 @@ export class ScheduleController {
 
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: ScheduleView.editRecurringModal(groups),
+      view: ScheduleView.selectScheduleForRecurringModal(schedules, 'edit'),
+    });
+  }
+
+  // 반복 일정 수정 - step1 (시간표 선택 후 반복 일정 목록 표시)
+  @View('recurring:modal:step1:edit')
+  async handleStep1EditRecurring({
+    ack,
+    view,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const values = view.state.values;
+    const scheduleId = parseInt(
+      values.schedule_block.schedule_input.selected_option?.value ?? '',
+      10,
+    );
+
+    if (isNaN(scheduleId)) {
+      await ack({ response_action: 'errors', errors: { schedule_block: '시간표를 선택해주세요.' } });
+      return;
+    }
+
+    const [groups, schedules] = await Promise.all([
+      this.scheduleService.findRecurrenceGroupsBySchedule(scheduleId),
+      this.scheduleService.findActiveSchedules(),
+    ]);
+    const scheduleName =
+      schedules.find((s) => s.id === scheduleId)?.name ?? '';
+
+    if (groups.length === 0) {
+      await ack({
+        response_action: 'errors',
+        errors: { schedule_block: '해당 시간표에 반복 일정이 없습니다.' },
+      });
+      return;
+    }
+
+    await ack({
+      response_action: 'push',
+      view: ScheduleView.editRecurringModal(groups, scheduleName),
     });
   }
 

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -35,8 +35,11 @@ export interface UpdateRecurringEventsDto {
   title?: string;
   description?: string;
   location?: string;
-  startTime?: string; // HH:MM, undefined → 시간 변경 안 함
+  startTime?: string; // HH:MM
   endTime?: string; // HH:MM
+  daysOfWeek?: number[]; // 변경 시 전체 삭제 후 재생성
+  startDate?: string; // YYYY-MM-DD — 변경 시 전체 삭제 후 재생성
+  endDate?: string; // YYYY-MM-DD
 }
 
 export interface CreateRecurringEventsDto {
@@ -552,8 +555,12 @@ export class ScheduleService {
       groupId,
       title: dto.title,
       scheduleId: dto.scheduleId,
-      daysOfWeek: dto.daysOfWeek ?? undefined,
+      daysOfWeek: dto.daysOfWeek
+        ? [...dto.daysOfWeek].sort((a, b) => a - b)
+        : undefined,
       location: dto.location,
+      startDate: dto.startDate,
+      endDate: dto.endDate,
       startTime: dto.startTime,
       endTime: dto.endTime,
       recurrenceType: dto.recurrenceType,
@@ -584,6 +591,10 @@ export class ScheduleService {
     this.logger.log(
       `Recurring events created: groupId=${groupId}, total=${successCount}/${dates.length}`,
     );
+  }
+
+  async findRecurrenceGroupById(id: number): Promise<RecurrenceGroup | null> {
+    return this.recurrenceGroupRepository.findOne({ where: { id } });
   }
 
   // groupId로 그룹 조회
@@ -632,6 +643,7 @@ export class ScheduleService {
   async deleteRecurringGroup(
     groupDbId: number,
     scope: 'all' | 'future',
+    filterOriginal = false,
   ): Promise<{ deleted: number; total: number }> {
     const group = await this.recurrenceGroupRepository.findOne({
       where: { id: groupDbId },
@@ -657,6 +669,10 @@ export class ScheduleService {
       events = events.filter(
         (e) => (e.start?.dateTime ?? e.start?.date ?? '') >= today,
       );
+    }
+
+    if (filterOriginal) {
+      events = events.filter((e) => isOriginalEvent(e, group));
     }
 
     const results = await runInChunks(events, (e) =>
@@ -688,8 +704,9 @@ export class ScheduleService {
           text: `🗑️ ${schedule.name} 반복 일정 삭제 안내`,
           blocks: buildRecurringDeleteBlocks(
             schedule.name,
-            group.title,
+            group,
             scope,
+            filterOriginal,
             deletedCount,
             events.length,
           ),
@@ -735,39 +752,104 @@ export class ScheduleService {
       );
     }
 
-    const results = await runInChunks(events, (e) => {
-      let startDateTime: string | undefined;
-      let endDateTime: string | undefined;
+    // 원본 조건(제목·시간·요일)과 일치하는 이벤트만 수정
+    events = events.filter((e) => isOriginalEvent(e, group));
 
-      if (dto.startTime && e.start?.dateTime) {
-        const datePart = e.start.dateTime.slice(0, 10);
-        startDateTime = `${datePart}T${dto.startTime}:00+09:00`;
-      }
-      if (dto.endTime && e.end?.dateTime) {
-        const datePart = e.end.dateTime.slice(0, 10);
-        endDateTime = `${datePart}T${dto.endTime}:00+09:00`;
-      }
+    let updatedCount = 0;
 
-      return this.googleCalendarService.updateEventAsServiceAccount(
-        schedule.calendarId,
-        e.id!,
-        {
-          summary: dto.title,
-          description: dto.description,
-          location: dto.location,
-          startDateTime,
-          endDateTime,
-        },
+    const needsRecreate =
+      dto.daysOfWeek !== undefined ||
+      dto.startDate !== undefined ||
+      dto.endDate !== undefined;
+
+    if (needsRecreate) {
+      // ── 요일/기간 변경: 기존 원본 전체 삭제 후 재생성 ───────────────
+      await runInChunks(events, (e) =>
+        this.googleCalendarService.deleteEventAsServiceAccount(
+          schedule.calendarId,
+          e.id!,
+        ),
       );
-    });
-    const updatedCount = results.filter((r) => r.status === 'fulfilled').length;
+
+      const effectiveStartDate = dto.startDate ?? group.startDate ?? null;
+      const effectiveEndDate = dto.endDate ?? group.endDate ?? null;
+
+      if (effectiveStartDate && effectiveEndDate) {
+        const effectiveStartTime = dto.startTime ?? group.startTime ?? '00:00';
+        const effectiveEndTime = dto.endTime ?? group.endTime ?? '00:00';
+        const effectiveDaysOfWeek =
+          dto.daysOfWeek ?? group.daysOfWeek ?? undefined;
+
+        const newDates = expandRecurringDates({
+          scheduleId: group.scheduleId,
+          title: dto.title ?? group.title,
+          startDate: effectiveStartDate,
+          endDate: effectiveEndDate,
+          startTime: effectiveStartTime,
+          endTime: effectiveEndTime,
+          daysOfWeek: effectiveDaysOfWeek,
+          recurrenceType: (group.recurrenceType as RecurrenceType) ?? 'weekly',
+        });
+
+        const createResults = await runInChunks(
+          newDates,
+          ({ startDateTime, endDateTime }) =>
+            this.googleCalendarService.createEventAsServiceAccount(
+              schedule.calendarId,
+              {
+                summary: dto.title ?? group.title,
+                startDateTime,
+                endDateTime,
+                description: dto.description,
+                location: dto.location ?? group.location ?? undefined,
+                groupId: group.groupId,
+              },
+            ),
+        );
+        updatedCount = createResults.filter(
+          (r) => r.status === 'fulfilled',
+        ).length;
+      }
+    } else {
+      // ── 일반 수정 (제목·시각·설명·장소) ──────────────────────────────
+      const results = await runInChunks(events, (e) => {
+        let startDateTime: string | undefined;
+        let endDateTime: string | undefined;
+
+        if (dto.startTime && e.start?.dateTime) {
+          const datePart = e.start.dateTime.slice(0, 10);
+          startDateTime = `${datePart}T${dto.startTime}:00+09:00`;
+        }
+        if (dto.endTime && e.end?.dateTime) {
+          const datePart = e.end.dateTime.slice(0, 10);
+          endDateTime = `${datePart}T${dto.endTime}:00+09:00`;
+        }
+
+        return this.googleCalendarService.updateEventAsServiceAccount(
+          schedule.calendarId,
+          e.id!,
+          {
+            summary: dto.title,
+            description: dto.description,
+            location: dto.location,
+            startDateTime,
+            endDateTime,
+          },
+        );
+      });
+      updatedCount = results.filter((r) => r.status === 'fulfilled').length;
+    }
 
     // DB 업데이트 데이터 빌드
-    const updateData: any = {};
+    const updateData: Partial<RecurrenceGroup> = {};
     if (dto.title) updateData.title = dto.title;
     if (dto.location !== undefined) updateData.location = dto.location;
     if (dto.startTime) updateData.startTime = dto.startTime;
     if (dto.endTime) updateData.endTime = dto.endTime;
+    if (dto.daysOfWeek !== undefined)
+      updateData.daysOfWeek = [...dto.daysOfWeek].sort((a, b) => a - b);
+    if (dto.startDate) updateData.startDate = dto.startDate;
+    if (dto.endDate) updateData.endDate = dto.endDate;
 
     if (Object.keys(updateData).length > 0) {
       await this.recurrenceGroupRepository.update(
@@ -783,10 +865,11 @@ export class ScheduleService {
       slackChannelIds.map((channel) =>
         this.slack.chat.postMessage({
           channel,
-          text: `✏️ ${schedule.name} 반복 일정 수정 안내`,
+          text: `🔄 ${schedule.name} 반복 일정 수정 안내`,
           blocks: buildRecurringUpdateBlocks(
             schedule.name,
-            dto.title ?? group.title,
+            group,
+            dto,
             scope,
             updatedCount,
             events.length,
@@ -900,12 +983,22 @@ async function runInChunks<T, R>(
 
 function buildRecurringDeleteBlocks(
   scheduleName: string,
-  title: string,
+  group: RecurrenceGroup,
   scope: 'all' | 'future',
+  filterOriginal: boolean,
   deletedCount: number,
   totalCount: number,
 ): KnownBlock[] {
+  const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+  const fmtDays = (days: number[] | null) =>
+    days && days.length > 0
+      ? [...days].sort((a, b) => a - b).map((d) => DAY_LABELS[d]).join('·')
+      : '미지정';
+  const fmtTime = (s: string, e: string) => `${s} - ${e}`;
+  const fmtPeriod = (s: string, e: string) => `${s} - ${e}`;
+
   const scopeText = scope === 'all' ? '전체' : '오늘 이후';
+  const filterText = filterOriginal ? '원본만' : '전체';
   const statusText =
     deletedCount < totalCount
       ? `⚠️ ${deletedCount}/${totalCount}개 삭제 완료`
@@ -923,30 +1016,107 @@ function buildRecurringDeleteBlocks(
     { type: 'divider' },
     {
       type: 'section',
-      text: { type: 'mrkdwn', text: `📌 *일정 제목*\n*${title}*` },
+      text: { type: 'mrkdwn', text: `📌 *일정 제목*\n*${group.title}*` },
     },
     {
       type: 'section',
       fields: [
-        { type: 'mrkdwn', text: `🔍 *삭제 범위*\n${scopeText}` },
-        { type: 'mrkdwn', text: `📊 *처리 결과*\n${statusText}` },
+        {
+          type: 'mrkdwn',
+          text: `🕐 *시간*\n${fmtTime(group.startTime, group.endTime)}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `📅 *요일*\n${fmtDays(group.daysOfWeek)}`,
+        },
+      ],
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: `🗓️ *기간*\n${fmtPeriod(group.startDate, group.endDate)}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `📍 *장소*\n${group.location || '_미지정_'}`,
+        },
       ],
     },
     { type: 'divider' },
     {
       type: 'context',
-      elements: [{ type: 'mrkdwn', text: `*Bannote Bot*` }],
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `🔍 *삭제 범위:* ${scopeText} (${filterText}) | 📊 *처리 결과:* ${statusText} | *Bannote Bot*`,
+        },
+      ],
     },
   ] as unknown as KnownBlock[];
 }
 
 function buildRecurringUpdateBlocks(
   scheduleName: string,
-  title: string,
+  group: RecurrenceGroup,
+  dto: UpdateRecurringEventsDto,
   scope: 'all' | 'future',
   updatedCount: number,
   totalCount: number,
 ): KnownBlock[] {
+  const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+  const fmtDays = (days: number[] | null) =>
+    days && days.length > 0
+      ? [...days].sort((a, b) => a - b).map((d) => DAY_LABELS[d]).join('·')
+      : '미지정';
+  const fmtTime = (s: string | null, e: string | null) =>
+    s && e ? `${s} - ${e}` : '미지정';
+  const fmtPeriod = (s: string | null, e: string | null) =>
+    s && e ? `${s} - ${e}` : '미지정';
+
+  // 제목
+  const titleChanged = dto.title !== undefined && dto.title !== group.title;
+  const titleText = titleChanged
+    ? `📌 *일정 제목* ✏️\n~${group.title}~ → *${dto.title}*`
+    : `📌 *일정 제목*\n*${group.title}*`;
+
+  // 시간
+  const newStart = dto.startTime ?? group.startTime;
+  const newEnd = dto.endTime ?? group.endTime;
+  const timeChanged =
+    (dto.startTime !== undefined && dto.startTime !== group.startTime) ||
+    (dto.endTime !== undefined && dto.endTime !== group.endTime);
+  const timeText = timeChanged
+    ? `🕐 *시간* ✏️\n~${fmtTime(group.startTime, group.endTime)}~ → *${fmtTime(newStart, newEnd)}*`
+    : `🕐 *시간*\n${fmtTime(group.startTime, group.endTime)}`;
+
+  // 요일
+  const daysChanged =
+    dto.daysOfWeek !== undefined &&
+    fmtDays(dto.daysOfWeek) !== fmtDays(group.daysOfWeek);
+  const daysText = daysChanged
+    ? `📅 *요일* ✏️\n~${fmtDays(group.daysOfWeek)}~ → *${fmtDays(dto.daysOfWeek!)}*`
+    : `📅 *요일*\n${fmtDays(group.daysOfWeek)}`;
+
+  // 기간
+  const newStartDate = dto.startDate ?? group.startDate;
+  const newEndDate = dto.endDate ?? group.endDate;
+  const periodChanged =
+    (dto.startDate !== undefined && dto.startDate !== group.startDate) ||
+    (dto.endDate !== undefined && dto.endDate !== group.endDate);
+  const periodText = periodChanged
+    ? `🗓️ *기간* ✏️\n~${fmtPeriod(group.startDate, group.endDate)}~ \n→ *${fmtPeriod(newStartDate, newEndDate)}*`
+    : `🗓️ *기간*\n${fmtPeriod(group.startDate, group.endDate)}`;
+
+  // 장소
+  const locationChanged =
+    dto.location !== undefined && dto.location !== group.location;
+  const locationText = locationChanged
+    ? `📍 *장소* ✏️\n~${group.location || '미지정'}~ → *${dto.location || '미지정'}*`
+    : `📍 *장소*\n${group.location || '_미지정_'}`;
+
+  // 처리 결과
   const scopeText = scope === 'all' ? '전체' : '오늘 이후';
   const statusText =
     updatedCount < totalCount
@@ -958,26 +1128,38 @@ function buildRecurringUpdateBlocks(
       type: 'header',
       text: {
         type: 'plain_text',
-        text: `✏️ [${scheduleName}] 반복 일정 수정 안내`,
+        text: `🔄 [${scheduleName}] 반복 일정 수정 안내`,
         emoji: true,
       },
     },
     { type: 'divider' },
     {
       type: 'section',
-      text: { type: 'mrkdwn', text: `📌 *일정 제목*\n*${title}*` },
+      text: { type: 'mrkdwn', text: titleText },
     },
     {
       type: 'section',
       fields: [
-        { type: 'mrkdwn', text: `🔍 *수정 범위*\n${scopeText}` },
-        { type: 'mrkdwn', text: `📊 *처리 결과*\n${statusText}` },
+        { type: 'mrkdwn', text: timeText },
+        { type: 'mrkdwn', text: daysText },
+      ],
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: periodText },
+        { type: 'mrkdwn', text: locationText },
       ],
     },
     { type: 'divider' },
     {
       type: 'context',
-      elements: [{ type: 'mrkdwn', text: `*Bannote Bot*` }],
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `🔍 *수정 범위:* ${scopeText} | 📊 *처리 결과:* ${statusText} | *Bannote Bot*`,
+        },
+      ],
     },
   ] as unknown as KnownBlock[];
 }
@@ -989,25 +1171,28 @@ function buildRecurringCreationBlocks(
   totalCount: number,
   successCount: number,
 ): KnownBlock[] {
+  const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
   const recurrenceLabel: Record<RecurrenceType, string> = {
     weekly: '매주',
     biweekly: '격주',
     monthly: '매월',
   };
-  const dayLabels = ['일', '월', '화', '수', '목', '금', '토'];
-  const daysText = dto.daysOfWeek?.length
-    ? dto.daysOfWeek.map((d) => dayLabels[d]).join(', ')
-    : '';
+  const fmtDays = (days: number[] | undefined) =>
+    days && days.length > 0
+      ? [...days].sort((a, b) => a - b).map((d) => DAY_LABELS[d]).join('·')
+      : '미지정';
+  const fmtTime = (s: string, e: string) => `${s} - ${e}`;
+  const fmtPeriod = (s: string, e: string) => `${s} - ${e}`;
 
   const recurrenceText =
-    dto.recurrenceType !== 'monthly' && daysText
-      ? `${recurrenceLabel[dto.recurrenceType]} ${daysText}요일`
+    dto.recurrenceType !== 'monthly' && dto.daysOfWeek?.length
+      ? `${recurrenceLabel[dto.recurrenceType]} ${fmtDays(dto.daysOfWeek)}요일`
       : recurrenceLabel[dto.recurrenceType];
 
   const statusText =
     successCount < totalCount
       ? `⚠️ ${successCount}/${totalCount}개 생성 완료`
-      : `총 ${successCount}개`;
+      : `총 ${successCount}개 생성`;
 
   return [
     {
@@ -1021,21 +1206,18 @@ function buildRecurringCreationBlocks(
     { type: 'divider' },
     {
       type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `📌 *일정 제목*\n*${dto.title}*`,
-      },
+      text: { type: 'mrkdwn', text: `📌 *일정 제목*\n*${dto.title}*` },
     },
     {
       type: 'section',
       fields: [
         {
           type: 'mrkdwn',
-          text: `🗓️ *기간*\n${dto.startDate} ~ ${dto.endDate}`,
+          text: `🕐 *시간*\n${fmtTime(dto.startTime, dto.endTime)}`,
         },
         {
           type: 'mrkdwn',
-          text: `🕐 *시간*\n${dto.startTime} ~ ${dto.endTime}`,
+          text: `📅 *요일*\n${fmtDays(dto.daysOfWeek)}`,
         },
       ],
     },
@@ -1044,11 +1226,11 @@ function buildRecurringCreationBlocks(
       fields: [
         {
           type: 'mrkdwn',
-          text: `🔁 *반복*\n${recurrenceText}`,
+          text: `🗓️ *기간*\n${fmtPeriod(dto.startDate, dto.endDate)}`,
         },
         {
           type: 'mrkdwn',
-          text: `📊 *생성 결과*\n${statusText}`,
+          text: `📍 *장소*\n${dto.location || '_미지정_'}`,
         },
       ],
     },
@@ -1058,9 +1240,58 @@ function buildRecurringCreationBlocks(
       elements: [
         {
           type: 'mrkdwn',
-          text: `*Bannote Bot*`,
+          text: `🔁 *반복:* ${recurrenceText} | 📊 *처리 결과:* ${statusText} | *Bannote Bot*`,
         },
       ],
     },
   ] as unknown as KnownBlock[];
+}
+
+// ========== 원본 이벤트 판별 헬퍼 ==========
+
+/** Google Calendar 이벤트 dateTime 문자열에서 KST 기준 HH:MM 추출 */
+function extractTimeKST(dateTimeStr: string): string {
+  const d = new Date(dateTimeStr);
+  const kstHours = (d.getUTCHours() + 9) % 24;
+  const kstMinutes = d.getUTCMinutes();
+  return `${String(kstHours).padStart(2, '0')}:${String(kstMinutes).padStart(2, '0')}`;
+}
+
+/** Google Calendar 이벤트 dateTime 문자열에서 KST 기준 요일(0=일 … 6=토) 추출 */
+function getDayOfWeekKST(dateTimeStr: string): number {
+  const d = new Date(dateTimeStr);
+  const kstMs = d.getTime() + 9 * 60 * 60 * 1000;
+  return new Date(kstMs).getUTCDay();
+}
+
+/**
+ * 이벤트가 반복 그룹의 원본 생성 조건(제목·시작시각·종료시각·요일)을 만족하는지 확인.
+ * 하나라도 다르면 개별 수정된 것으로 판단해 false를 반환한다.
+ */
+function isOriginalEvent(
+  event: {
+    summary?: string | null;
+    start?: { dateTime?: string | null } | null;
+    end?: { dateTime?: string | null } | null;
+  },
+  group: RecurrenceGroup,
+): boolean {
+  if (event.summary !== group.title) return false;
+
+  if (group.startTime && event.start?.dateTime) {
+    if (extractTimeKST(event.start.dateTime) !== group.startTime) return false;
+  }
+  if (group.endTime && event.end?.dateTime) {
+    if (extractTimeKST(event.end.dateTime) !== group.endTime) return false;
+  }
+  if (
+    group.daysOfWeek &&
+    group.daysOfWeek.length > 0 &&
+    event.start?.dateTime
+  ) {
+    if (!group.daysOfWeek.includes(getDayOfWeekKST(event.start.dateTime)))
+      return false;
+  }
+
+  return true;
 }

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -159,7 +159,9 @@ export class ScheduleService {
       .andWhere('schedule.deletedAt IS NULL')
       .select('schedule.id')
       .getRawMany()
-      .then((rows: { schedule_id: number }[]) => rows.map((r) => r.schedule_id));
+      .then((rows: { schedule_id: number }[]) =>
+        rows.map((r) => r.schedule_id),
+      );
 
     if (ids.length === 0) return [];
 
@@ -359,10 +361,11 @@ export class ScheduleService {
     const channelId = randomUUID();
 
     try {
-      const { resourceId } = await this.googleCalendarService.watchCalendarEvents(
-        schedule.calendarId,
-        channelId,
-      );
+      const { resourceId } =
+        await this.googleCalendarService.watchCalendarEvents(
+          schedule.calendarId,
+          channelId,
+        );
 
       const syncToken = await this.googleCalendarService.getInitialSyncToken(
         schedule.calendarId,
@@ -463,7 +466,10 @@ export class ScheduleService {
     const schedule = await this.findById(id);
     if (!schedule) throw new BusinessError(ErrorCode.SCHEDULE_NOT_FOUND);
 
-    await this.googleCalendarService.unshareCalendar(schedule.calendarId, email);
+    await this.googleCalendarService.unshareCalendar(
+      schedule.calendarId,
+      email,
+    );
   }
 
   // 구독 (사용자 캘린더 목록에 추가)
@@ -512,14 +518,17 @@ export class ScheduleService {
 
     // 3. 이벤트 10개씩 청크 생성 (Rate Limit 방지)
     const results = await runInChunks(dates, ({ startDateTime, endDateTime }) =>
-      this.googleCalendarService.createEventAsServiceAccount(schedule.calendarId, {
-        summary: dto.title,
-        startDateTime,
-        endDateTime,
-        description: dto.description,
-        location: dto.location,
-        groupId,
-      }),
+      this.googleCalendarService.createEventAsServiceAccount(
+        schedule.calendarId,
+        {
+          summary: dto.title,
+          startDateTime,
+          endDateTime,
+          description: dto.description,
+          location: dto.location,
+          groupId,
+        },
+      ),
     );
 
     const successCount = results.filter((r) => r.status === 'fulfilled').length;
@@ -543,6 +552,11 @@ export class ScheduleService {
       groupId,
       title: dto.title,
       scheduleId: dto.scheduleId,
+      daysOfWeek: dto.daysOfWeek ?? undefined,
+      location: dto.location,
+      startTime: dto.startTime,
+      endTime: dto.endTime,
+      recurrenceType: dto.recurrenceType,
     });
 
     // 5. Slack 채널에 요약 알림 직접 발송
@@ -598,6 +612,21 @@ export class ScheduleService {
       ...g,
       scheduleName: scheduleMap.get(g.scheduleId) ?? '',
     }));
+  }
+
+  // 반복 그룹이 있는 스케줄 목록 조회 (step1 모달용)
+  async findSchedulesWithRecurrenceGroups(): Promise<
+    { id: number; name: string }[]
+  > {
+    const groups = await this.recurrenceGroupRepository.find({
+      select: ['scheduleId'],
+    });
+    const scheduleIds = [...new Set(groups.map((g) => g.scheduleId))];
+    if (scheduleIds.length === 0) return [];
+    const schedules = await this.scheduleRepository.findBy({
+      id: In(scheduleIds),
+    });
+    return schedules.map((s) => ({ id: s.id, name: s.name }));
   }
 
   async deleteRecurringGroup(
@@ -733,10 +762,17 @@ export class ScheduleService {
     });
     const updatedCount = results.filter((r) => r.status === 'fulfilled').length;
 
-    if (dto.title) {
+    // DB 업데이트 데이터 빌드
+    const updateData: any = {};
+    if (dto.title) updateData.title = dto.title;
+    if (dto.location !== undefined) updateData.location = dto.location;
+    if (dto.startTime) updateData.startTime = dto.startTime;
+    if (dto.endTime) updateData.endTime = dto.endTime;
+
+    if (Object.keys(updateData).length > 0) {
       await this.recurrenceGroupRepository.update(
         { id: groupDbId },
-        { title: dto.title },
+        updateData,
       );
     }
 

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -7,6 +7,7 @@ import { Repository, In } from 'typeorm';
 import { Schedule, ScheduleStatus } from './schedule.entity';
 import { RecurrenceGroup } from './recurrence-group.entity';
 import { GoogleCalendarService } from '../google/google-calendar.service';
+import { UserService } from '../user/user.service';
 import { Tag } from '../tag/tag.entity';
 import { ChannelService } from '../channel/channel.service';
 import { WebClient } from '@slack/web-api';
@@ -70,6 +71,7 @@ export class ScheduleService {
     @Inject(CACHE_MANAGER) private cache: Cache,
     private readonly channelService: ChannelService,
     private readonly googleCalendarService: GoogleCalendarService,
+    private readonly userService: UserService,
   ) {}
 
   // 스케줄 생성 (Google Calendar도 함께 생성)
@@ -506,7 +508,25 @@ export class ScheduleService {
 
   // ========== 반복 일정 ==========
 
-  async createRecurringEvents(dto: CreateRecurringEventsDto): Promise<void> {
+  private async resolveWriterDisplay(calendarId: string): Promise<string> {
+    try {
+      const acl = await this.googleCalendarService.getCalendarAcl(calendarId);
+      const emails = acl
+        .filter((e) => e.role === 'writer' || e.role === 'owner')
+        .map((e) => e.email);
+      const slackIds = await this.userService.mapEmailsToSlackIds(emails);
+      return slackIds.length > 0
+        ? slackIds.map((id) => `<@${id}>`).join('  ')
+        : '알 수 없음';
+    } catch {
+      return '알 수 없음';
+    }
+  }
+
+  async createRecurringEvents(
+    dto: CreateRecurringEventsDto,
+    executorSlackId?: string,
+  ): Promise<void> {
     const schedule = await this.findById(dto.scheduleId);
     if (!schedule) throw new BusinessError(ErrorCode.SCHEDULE_NOT_FOUND);
 
@@ -571,11 +591,19 @@ export class ScheduleService {
       dto.scheduleId,
     );
     if (slackChannelIds.length > 0) {
+      const writerDisplay = await this.resolveWriterDisplay(
+        schedule.calendarId,
+      );
+      const executorDisplay = executorSlackId
+        ? `<@${executorSlackId}>`
+        : '알 수 없음';
       const blocks = buildRecurringCreationBlocks(
         schedule.name,
         dto,
         dates.length,
         successCount,
+        executorDisplay,
+        writerDisplay,
       );
       await Promise.allSettled(
         slackChannelIds.map((channel) =>
@@ -644,6 +672,7 @@ export class ScheduleService {
     groupDbId: number,
     scope: 'all' | 'future',
     filterOriginal = false,
+    executorSlackId?: string,
   ): Promise<{ deleted: number; total: number }> {
     const group = await this.recurrenceGroupRepository.findOne({
       where: { id: groupDbId },
@@ -697,6 +726,10 @@ export class ScheduleService {
     const slackChannelIds = await this.channelService.getSlackChannelIds(
       group.scheduleId,
     );
+    const writerDisplay = await this.resolveWriterDisplay(schedule.calendarId);
+    const executorDisplay = executorSlackId
+      ? `<@${executorSlackId}>`
+      : '알 수 없음';
     await Promise.allSettled(
       slackChannelIds.map((channel) =>
         this.slack.chat.postMessage({
@@ -709,6 +742,8 @@ export class ScheduleService {
             filterOriginal,
             deletedCount,
             events.length,
+            executorDisplay,
+            writerDisplay,
           ),
         }),
       ),
@@ -725,6 +760,7 @@ export class ScheduleService {
     groupDbId: number,
     dto: UpdateRecurringEventsDto,
     scope: 'all' | 'future',
+    executorSlackId?: string,
   ): Promise<{ updated: number; total: number }> {
     const group = await this.recurrenceGroupRepository.findOne({
       where: { id: groupDbId },
@@ -861,6 +897,10 @@ export class ScheduleService {
     const slackChannelIds = await this.channelService.getSlackChannelIds(
       group.scheduleId,
     );
+    const writerDisplay = await this.resolveWriterDisplay(schedule.calendarId);
+    const executorDisplay = executorSlackId
+      ? `<@${executorSlackId}>`
+      : '알 수 없음';
     await Promise.allSettled(
       slackChannelIds.map((channel) =>
         this.slack.chat.postMessage({
@@ -873,6 +913,8 @@ export class ScheduleService {
             scope,
             updatedCount,
             events.length,
+            executorDisplay,
+            writerDisplay,
           ),
         }),
       ),
@@ -988,11 +1030,16 @@ function buildRecurringDeleteBlocks(
   filterOriginal: boolean,
   deletedCount: number,
   totalCount: number,
+  executorDisplay: string,
+  writerDisplay: string,
 ): KnownBlock[] {
   const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
   const fmtDays = (days: number[] | null) =>
     days && days.length > 0
-      ? [...days].sort((a, b) => a - b).map((d) => DAY_LABELS[d]).join('·')
+      ? [...days]
+          .sort((a, b) => a - b)
+          .map((d) => DAY_LABELS[d])
+          .join('·')
       : '미지정';
   const fmtTime = (s: string, e: string) => `${s} - ${e}`;
   const fmtPeriod = (s: string, e: string) => `${s} - ${e}`;
@@ -1044,6 +1091,13 @@ function buildRecurringDeleteBlocks(
         },
       ],
     },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `👤 *실행자*\n${executorDisplay}` },
+        { type: 'mrkdwn', text: `👥 *담당자*\n${writerDisplay}` },
+      ],
+    },
     { type: 'divider' },
     {
       type: 'context',
@@ -1064,11 +1118,16 @@ function buildRecurringUpdateBlocks(
   scope: 'all' | 'future',
   updatedCount: number,
   totalCount: number,
+  executorDisplay: string,
+  writerDisplay: string,
 ): KnownBlock[] {
   const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
   const fmtDays = (days: number[] | null) =>
     days && days.length > 0
-      ? [...days].sort((a, b) => a - b).map((d) => DAY_LABELS[d]).join('·')
+      ? [...days]
+          .sort((a, b) => a - b)
+          .map((d) => DAY_LABELS[d])
+          .join('·')
       : '미지정';
   const fmtTime = (s: string | null, e: string | null) =>
     s && e ? `${s} - ${e}` : '미지정';
@@ -1151,6 +1210,13 @@ function buildRecurringUpdateBlocks(
         { type: 'mrkdwn', text: locationText },
       ],
     },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `👤 *실행자*\n${executorDisplay}` },
+        { type: 'mrkdwn', text: `👥 *담당자*\n${writerDisplay}` },
+      ],
+    },
     { type: 'divider' },
     {
       type: 'context',
@@ -1170,6 +1236,8 @@ function buildRecurringCreationBlocks(
   dto: CreateRecurringEventsDto,
   totalCount: number,
   successCount: number,
+  executorDisplay: string,
+  writerDisplay: string,
 ): KnownBlock[] {
   const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
   const recurrenceLabel: Record<RecurrenceType, string> = {
@@ -1179,7 +1247,10 @@ function buildRecurringCreationBlocks(
   };
   const fmtDays = (days: number[] | undefined) =>
     days && days.length > 0
-      ? [...days].sort((a, b) => a - b).map((d) => DAY_LABELS[d]).join('·')
+      ? [...days]
+          .sort((a, b) => a - b)
+          .map((d) => DAY_LABELS[d])
+          .join('·')
       : '미지정';
   const fmtTime = (s: string, e: string) => `${s} - ${e}`;
   const fmtPeriod = (s: string, e: string) => `${s} - ${e}`;
@@ -1232,6 +1303,13 @@ function buildRecurringCreationBlocks(
           type: 'mrkdwn',
           text: `📍 *장소*\n${dto.location || '_미지정_'}`,
         },
+      ],
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `👤 *실행자*\n${executorDisplay}` },
+        { type: 'mrkdwn', text: `👥 *담당자*\n${writerDisplay}` },
       ],
     },
     { type: 'divider' },

--- a/src/schedule/schedule.view.ts
+++ b/src/schedule/schedule.view.ts
@@ -948,12 +948,42 @@ export class ScheduleView {
             ],
           },
         },
+        {
+          type: 'input',
+          block_id: 'filter_block',
+          label: { type: 'plain_text', text: '삭제 대상' },
+          hint: {
+            type: 'plain_text',
+            text: '원본만: 생성 후 개별 수정된 일정은 제외합니다',
+          },
+          element: {
+            type: 'static_select',
+            action_id: 'filter_input',
+            initial_option: {
+              text: { type: 'plain_text', text: '원본만 삭제' },
+              value: 'original',
+            },
+            options: [
+              {
+                text: { type: 'plain_text', text: '원본만 삭제' },
+                value: 'original',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: '전체 삭제 (수정된 것 포함)',
+                },
+                value: 'all',
+              },
+            ],
+          },
+        },
       ],
     };
   }
 
-  // Step 2: 반복 일정 수정 모달 (특정 시간표 필터링 후)
-  static editRecurringModal(
+  // Step 2: 반복 일정 선택 모달 (그룹 드롭다운만, 다음 → 프리필 폼)
+  static selectGroupForEditModal(
     groups: {
       id: number;
       title: string;
@@ -962,22 +992,19 @@ export class ScheduleView {
       endTime: string | null;
     }[],
     scheduleName: string,
+    scheduleId: number,
   ): View {
     return {
       type: 'modal',
-      callback_id: 'recurring:modal:edit',
+      callback_id: 'recurring:modal:step2:edit',
+      private_metadata: JSON.stringify({ scheduleName, scheduleId }),
       title: { type: 'plain_text', text: '반복 일정 수정' },
-      submit: { type: 'plain_text', text: '수정' },
+      submit: { type: 'plain_text', text: '다음' },
       close: { type: 'plain_text', text: '취소' },
       blocks: [
         {
           type: 'context',
-          elements: [
-            {
-              type: 'mrkdwn',
-              text: `📅 *${scheduleName}*`,
-            },
-          ],
+          elements: [{ type: 'mrkdwn', text: `📅 *${scheduleName}*` }],
         },
         {
           type: 'input',
@@ -996,64 +1023,144 @@ export class ScheduleView {
             })),
           },
         },
+      ],
+    };
+  }
+
+  // Step 3: 반복 일정 수정 폼 (선택된 그룹 기본값 프리필)
+  static editRecurringModal(
+    group: {
+      id: number;
+      title: string;
+      daysOfWeek: number[] | null;
+      startTime: string | null;
+      endTime: string | null;
+      location: string | null;
+      startDate: string | null;
+      endDate: string | null;
+    },
+    scheduleName: string,
+  ): View {
+    const DAY_OPTIONS = [
+      { text: { type: 'plain_text' as const, text: '일' }, value: '0' },
+      { text: { type: 'plain_text' as const, text: '월' }, value: '1' },
+      { text: { type: 'plain_text' as const, text: '화' }, value: '2' },
+      { text: { type: 'plain_text' as const, text: '수' }, value: '3' },
+      { text: { type: 'plain_text' as const, text: '목' }, value: '4' },
+      { text: { type: 'plain_text' as const, text: '금' }, value: '5' },
+      { text: { type: 'plain_text' as const, text: '토' }, value: '6' },
+    ];
+    const initialDays = group.daysOfWeek
+      ? DAY_OPTIONS.filter((o) => group.daysOfWeek!.includes(parseInt(o.value)))
+      : undefined;
+
+    return {
+      type: 'modal',
+      callback_id: 'recurring:modal:edit',
+      private_metadata: JSON.stringify({ groupDbId: group.id }),
+      title: { type: 'plain_text', text: '반복 일정 수정' },
+      submit: { type: 'plain_text', text: '수정' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: `📅 *${scheduleName}*` }],
+        },
         {
           type: 'input',
           block_id: 'title_block',
-          label: { type: 'plain_text', text: '새 제목' },
-          optional: true,
+          label: { type: 'plain_text', text: '제목' },
           element: {
             type: 'plain_text_input',
             action_id: 'title_input',
-            placeholder: { type: 'plain_text', text: '비우면 기존 제목 유지' },
+            initial_value: group.title,
+            placeholder: { type: 'plain_text', text: '제목' },
           },
         },
         {
           type: 'input',
           block_id: 'description_block',
-          label: { type: 'plain_text', text: '새 설명' },
+          label: { type: 'plain_text', text: '설명' },
           optional: true,
           element: {
             type: 'plain_text_input',
             action_id: 'description_input',
             multiline: true,
-            placeholder: { type: 'plain_text', text: '비우면 기존 설명 유지' },
+            placeholder: { type: 'plain_text', text: '설명' },
           },
         },
         {
           type: 'input',
           block_id: 'location_block',
-          label: { type: 'plain_text', text: '새 장소' },
+          label: { type: 'plain_text', text: '장소' },
           optional: true,
           element: {
             type: 'plain_text_input',
             action_id: 'location_input',
-            placeholder: { type: 'plain_text', text: '비우면 기존 장소 유지' },
+            ...(group.location ? { initial_value: group.location } : {}),
+            placeholder: { type: 'plain_text', text: '장소' },
           },
         },
         {
           type: 'input',
           block_id: 'start_time_block',
-          label: { type: 'plain_text', text: '새 시작 시각' },
-          optional: true,
-          hint: {
-            type: 'plain_text',
-            text: '시간 변경 시에만 입력 (시작/종료 함께 입력)',
-          },
+          label: { type: 'plain_text', text: '시작 시각' },
           element: {
             type: 'timepicker',
             action_id: 'start_time_input',
+            ...(group.startTime ? { initial_time: group.startTime } : {}),
             placeholder: { type: 'plain_text', text: '시작 시각' },
           },
         },
         {
           type: 'input',
           block_id: 'end_time_block',
-          label: { type: 'plain_text', text: '새 종료 시각' },
-          optional: true,
+          label: { type: 'plain_text', text: '종료 시각' },
           element: {
             type: 'timepicker',
             action_id: 'end_time_input',
+            ...(group.endTime ? { initial_time: group.endTime } : {}),
             placeholder: { type: 'plain_text', text: '종료 시각' },
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'days_of_week_block',
+          label: { type: 'plain_text', text: '요일' },
+          hint: {
+            type: 'plain_text',
+            text: '제거된 요일의 원본 일정은 삭제, 추가된 요일에는 같은 기간으로 신규 생성',
+          },
+          element: {
+            type: 'multi_static_select',
+            action_id: 'days_of_week_input',
+            placeholder: { type: 'plain_text', text: '요일 선택' },
+            options: DAY_OPTIONS,
+            ...(initialDays && initialDays.length > 0
+              ? { initial_options: initialDays }
+              : {}),
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'start_date_block',
+          label: { type: 'plain_text', text: '시작일' },
+          element: {
+            type: 'datepicker',
+            action_id: 'start_date_input',
+            ...(group.startDate ? { initial_date: group.startDate } : {}),
+            placeholder: { type: 'plain_text', text: '시작일' },
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'end_date_block',
+          label: { type: 'plain_text', text: '종료일' },
+          element: {
+            type: 'datepicker',
+            action_id: 'end_date_input',
+            ...(group.endDate ? { initial_date: group.endDate } : {}),
+            placeholder: { type: 'plain_text', text: '종료일' },
           },
         },
         {
@@ -1087,7 +1194,12 @@ function formatRecurrenceGroupLabel(g: {
   const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
   const parts: string[] = [];
   if (g.daysOfWeek && g.daysOfWeek.length > 0) {
-    parts.push(g.daysOfWeek.map((d) => DAY_LABELS[d]).join(''));
+    parts.push(
+      [...g.daysOfWeek]
+        .sort((a, b) => a - b)
+        .map((d) => DAY_LABELS[d])
+        .join('·'),
+    );
   }
   if (g.startTime && g.endTime) {
     parts.push(`${g.startTime}-${g.endTime}`);

--- a/src/schedule/schedule.view.ts
+++ b/src/schedule/schedule.view.ts
@@ -852,8 +852,52 @@ export class ScheduleView {
     };
   }
 
+  // Step 1: 캘린더(시간표) 선택 모달 — 수정/삭제 공통
+  static selectScheduleForRecurringModal(
+    schedules: { id: number; name: string }[],
+    mode: 'edit' | 'delete',
+  ): View {
+    const isEdit = mode === 'edit';
+    return {
+      type: 'modal',
+      callback_id: isEdit
+        ? 'recurring:modal:step1:edit'
+        : 'recurring:modal:step1:delete',
+      title: {
+        type: 'plain_text',
+        text: isEdit ? '반복 일정 수정' : '반복 일정 삭제',
+      },
+      submit: { type: 'plain_text', text: '다음' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'input',
+          block_id: 'schedule_block',
+          label: { type: 'plain_text', text: '시간표 선택' },
+          element: {
+            type: 'static_select',
+            action_id: 'schedule_input',
+            placeholder: { type: 'plain_text', text: '시간표를 선택하세요' },
+            options: schedules.map((s) => ({
+              text: { type: 'plain_text' as const, text: s.name },
+              value: String(s.id),
+            })),
+          },
+        },
+      ],
+    };
+  }
+
+  // Step 2: 반복 일정 삭제 모달 (특정 시간표 필터링 후)
   static deleteRecurringModal(
-    groups: { id: number; title: string; scheduleName: string }[],
+    groups: {
+      id: number;
+      title: string;
+      daysOfWeek: number[] | null;
+      startTime: string | null;
+      endTime: string | null;
+    }[],
+    scheduleName: string,
   ): View {
     return {
       type: 'modal',
@@ -862,6 +906,15 @@ export class ScheduleView {
       submit: { type: 'plain_text', text: '삭제' },
       close: { type: 'plain_text', text: '취소' },
       blocks: [
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `📅 *${scheduleName}*`,
+            },
+          ],
+        },
         {
           type: 'input',
           block_id: 'group_block',
@@ -873,7 +926,7 @@ export class ScheduleView {
             options: groups.map((g) => ({
               text: {
                 type: 'plain_text' as const,
-                text: `[${g.scheduleName}] ${g.title}`,
+                text: formatRecurrenceGroupLabel(g),
               },
               value: String(g.id),
             })),
@@ -899,8 +952,16 @@ export class ScheduleView {
     };
   }
 
+  // Step 2: 반복 일정 수정 모달 (특정 시간표 필터링 후)
   static editRecurringModal(
-    groups: { id: number; title: string; scheduleName: string }[],
+    groups: {
+      id: number;
+      title: string;
+      daysOfWeek: number[] | null;
+      startTime: string | null;
+      endTime: string | null;
+    }[],
+    scheduleName: string,
   ): View {
     return {
       type: 'modal',
@@ -909,6 +970,15 @@ export class ScheduleView {
       submit: { type: 'plain_text', text: '수정' },
       close: { type: 'plain_text', text: '취소' },
       blocks: [
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `📅 *${scheduleName}*`,
+            },
+          ],
+        },
         {
           type: 'input',
           block_id: 'group_block',
@@ -920,7 +990,7 @@ export class ScheduleView {
             options: groups.map((g) => ({
               text: {
                 type: 'plain_text' as const,
-                text: `[${g.scheduleName}] ${g.title}`,
+                text: formatRecurrenceGroupLabel(g),
               },
               value: String(g.id),
             })),
@@ -1005,4 +1075,22 @@ export class ScheduleView {
       ],
     };
   }
+}
+
+// 반복 일정 그룹 표시 라벨 포맷: "운영체제 강의 (월수 09:00-11:00)"
+function formatRecurrenceGroupLabel(g: {
+  title: string;
+  daysOfWeek: number[] | null;
+  startTime: string | null;
+  endTime: string | null;
+}): string {
+  const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+  const parts: string[] = [];
+  if (g.daysOfWeek && g.daysOfWeek.length > 0) {
+    parts.push(g.daysOfWeek.map((d) => DAY_LABELS[d]).join(''));
+  }
+  if (g.startTime && g.endTime) {
+    parts.push(`${g.startTime}-${g.endTime}`);
+  }
+  return parts.length > 0 ? `${g.title} (${parts.join(' ')})` : g.title;
 }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 반복 일정의 수가 늘어날 경우 기존의 수정/삭제 모달에는 반복 일정의 제목만 표시되기에 찾는것이 힘듬
- 캘린더를 우선 선택 -> 반복 일정 선택 (반복 일정 선택에는 제목/요일/시간을 표시)
- 반복 일정 생성 시 생성 정보를 데이터베이스에 저장 하여 수정/삭제 시에 기존 반복 일정 정보 표시
- 생성/수정/삭제 알림 정보 개선

## 주요 변경 사항

### 반복 일정 수정/삭제 모달 개선
- 반복 일정의 수가 늘어날 경우 기존의 수정/삭제 모달에는 반복 일정의 제목만 표시되기에 찾는것이 힘듬
- 캘린더를 우선 선택 -> 반복 일정 선택 (반복 일정 선택에는 제목/요일/시간을 표시) 으로 흐름 변경
- 수정 모달에서 시작일/종료일/요일 변경 가능하도록 추가
- 삭제 모달에서 삭제 대상으로 원본만 삭제할지 수정된 이벤트도 삭제할지 선택 추가

<details><summary>반복 일정 수정 모달</summary>
<p>

이전

<img width="1042" height="1298" alt="CleanShot 2026-04-16 at 22 26 59@2x" src="https://github.com/user-attachments/assets/685373d4-b102-41e7-b680-8cd5beee792e" />

이후

1. 시간표 선택
<img width="1042" height="472" alt="CleanShot 2026-04-16 at 22 27 43@2x" src="https://github.com/user-attachments/assets/1c1221c0-160f-4028-bf70-e4bdd548aae2" />

2. 반복 일정 선택
<img width="1042" height="540" alt="CleanShot 2026-04-16 at 22 28 06@2x" src="https://github.com/user-attachments/assets/c55085ee-1f15-42d2-b009-3397bb84db73" />

3. 수정 (기존의 내용이 채워져있음) 
<img width="1042" height="1284" alt="CleanShot 2026-04-16 at 22 28 36@2x" src="https://github.com/user-attachments/assets/377f9c84-ef41-4862-abb6-429065356e9e" />

</p>
</details> 

### 반복 일정 엔티티 변경
- 반복 일정 엔티티에 location, startTime, endTime, startDate, endDate, daysOfWeek, recurrenceType 필드 추가
- 반복 일정 생성, 수정 시 DB 정보 갱신

### 반복 일정 알림 정보 개선
- 생성/수정/삭제 알림 정보 개선
- 수정될 경우 이전 내용 및 변경 내용 DB 비교를 통해 표시

<details><summary>반복 일정 추가</summary>
<p>

이전

<img width="916" height="574" alt="CleanShot 2026-04-16 at 22 25 26@2x" src="https://github.com/user-attachments/assets/37fd3203-780e-4487-b24c-84902ab4ca00" />

이후

<img width="892" height="678" alt="CleanShot 2026-04-16 at 22 19 59@2x" src="https://github.com/user-attachments/assets/b119755c-e527-4d15-8990-0640cfad558d" />


</p>
</details> 

<details><summary>반복 일정 변경</summary>
<p>

이전

<img width="764" height="416" alt="CleanShot 2026-04-16 at 22 25 50@2x" src="https://github.com/user-attachments/assets/e2d65d43-22d8-4b1a-a722-98ea4a71257c" />

이후

<img width="912" height="630" alt="CleanShot 2026-04-16 at 22 21 28@2x" src="https://github.com/user-attachments/assets/e96bb733-9d58-4792-9534-c5cbfbd45b80" />

</p>
</details> 

<details><summary>반복 일정 삭제</summary>
<p>

이전

<img width="764" height="416" alt="CleanShot 2026-04-16 at 22 26 06@2x" src="https://github.com/user-attachments/assets/7d2f1b00-f9ee-4058-aa2e-f6e2d2246ea8" />

이후

<img width="912" height="630" alt="CleanShot 2026-04-16 at 22 22 13@2x" src="https://github.com/user-attachments/assets/03f5899f-e912-4ef7-9b08-55754d79daf9" />


</p>
</details> 

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
