### PR TITLE
Feat/business error handling

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -13,6 +13,8 @@ export enum ErrorCode {
   BOOKING_CONFLICT = 'BOOKING_CONFLICT',
   CALENDAR_WRITER_NOT_FOUND = 'CALENDAR_WRITER_NOT_FOUND',
   CALENDAR_WRITER_NO_TOKEN = 'CALENDAR_WRITER_NO_TOKEN',
+  CANNOT_EDIT_PENDING_USER = 'CANNOT_EDIT_PENDING_USER',
+  CHANNEL_NAME_TAKEN = 'CHANNEL_NAME_TAKEN',
 }
 
 export const ERROR_MESSAGES: Record<ErrorCode, string> = {
@@ -31,6 +33,10 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
     '캘린더 수정 권한을 가진 활성 유저를 찾을 수 없습니다. \n관리자에게 문의해주세요.',
   [ErrorCode.CALENDAR_WRITER_NO_TOKEN]:
     '캘린더 수정 권한자의 인증 정보가 없습니다. \n관리자에게 문의해주세요.',
+  [ErrorCode.CANNOT_EDIT_PENDING_USER]:
+    '승인 대기 또는 미가입 상태의 유저는 편집할 수 없습니다.\n가입 승인 관리에서 먼저 처리해주세요.',
+  [ErrorCode.CHANNEL_NAME_TAKEN]:
+    '이미 존재하는 Slack 채널 이름입니다. 채널을 직접 연결해주세요.',
 };
 
 export class BusinessError extends Error {

--- a/src/common/slack-error.middleware.ts
+++ b/src/common/slack-error.middleware.ts
@@ -27,20 +27,38 @@ export const slackErrorMiddleware = async (
 
     if (!client) return;
 
+    const triggerId: string | undefined = body?.trigger_id;
+    logger.debug(
+      `[ErrorModal] triggerId=${triggerId}, userId=${body && 'user' in body ? (body.user as any)?.id : body?.user_id}`,
+    );
     const userId: string | undefined =
       body && 'user' in body && body.user
         ? (body.user as { id?: string }).id
         : body?.user_id;
-    const channelId: string | undefined = body?.channel_id ?? body?.channel?.id;
     const blocks = ErrorView.fromError(err);
     // text는 알림 fallback용 — blocks와 함께 쓸 때 Slack이 text만 렌더링하지 않도록 분리
     const text =
       err instanceof Error ? `❌ ${err.message}` : '❌ 오류가 발생했습니다.';
 
-    if (channelId && userId) {
-      await client.chat
-        .postEphemeral({ channel: channelId, user: userId, text, blocks })
-        .catch(() => {});
+    if (triggerId) {
+      const isInsideModal = body?.view?.type === 'modal';
+      const openOrPush = isInsideModal ? client.views.push : client.views.open;
+      await openOrPush({
+        trigger_id: triggerId,
+        view: {
+          type: 'modal',
+          title: { type: 'plain_text', text: '오류' },
+          close: { type: 'plain_text', text: '닫기' },
+          blocks,
+        },
+      }).catch(async (e: unknown) => {
+        logger.warn('[ErrorModal] views failed, fallback to DM', e);
+        if (userId) {
+          await client.chat
+            .postMessage({ channel: userId, text, blocks })
+            .catch(() => {});
+        }
+      });
     } else if (userId) {
       await client.chat
         .postMessage({ channel: userId, text, blocks })

--- a/src/student-class/student-class.controller.ts
+++ b/src/student-class/student-class.controller.ts
@@ -1,4 +1,5 @@
 import { Controller } from '@nestjs/common';
+import { BusinessError, ErrorCode } from '../common/errors';
 import { Action, Command, View } from 'nestjs-slack-bolt';
 import type {
   AllMiddlewareArgs,
@@ -121,10 +122,13 @@ export class StudentClassController {
       admissionYear,
       section,
     );
-    const channelResult = await client.conversations.create({
-      name: channelName,
-      is_private: false,
-    });
+    const channelResult = await client.conversations
+      .create({ name: channelName, is_private: false })
+      .catch((e: any) => {
+        if (e?.data?.error === 'name_taken')
+          throw new BusinessError(ErrorCode.CHANNEL_NAME_TAKEN);
+        throw e;
+      });
 
     const channelId = channelResult.channel?.id;
     if (channelId) {
@@ -211,10 +215,7 @@ export class StudentClassController {
 
   // 반 편집 제출
   @View('student-class:modal:edit')
-  async handleEdit({
-    ack,
-    view,
-  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+  async handleEdit({ ack, view }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
     const { classId } = JSON.parse(view.private_metadata || '{}') as {
       classId: number;
     };

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -12,6 +12,7 @@ import type {
 import { UserView, UserListFilter, UserListModalState } from './user.view';
 import { OAuthUtil } from './google-oauth.util';
 import { UserRole, UserStatus } from './user.entity';
+import { BusinessError, ErrorCode } from '../common/errors';
 import { StudentClassService } from '../student-class/student-class.service';
 import { CMD } from '../common/slack-commands';
 import { PermissionService } from './permission.service';
@@ -470,6 +471,13 @@ export class UserController {
       this.studentClassService.findActiveClasses(),
     ]);
     if (!targetUser) return;
+
+    if (
+      targetUser.status !== UserStatus.ACTIVE &&
+      targetUser.status !== UserStatus.INACTIVE
+    ) {
+      throw new BusinessError(ErrorCode.CANNOT_EDIT_PENDING_USER);
+    }
 
     await client.views.push({
       trigger_id: body.trigger_id,

--- a/src/user/user.view.ts
+++ b/src/user/user.view.ts
@@ -597,13 +597,18 @@ export class UserView {
               text: { type: 'plain_text' as const, text: STATUS_LABELS[s] },
               value: s,
             })),
-            initial_option: {
-              text: {
-                type: 'plain_text' as const,
-                text: STATUS_LABELS[prefill.status],
-              },
-              value: prefill.status,
-            },
+            ...(prefill.status === UserStatus.ACTIVE ||
+            prefill.status === UserStatus.INACTIVE
+              ? {
+                  initial_option: {
+                    text: {
+                      type: 'plain_text' as const,
+                      text: STATUS_LABELS[prefill.status],
+                    },
+                    value: prefill.status,
+                  },
+                }
+              : {}),
           },
         },
       ],


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 모달에서 에러 발생 시 에러 모달로 처리
- 비즈니스 에러 추가

## 주요 변경 사항

### 에러 처리
- trigger_id가 있는 경우 모달로 에러 표시 (모달 안에 있으면 push, 아니면 open)
- trigger_id 없으면 DM으로 폴백
- ephemeral 메시지 방식 제거 (특정 채널에서 slash 커맨드로 에러 발생 시 채널로 자신만 보이는 메시지 발송)

### 비즈니스 에러 코드 추가
- `CANNOT_EDIT_PENDING_USER` 에러 코드 추가
- 승인 대기/미가입 유저 편집 시도 시 `CANNOT_EDIT_PENDING_USER` 에러 발생
- `CHANNEL_NAME_TAKEN` 에러 코드 추가
- 반 생성 시 정해진 Slack 채널 이름이 이미 존재하는 경우 `CHANNEL_NAME_TAKEN` 에러 발생

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
