### PR TITLE
feat: 시간표·반·태그·스터디룸 소프트 삭제 추가

### DIFF
--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -527,6 +527,46 @@ export class ScheduleController {
     });
   }
 
+  // 삭제 버튼 → 확인 모달 열기
+  @Action(/^schedule:list:delete:/)
+  async handleOpenDelete({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string; value: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+    const scheduleName = action.value;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: ScheduleView.deleteConfirmModal(scheduleId, scheduleName),
+    });
+  }
+
+  // 삭제 확인 모달 제출 → 소프트 삭제
+  @View('schedule:modal:delete')
+  async handleDelete({
+    ack,
+    body,
+    view,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    await ack();
+
+    const scheduleId = parseInt(view.private_metadata, 10);
+    await this.scheduleService.deleteSchedule(scheduleId);
+
+    logger.info(`Schedule ${scheduleId} deleted by ${body.user.id}`);
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: '✅ 시간표가 삭제되었습니다.',
+    });
+  }
+
   // 수정 모달 제출 → 시간표 정보 업데이트
   @View('schedule:modal:edit')
   async handleEdit({

--- a/src/schedule/schedule.view.ts
+++ b/src/schedule/schedule.view.ts
@@ -178,6 +178,13 @@ export class ScheduleView {
               action_id: `schedule:list:toggle:${schedule.id}`,
               value: toggleValue,
             },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '삭제' },
+              action_id: `schedule:list:delete:${schedule.id}`,
+              value: schedule.name,
+              style: 'danger',
+            },
           ],
         },
       );
@@ -1177,6 +1184,26 @@ export class ScheduleView {
                 value: 'future',
               },
             ],
+          },
+        },
+      ],
+    };
+  }
+
+  static deleteConfirmModal(scheduleId: number, scheduleName: string): View {
+    return {
+      type: 'modal',
+      callback_id: 'schedule:modal:delete',
+      private_metadata: String(scheduleId),
+      title: { type: 'plain_text', text: '시간표 삭제' },
+      submit: { type: 'plain_text', text: '삭제' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${scheduleName}* 시간표를 삭제하시겠습니까?\n\n⚠️ Google Calendar도 함께 삭제되며 되돌릴 수 없습니다.`,
           },
         },
       ],

--- a/src/space/space.controller.ts
+++ b/src/space/space.controller.ts
@@ -639,4 +639,41 @@ export class SpaceController {
       text: `✅ *${roomName}* 이 ${label}되었습니다.`,
     });
   }
+
+  @Action('study-room:admin:open-delete')
+  async adminOpenDelete({
+    ack,
+    client,
+    body,
+    action,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+    const { roomId, roomName } = JSON.parse(
+      (action as { value: string }).value,
+    ) as { roomId: number; roomName: string };
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: SpaceView.deleteConfirmModal(roomId, roomName),
+    });
+  }
+
+  @View('study-room:modal:delete')
+  async submitDelete({
+    ack,
+    body,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    await ack();
+
+    const roomId = parseInt(body.view.private_metadata, 10);
+    await this.spaceService.remove(roomId);
+
+    logger.info(`Space ${roomId} deleted by ${body.user.id}`);
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: '✅ 스터디룸이 삭제되었습니다.',
+    });
+  }
 }

--- a/src/space/space.view.ts
+++ b/src/space/space.view.ts
@@ -567,6 +567,13 @@ export class SpaceView {
                       }
                     : undefined,
               },
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '삭제' },
+                action_id: 'study-room:admin:open-delete',
+                style: 'danger',
+                value: meta,
+              },
             ],
           },
           { type: 'divider' },
@@ -779,6 +786,26 @@ export class SpaceView {
           initialUsers: initialEditorSlackIds,
           optional: true,
         }),
+      ],
+    };
+  }
+
+  static deleteConfirmModal(roomId: number, roomName: string): View {
+    return {
+      type: 'modal',
+      callback_id: 'study-room:modal:delete',
+      private_metadata: String(roomId),
+      title: { type: 'plain_text', text: '스터디룸 삭제' },
+      submit: { type: 'plain_text', text: '삭제' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${roomName}* 스터디룸을 삭제하시겠습니까?\n\n⚠️ Google Calendar도 함께 삭제되며 되돌릴 수 없습니다.`,
+          },
+        },
       ],
     };
   }

--- a/src/student-class/student-class.controller.ts
+++ b/src/student-class/student-class.controller.ts
@@ -186,6 +186,16 @@ export class StudentClassController {
       return;
     }
 
+    if (op === 'delete') {
+      const cls = await this.studentClassService.findById(classId);
+      if (!cls) return;
+      await client.views.push({
+        trigger_id: body.trigger_id,
+        view: StudentClassView.deleteConfirmModal(classId, cls.name),
+      });
+      return;
+    }
+
     if (op === 'graduate') {
       await this.studentClassService.graduateClass(classId);
       logger.info(`StudentClass ${classId} graduated`);
@@ -242,6 +252,27 @@ export class StudentClassController {
     await this.studentClassService.updateClass(classId, {
       graduationYear,
       ...(slackChannelId !== null ? { slackChannelId } : {}),
+    });
+  }
+
+  // 반 삭제 확인 모달 제출 → 소프트 삭제
+  @View('student-class:modal:delete')
+  async handleDelete({
+    ack,
+    body,
+    view,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    await ack();
+
+    const classId = parseInt(view.private_metadata, 10);
+    await this.studentClassService.deleteClass(classId);
+
+    logger.info(`StudentClass ${classId} deleted by ${body.user.id}`);
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: '✅ 반이 삭제되었습니다.',
     });
   }
 }

