### PR TITLE
feat: 유저 이름 Slack 프로필과 자동 동기화

### DIFF
--- a/src/slack-home/slack-home.controller.ts
+++ b/src/slack-home/slack-home.controller.ts
@@ -30,6 +30,7 @@ export class SlackHomeController {
   }: SlackEventMiddlewareArgs<'app_home_opened'> & AllMiddlewareArgs) {
     try {
       if (event.tab === 'home') {
+        await this.slackHomeService.syncSlackName(client, event.user);
         await client.views.publish({
           user_id: event.user,
           view: await this.slackHomeService.getHomeView(event.user),

--- a/src/slack-home/slack-home.service.ts
+++ b/src/slack-home/slack-home.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import type { WebClient } from '@slack/web-api';
 import { UserService } from 'src/user/user.service';
 import { UserRole, UserStatus } from 'src/user/user.entity';
 import { HomeView } from './slack-home.view';
@@ -6,6 +7,20 @@ import { HomeView } from './slack-home.view';
 @Injectable()
 export class SlackHomeService {
   constructor(private readonly userService: UserService) {}
+
+  async syncSlackName(client: WebClient, slackUserId: string): Promise<void> {
+    try {
+      const user = await this.userService.findBySlackId(slackUserId);
+      if (!user || user.status === UserStatus.REGISTERED) return;
+
+      const info = await client.users.info({ user: slackUserId });
+      const slackName =
+        info.user?.profile?.display_name || info.user?.real_name;
+      if (!slackName || slackName === user.name) return;
+
+      await this.userService.updateMyInfo(slackUserId, { name: slackName });
+    } catch {}
+  }
 
   async getHomeView(slackUserId: string) {
     const user = await this.userService.findBySlackIdWithClass(slackUserId);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -94,7 +94,6 @@ export class UserController {
         await this.slackService.client.views.update({
           view_id: viewId,
           view: UserView.registerFormModal({
-            name: googleUser.name,
             email: googleUser.email,
             refreshToken,
             classes: activeClasses.map((c) => ({
@@ -138,7 +137,6 @@ export class UserController {
       const values = view.state.values;
 
       // 폼 데이터 추출
-      const name = values.name_block.name_input.value ?? '';
       const code = values.code_block.code_input.value ?? '';
       const role = values.role_block.role_input.selected_option
         ?.value as UserRole;
@@ -146,11 +144,15 @@ export class UserController {
       const studentClassId =
         classValue && classValue !== 'none' ? Number(classValue) : undefined;
 
-      // 워크스페이스 소유자 여부 확인
+      // 슬랙 프로필 조회 (이름 동기화 + 소유자 여부 확인)
       const userInfo = await this.slackService.client.users.info({
         user: slackUserId,
       });
       const isOwner = userInfo.user?.is_owner ?? false;
+      const slackName =
+        userInfo.user?.profile?.display_name ||
+        userInfo.user?.real_name ||
+        undefined;
 
       // 학생이거나 워크스페이스 소유자면 바로 승인
       const needsApproval = role !== UserRole.STUDENT && !isOwner;
@@ -158,7 +160,7 @@ export class UserController {
       const registrationData = {
         code,
         role,
-        name: name || undefined,
+        name: slackName,
         studentClassId,
       };
 
@@ -505,12 +507,12 @@ export class UserController {
     const role = values.role_block.role_input.selected_option?.value as
       | UserRole
       | undefined;
-    const classValue =
-      values.class_block?.class_input?.selected_option?.value;
+    const classValue = values.class_block?.class_input?.selected_option?.value;
     const studentClassId =
       classValue && classValue !== 'none' ? Number(classValue) : null;
-    const status = values.status_block.status_input.selected_option
-      ?.value as UserStatus | undefined;
+    const status = values.status_block.status_input.selected_option?.value as
+      | UserStatus
+      | undefined;
 
     await ack();
 
@@ -547,7 +549,6 @@ export class UserController {
     await client.views.open({
       trigger_id: body.trigger_id,
       view: UserView.myInfoModal({
-        name: user.name,
         code: user.code,
         role: user.role,
         status: user.status,
@@ -572,16 +573,14 @@ export class UserController {
     const slackId = body.user.id;
     const values = view.state.values;
 
-    const name = values.name_block.name_input.value ?? undefined;
     const code = values.code_block.code_input.value ?? undefined;
-    const classValue =
-      values.class_block?.class_input?.selected_option?.value;
+    const classValue = values.class_block?.class_input?.selected_option?.value;
     const studentClassId =
       classValue && classValue !== 'none' ? Number(classValue) : null;
 
     await ack();
 
-    await this.userService.updateMyInfo(slackId, { name, code, studentClassId });
+    await this.userService.updateMyInfo(slackId, { code, studentClassId });
   }
 
   // 반의 Slack 채널에 유저 초대 (채널 없거나 이미 가입된 경우 조용히 무시)

--- a/src/user/user.view.ts
+++ b/src/user/user.view.ts
@@ -9,7 +9,6 @@ export interface ClassOption {
 }
 
 export interface RegisterFormPrefill {
-  name: string;
   email: string;
   refreshToken: string;
   classes: ClassOption[];
@@ -76,7 +75,6 @@ export interface EditUserPrefill {
 }
 
 export interface MyInfoPrefill {
-  name: string;
   code: string | null;
   role: UserRole | null;
   status: UserStatus;
@@ -149,24 +147,7 @@ export class UserView {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: 'Google 로그인 완료!\n아래 정보를 입력해주세요.',
-          },
-        },
-        {
-          type: 'input',
-          block_id: 'name_block',
-          element: {
-            type: 'plain_text_input',
-            action_id: 'name_input',
-            initial_value: prefill.name,
-            placeholder: {
-              type: 'plain_text',
-              text: '이름을 입력하세요',
-            },
-          },
-          label: {
-            type: 'plain_text',
-            text: '이름',
+            text: 'Google 로그인 완료!\n아래 정보를 입력해주세요.\n이름은 Slack 프로필 이름으로 자동 설정됩니다.',
           },
         },
         {
@@ -301,7 +282,7 @@ export class UserView {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `*${user.name}* (${user.email})\n${user.code} | ${ROLE_LABELS[user.role]}${classInfo}`,
+            text: `<@${user.slackId}> (${user.email})\n${user.code} | ${ROLE_LABELS[user.role]}${classInfo}`,
           },
           accessory: {
             type: 'overflow',
@@ -674,14 +655,13 @@ export class UserView {
           ],
         },
         {
-          type: 'input',
-          block_id: 'name_block',
-          label: { type: 'plain_text', text: '이름' },
-          element: {
-            type: 'plain_text_input',
-            action_id: 'name_input',
-            initial_value: prefill.name,
-          },
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: '이름은 Slack 프로필과 자동으로 동기화됩니다.',
+            },
+          ],
         },
         {
           type: 'input',


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 슬랙의 이름과 서버의 이름이 이중으로 관리 되어 이름 관리에 불편함 발생 우려
- 홈 탭 열릴 때 마다 슬랙의 이름에 동기화 시켜 일관성 유지

## 주요 변경 사항

### 이름 동기화
- 홈 탭 열릴 때마다 Slack display_name으로 DB 이름 자동 업데이트
- 가입 시 이름을 Slack 프로필에서 자동 설정 (가입 모달에서 이름 입력 필드 제거)
- 내 정보 수정 모달에서 이름 필드 제거 (Slack 동기화 안내 문구로 대체)
- 가입 승인 모달에서 이름 제거, 슬랙 멘션으로 표시

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
