### PR TITLE
Feat/aws ecs infra: AWS ECS 기반 인프라 구성 추가 및 깃허브 워크플로우 추가

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,46 @@
+name: Terraform Apply
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        working-directory: terraform
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -backend-config="key=gsc-slack-app/terraform.tfstate" \
+            -backend-config="region=ap-northeast-2"
+
+      - name: Terraform Apply
+        working-directory: terraform
+        run: |
+          terraform apply -auto-approve \
+            -var-file=prod.tfvars \
+            -var="secrets_arn=${{ secrets.SECRETS_ARN }}" \
+            -var="ecs_task_execution_role_arn=${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}" \
+            -var="ecs_task_role_arn=${{ secrets.ECS_TASK_ROLE_ARN }}"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "terraform/**"
 
 permissions:
   id-token: write

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,70 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - "terraform/**"
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        working-directory: terraform
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -backend-config="key=gsc-slack-app/terraform.tfstate" \
+            -backend-config="region=ap-northeast-2"
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: terraform
+        run: |
+          terraform plan -no-color \
+            -var-file=prod.tfvars \
+            -var="secrets_arn=${{ secrets.SECRETS_ARN }}" \
+            -var="ecs_task_execution_role_arn=${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}" \
+            -var="ecs_task_role_arn=${{ secrets.ECS_TASK_ROLE_ARN }}"
+        continue-on-error: true
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan 결과
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+            > Plan 상태: ${{ steps.plan.outcome }}`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output,
+            });
+
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - dev
-    paths:
-      - "terraform/**"
 
 permissions:
   id-token: write

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -53,11 +53,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const output = `#### Terraform Plan 결과
+            const stdout = `${{ steps.plan.outputs.stdout }}`;
+            const summary = stdout.match(/Plan: .+|No changes\..+/)?.[0] ?? '';
+            const output = `#### Terraform Plan 결과 — ${{ steps.plan.outcome == 'success' && '✅ 성공' || '❌ 실패' }}
+            > ${summary}
+            <details>
+            <summary>상세 보기</summary>
+
             \`\`\`
-            ${{ steps.plan.outputs.stdout }}
+            ${stdout}
             \`\`\`
-            > Plan 상태: ${{ steps.plan.outcome }}`;
+            </details>`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,11 @@ postgres_data
 # Backups
 backups/
 
+# Terraform
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.backup
+
 #Claude
 .claude/
 CLAUDE.md

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,41 @@
+resource "aws_lb" "main" {
+  name               = "${local.name_prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  tags = {
+    Name = "${local.name_prefix}-alb"
+  }
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${local.name_prefix}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-tg"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,106 @@
+resource "aws_ecs_cluster" "main" {
+  name = "${local.name_prefix}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-cluster"
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${local.name_prefix}-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = var.app_name
+      image     = var.container_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      secrets = [
+        { name = "SLACK_BOT_TOKEN",                    valueFrom = "${var.secrets_arn}:SLACK_BOT_TOKEN::" },
+        { name = "SLACK_APP_TOKEN",                    valueFrom = "${var.secrets_arn}:SLACK_APP_TOKEN::" },
+        { name = "SLACK_SIGNING_SECRET",               valueFrom = "${var.secrets_arn}:SLACK_SIGNING_SECRET::" },
+        { name = "GOOGLE_CLIENT_ID",                   valueFrom = "${var.secrets_arn}:GOOGLE_CLIENT_ID::" },
+        { name = "GOOGLE_CLIENT_SECRET",               valueFrom = "${var.secrets_arn}:GOOGLE_CLIENT_SECRET::" },
+        { name = "GOOGLE_SERVICE_ACCOUNT_EMAIL",       valueFrom = "${var.secrets_arn}:GOOGLE_SERVICE_ACCOUNT_EMAIL::" },
+        { name = "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY", valueFrom = "${var.secrets_arn}:GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY::" },
+        { name = "DB_USERNAME",                        valueFrom = "${var.secrets_arn}:DB_USERNAME::" },
+        { name = "DB_PASSWORD",                        valueFrom = "${var.secrets_arn}:DB_PASSWORD::" },
+        { name = "DB_DATABASE",                        valueFrom = "${var.secrets_arn}:DB_DATABASE::" },
+        { name = "ENCRYPTION_SECRET",                  valueFrom = "${var.secrets_arn}:ENCRYPTION_SECRET::" },
+        { name = "REDIS_PASSWORD",                     valueFrom = "${var.secrets_arn}:REDIS_PASSWORD::" },
+      ]
+
+      environment = [
+        { name = "DB_SYNCHRONIZE", value = "false" },
+        { name = "NODE_ENV",       value = "production" },
+        { name = "DB_HOST",        value = aws_db_instance.main.address },
+        { name = "DB_PORT",        value = tostring(aws_db_instance.main.port) },
+        { name = "REDIS_HOST",     value = aws_elasticache_cluster.main.cache_nodes[0].address },
+        { name = "REDIS_PORT",     value = tostring(aws_elasticache_cluster.main.cache_nodes[0].port) },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = "/ecs/${local.name_prefix}"
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+          awslogs-create-group  = "true"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${local.name_prefix}-task"
+  }
+}
+
+resource "aws_ecs_service" "app" {
+  name            = "${local.name_prefix}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.public[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = var.app_name
+    container_port   = var.container_port
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-service"
+  }
+}

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,0 +1,24 @@
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${local.name_prefix}-cache-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Name = "${local.name_prefix}-cache-subnet-group"
+  }
+}
+
+resource "aws_elasticache_cluster" "main" {
+  cluster_id           = "${local.name_prefix}-cache"
+  engine               = "redis"
+  engine_version       = "7.1"
+  node_type            = var.cache_node_type
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.main.name
+  security_group_ids   = [aws_security_group.cache.id]
+
+  tags = {
+    Name = "${local.name_prefix}-cache"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    # bucket, key, region은 워크플로우에서 -backend-config로 주입
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_secretsmanager_secret_version" "app" {
+  secret_id = var.secrets_arn
+}
+
+locals {
+  secrets = jsondecode(data.aws_secretsmanager_secret_version.app.secret_string)
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,166 @@
+locals {
+  name_prefix = "${var.app_name}-${var.environment}"
+}
+
+# 가용 영역 조회
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${local.name_prefix}-vpc"
+  }
+}
+
+# 인터넷 게이트웨이
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-igw"
+  }
+}
+
+# 퍼블릭 서브넷 2개 (ALB + ECS 태스크, AZ 분산)
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.${count.index}.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${local.name_prefix}-public-${count.index + 1}"
+  }
+}
+
+# 프라이빗 서브넷 2개 (RDS + ElastiCache, AZ 분산)
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index + 10}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${local.name_prefix}-private-${count.index + 1}"
+  }
+}
+
+# 퍼블릭 라우팅 테이블 — IGW로 아웃바운드
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# ALB 보안 그룹 — 인터넷에서 80/443 허용
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb-sg"
+  description = "ALB security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-alb-sg"
+  }
+}
+
+# ECS 보안 그룹 — ALB에서 컨테이너 포트만 허용
+resource "aws_security_group" "ecs" {
+  name        = "${local.name_prefix}-ecs-sg"
+  description = "ECS tasks security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-sg"
+  }
+}
+
+# RDS 보안 그룹 — ECS에서 5432 포트만 허용
+resource "aws_security_group" "rds" {
+  name        = "${local.name_prefix}-rds-sg"
+  description = "RDS security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-rds-sg"
+  }
+}
+
+# ElastiCache 보안 그룹 — ECS에서 6379 포트만 허용
+resource "aws_security_group" "cache" {
+  name        = "${local.name_prefix}-cache-sg"
+  description = "ElastiCache security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-cache-sg"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "alb_dns_name" {
+  description = "ALB DNS name"
+  value       = aws_lb.main.dns_name
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name"
+  value       = aws_ecs_service.app.name
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,0 +1,16 @@
+aws_region  = "ap-northeast-2"
+app_name    = "gsc-slack-app"
+environment = "prod"
+
+# ECS
+container_image = "ghcr.io/kyumin1227/gsc-slack-app:latest"
+container_port  = 3000
+task_cpu        = 256
+task_memory     = 512
+desired_count   = 1
+
+# RDS
+db_instance_class = "db.t4g.micro"
+
+# ElastiCache
+cache_node_type = "cache.t4g.micro"

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,32 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "${local.name_prefix}-db-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Name = "${local.name_prefix}-db-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "${local.name_prefix}-db"
+  engine            = "postgres"
+  engine_version    = "17"
+  instance_class    = var.db_instance_class
+  allocated_storage = 20
+  storage_type      = "gp3"
+
+  db_name  = local.secrets["DB_DATABASE"]
+  username = local.secrets["DB_USERNAME"]
+  password = local.secrets["DB_PASSWORD"]
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  multi_az            = false
+  publicly_accessible = false
+  skip_final_snapshot = true
+
+  tags = {
+    Name = "${local.name_prefix}-db"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,78 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "app_name" {
+  description = "Application name (used for resource naming)"
+  type        = string
+  default     = "gsc-slack-app"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "prod"
+}
+
+# IAM
+variable "ecs_task_execution_role_arn" {
+  description = "ECS task execution role ARN"
+  type        = string
+}
+
+variable "ecs_task_role_arn" {
+  description = "ECS task role ARN"
+  type        = string
+}
+
+# ECS
+variable "container_image" {
+  description = "Docker image for the app container"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 3000
+}
+
+variable "task_cpu" {
+  description = "Fargate task CPU units"
+  type        = number
+  default     = 256
+}
+
+variable "task_memory" {
+  description = "Fargate task memory (MiB)"
+  type        = number
+  default     = 512
+}
+
+variable "desired_count" {
+  description = "Desired number of ECS tasks"
+  type        = number
+  default     = 1
+}
+
+# RDS
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+# ElastiCache
+variable "cache_node_type" {
+  description = "ElastiCache node type"
+  type        = string
+  default     = "cache.t4g.micro"
+}
+
+# Secrets Manager
+variable "secrets_arn" {
+  description = "Secrets Manager secret ARN containing app environment variables"
+  type        = string
+}


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- AWS ECS 기반 인프라 구성 추가
- Terraform Plan/Apply GitHub Actions 워크플로우 추가

## 주요 변경 사항

### AWS
- VPC, 퍼블릭/프라이빗 서브넷, IGW, 라우팅 테이블 구성
- ALB (HTTP 80) + 타겟 그룹, 헬스체크 설정
- ECS Fargate 클러스터, 태스크 정의, 서비스 구성
- RDS PostgreSQL 17 (프라이빗 서브넷)
- ElastiCache Redis 7.1 (프라이빗 서브넷)
- Secrets Manager에서 민감 정보 주입, DB/Redis 호스트는 리소스 출력값 참조

### 워크플로우
- PR 생성 시 (main, dev 대상) terraform plan 실행 후 결과 PR 코멘트 등록
- main 병합 시 terraform apply 자동 실행
- AWS OIDC 인증, S3 백엔드, Secrets Manager ARN GitHub Secrets로 주입

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