--- a/src/student-class/student-class.view.ts
+++ b/src/student-class/student-class.view.ts
@@ -80,6 +80,10 @@ export class StudentClassView {
                 text: { type: 'plain_text', text: toggleText },
                 value: `${toggleValue}:${cls.id}`,
               },
+              {
+                text: { type: 'plain_text', text: '🗑️ 삭제' },
+                value: `delete:${cls.id}`,
+              },
             ],
           },
         } as any);
@@ -232,6 +236,26 @@ export class StudentClassView {
           hint: {
             type: 'plain_text',
             text: '숫자만 입력하세요 (예: 2027)',
+          },
+        },
+      ],
+    };
+  }
+
+  static deleteConfirmModal(classId: number, className: string): View {
+    return {
+      type: 'modal',
+      callback_id: 'student-class:modal:delete',
+      private_metadata: String(classId),
+      title: { type: 'plain_text', text: '반 삭제' },
+      submit: { type: 'plain_text', text: '삭제' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${className}* 반을 삭제하시겠습니까?\n\n⚠️ 연결된 태그도 함께 삭제되며 되돌릴 수 없습니다.`,
           },
         },
       ],

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -135,4 +135,44 @@ export class TagController {
 
     logger.info(`Tag ${tagId} toggled to ${toggleAction}`);
   }
+
+  // 삭제 버튼 → 확인 모달 열기
+  @Action(/^tag:list:delete:/)
+  async handleOpenDelete({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string; value: string };
+    const tagId = parseInt(action.action_id.split(':').pop()!, 10);
+    const tagName = action.value;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: TagView.deleteConfirmModal(tagId, tagName),
+    });
+  }
+
+  // 삭제 확인 모달 제출 → 소프트 삭제
+  @View('tag:modal:delete')
+  async handleDelete({
+    ack,
+    body,
+    view,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    await ack();
+
+    const tagId = parseInt(view.private_metadata, 10);
+    await this.tagService.deleteTag(tagId);
+
+    logger.info(`Tag ${tagId} deleted by ${body.user.id}`);
+    await client.chat.postMessage({
+      channel: body.user.id,
+      text: '✅ 태그가 삭제되었습니다.',
+    });
+  }
 }

--- a/src/tag/tag.view.ts
+++ b/src/tag/tag.view.ts
@@ -52,22 +52,33 @@ export class TagView {
           tag.status === TagStatus.ACTIVE ? 'deactivate' : 'activate';
         const typeLabel = tag.isClassTag ? '(반)' : '';
 
-        blocks.push({
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `${statusEmoji} *${tag.name}* ${typeLabel}\n상태: ${STATUS_LABELS[tag.status]}`,
-          },
-          accessory: {
-            type: 'button',
+        blocks.push(
+          {
+            type: 'section',
             text: {
-              type: 'plain_text',
-              text: toggleText,
+              type: 'mrkdwn',
+              text: `${statusEmoji} *${tag.name}* ${typeLabel}\n상태: ${STATUS_LABELS[tag.status]}`,
             },
-            action_id: `tag:list:toggle:${tag.id}`,
-            value: toggleValue,
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: toggleText },
+              action_id: `tag:list:toggle:${tag.id}`,
+              value: toggleValue,
+            },
           },
-        });
+          {
+            type: 'actions',
+            elements: [
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '삭제' },
+                action_id: `tag:list:delete:${tag.id}`,
+                value: tag.name,
+                style: 'danger',
+              },
+            ],
+          },
+        );
       }
     }
 
@@ -83,6 +94,26 @@ export class TagView {
         text: '닫기',
       },
       blocks,
+    };
+  }
+
+  static deleteConfirmModal(tagId: number, tagName: string): View {
+    return {
+      type: 'modal',
+      callback_id: 'tag:modal:delete',
+      private_metadata: String(tagId),
+      title: { type: 'plain_text', text: '태그 삭제' },
+      submit: { type: 'plain_text', text: '삭제' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${tagName}* 태그를 삭제하시겠습니까?\n\n⚠️ 시간표에서 이 태그가 제거되며 되돌릴 수 없습니다.`,
+          },
+        },
+      ],
     };
   }
 


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 각 리소스(시간표, 스터디룸, 반, 태그) 소프트 삭제 기능 추가

## 주요 변경 사항

### 소프트 삭제
- 각 목록에서 삭제 버튼 → 확인 모달 → 소프트 삭제 순서로 처리
- 시간표/스터디룸은 Google Calendar도 함께 삭제
- 반 삭제 시 연결된 태그도 함께 삭제
- 삭제 완료 후 DM으로 결과 알림

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
