### PR TITLE
fix: data-source.ts 추가로 인한 빌드 경로 깨짐 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist
 /node_modules
 /build
+*.tsbuildinfo
 
 # Logs
 logs

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "data-source.ts"]
 }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- data-source.ts 의 추가로 빌드 경로가 깨져서 dev 서버 배포 실패

## 주요 변경 사항

### tsconfig.build.json 수정
- tsconfig.build.json에 rootDir: "./src" 명시
- data-source.ts를 빌드 제외 목록에 추가 (TypeORM CLI 전용)

### gitignore 수정
- .gitignore에 *.tsbuildinfo 추가

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
