### PR TITLE
feat: 반 관리 홈 탭 추가 및 반 수정 기능 구현

### DIFF
--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -318,6 +318,36 @@ export class HomeView {
         { type: 'divider' },
         {
           type: 'header',
+          text: { type: 'plain_text', text: '🏫 반 관리', emoji: true },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: '반을 *생성* 하거나 목록을 *조회·관리* 할 수 있어요.',
+            },
+          ],
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '반 생성' },
+              style: 'primary',
+              action_id: 'home:open-class-create',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '반 목록' },
+              action_id: 'home:open-class-list',
+            },
+          ],
+        },
+        { type: 'divider' },
+        {
+          type: 'header',
           text: { type: 'plain_text', text: '🏷️ 태그 관리', emoji: true },
         },
         {

--- a/src/student-class/student-class.controller.ts
+++ b/src/student-class/student-class.controller.ts
@@ -22,14 +22,17 @@ export class StudentClassController {
 
   // /반 - 반 목록 조회
   @Command(CMD.반)
+  @Action('home:open-class-list')
   async listClasses({
     ack,
     client,
     body,
-  }: SlackCommandMiddlewareArgs & AllMiddlewareArgs) {
+  }: (SlackCommandMiddlewareArgs | SlackActionMiddlewareArgs<BlockAction>) &
+    AllMiddlewareArgs) {
     await ack();
 
-    await this.permissionService.requireAdmin(body.user_id);
+    const userId = 'user_id' in body ? body.user_id : body.user.id;
+    await this.permissionService.requireAdmin(userId);
 
     const classes = await this.studentClassService.findAllClasses();
 
@@ -50,14 +53,17 @@ export class StudentClassController {
 
   // /반생성 - 반 생성 모달
   @Command(CMD.반생성)
+  @Action('home:open-class-create')
   async openCreateModal({
     ack,
     client,
     body,
-  }: SlackCommandMiddlewareArgs & AllMiddlewareArgs) {
+  }: (SlackCommandMiddlewareArgs | SlackActionMiddlewareArgs<BlockAction>) &
+    AllMiddlewareArgs) {
     await ack();
 
-    await this.permissionService.requireAdmin(body.user_id);
+    const userId = 'user_id' in body ? body.user_id : body.user.id;
+    await this.permissionService.requireAdmin(userId);
 
     await client.views.open({
       trigger_id: body.trigger_id,
@@ -146,9 +152,9 @@ export class StudentClassController {
     );
   }
 
-  // 반 상태 토글 (활성화/졸업)
-  @Action(/^student-class:list:toggle:/)
-  async handleToggle({
+  // 반 목록 overflow (편집 / 졸업처리 / 활성화)
+  @Action('student-class:list:overflow')
+  async handleOverflow({
     ack,
     body,
     client,
@@ -156,19 +162,36 @@ export class StudentClassController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    const action = body.actions[0] as { action_id: string; value: string };
-    const classId = parseInt(action.action_id.split(':').pop()!, 10);
-    const toggleAction = action.value;
+    const action = body.actions[0] as { selected_option: { value: string } };
+    const [op, idStr] = action.selected_option.value.split(':');
+    const classId = parseInt(idStr, 10);
 
-    if (toggleAction === 'graduate') {
+    if (op === 'edit') {
+      const cls = await this.studentClassService.findById(classId);
+      if (!cls) return;
+
+      await client.views.push({
+        trigger_id: body.trigger_id,
+        view: StudentClassView.editModal({
+          id: cls.id,
+          name: cls.name,
+          graduationYear: cls.graduationYear,
+          slackChannelId: cls.slackChannelId,
+        }),
+      });
+      return;
+    }
+
+    if (op === 'graduate') {
       await this.studentClassService.graduateClass(classId);
-    } else if (toggleAction === 'activate') {
+      logger.info(`StudentClass ${classId} graduated`);
+    } else if (op === 'activate') {
       await this.studentClassService.activateClass(classId);
+      logger.info(`StudentClass ${classId} activated`);
     }
 
     // 목록 새로고침
     const classes = await this.studentClassService.findAllClasses();
-
     if (body.view?.id) {
       await client.views.update({
         view_id: body.view.id,
@@ -184,7 +207,40 @@ export class StudentClassController {
         ),
       });
     }
+  }
 
-    logger.info(`StudentClass ${classId} toggled to ${toggleAction}`);
+  // 반 편집 제출
+  @View('student-class:modal:edit')
+  async handleEdit({
+    ack,
+    view,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const { classId } = JSON.parse(view.private_metadata || '{}') as {
+      classId: number;
+    };
+    const values = view.state.values;
+
+    const graduationYearStr =
+      values.graduation_year_block.graduation_year_input.value ?? '';
+    const graduationYear = parseInt(graduationYearStr, 10);
+
+    if (isNaN(graduationYear) || graduationYear < 2000) {
+      await ack({
+        response_action: 'errors',
+        errors: { graduation_year_block: '올바른 졸업연도를 입력해주세요.' },
+      });
+      return;
+    }
+
+    const slackChannelId =
+      values.slack_channel_block.slack_channel_input.selected_conversation ??
+      null;
+
+    await ack();
+
+    await this.studentClassService.updateClass(classId, {
+      graduationYear,
+      ...(slackChannelId !== null ? { slackChannelId } : {}),
+    });
   }
 }

--- a/src/student-class/student-class.service.ts
+++ b/src/student-class/student-class.service.ts
@@ -14,6 +14,11 @@ export interface CreateStudentClassDto {
   graduationYear: number;
 }
 
+export interface UpdateStudentClassDto {
+  graduationYear?: number;
+  slackChannelId?: string | null;
+}
+
 @Injectable()
 export class StudentClassService {
   constructor(
@@ -75,6 +80,15 @@ export class StudentClassService {
     slackChannelId: string,
   ): Promise<void> {
     await this.studentClassRepository.update({ id }, { slackChannelId });
+  }
+
+  // 반 정보 수정 (졸업연도, 슬랙 채널)
+  async updateClass(
+    id: number,
+    dto: UpdateStudentClassDto,
+  ): Promise<StudentClass | null> {
+    await this.studentClassRepository.update({ id }, dto);
+    return this.findById(id);
   }
 
   // 반 활성화 (졸업 취소)

--- a/src/student-class/student-class.view.ts
+++ b/src/student-class/student-class.view.ts
@@ -1,6 +1,13 @@
 import type { View } from '@slack/types';
 import { StudentClassStatus } from './student-class.entity';
 
+export interface StudentClassEditPrefill {
+  id: number;
+  name: string;
+  graduationYear: number;
+  slackChannelId?: string | null;
+}
+
 export interface StudentClassListItem {
   id: number;
   name: string;
@@ -62,15 +69,20 @@ export class StudentClassView {
             text: `${statusEmoji} *${cls.name}* (${gradeInfo})\n졸업 연도: ${cls.graduationYear} | 상태: ${STATUS_LABELS[cls.status]}${channelInfo}`,
           },
           accessory: {
-            type: 'button',
-            text: {
-              type: 'plain_text',
-              text: toggleText,
-            },
-            action_id: `student-class:list:toggle:${cls.id}`,
-            value: toggleValue,
+            type: 'overflow',
+            action_id: 'student-class:list:overflow',
+            options: [
+              {
+                text: { type: 'plain_text', text: '✏️ 편집' },
+                value: `edit:${cls.id}`,
+              },
+              {
+                text: { type: 'plain_text', text: toggleText },
+                value: `${toggleValue}:${cls.id}`,
+              },
+            ],
           },
-        });
+        } as any);
       }
     }
 
@@ -86,6 +98,51 @@ export class StudentClassView {
         text: '닫기',
       },
       blocks,
+    };
+  }
+
+  // 반 편집 모달
+  static editModal(prefill: StudentClassEditPrefill): View {
+    return {
+      type: 'modal',
+      callback_id: 'student-class:modal:edit',
+      private_metadata: JSON.stringify({ classId: prefill.id }),
+      title: { type: 'plain_text', text: '반 편집' },
+      submit: { type: 'plain_text', text: '저장' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: `*${prefill.name}*` },
+        },
+        {
+          type: 'input',
+          block_id: 'graduation_year_block',
+          label: { type: 'plain_text', text: '졸업 연도' },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'graduation_year_input',
+            initial_value: String(prefill.graduationYear),
+            placeholder: { type: 'plain_text', text: '숫자만 입력 (예: 2027)' },
+          },
+          hint: { type: 'plain_text', text: '숫자만 입력하세요 (예: 2027)' },
+        },
+        {
+          type: 'input',
+          block_id: 'slack_channel_block',
+          label: { type: 'plain_text', text: 'Slack 채널' },
+          optional: true,
+          element: {
+            type: 'conversations_select',
+            action_id: 'slack_channel_input',
+            placeholder: { type: 'plain_text', text: '채널을 선택하세요' },
+            filter: { include: ['public'], exclude_bot_users: true },
+            ...(prefill.slackChannelId
+              ? { initial_conversation: prefill.slackChannelId }
+              : {}),
+          },
+        },
+      ],
     };
   }
 


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 관리자의 홈 탭에서 반을 생성/수정 할수 있도록 추가
- 반 정보 편집 모달 추가

## 주요 변경 사항

### 반 목록 및 수정
- 관리자 홈 탭에 반 관리 섹션 추가 (반 생성, 반 목록 버튼)
- 반 목록 액션을 버튼에서 overflow 메뉴로 변경 (편집 / 졸업 처리 / 활성화)
- 반 편집 모달 추가: 졸업 연도 수정 및 Slack 채널 선택 (conversations_select)
- 반 목록/생성 핸들러가 Command와 Action 모두 처리하도록 확장
- StudentClassService에 updateClass 메서드 추가

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [ ] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
