### PR TITLE
fix: ECS 환경변수에 SLACK_SOCKET_MODE=false 추가

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -49,8 +49,9 @@ resource "aws_ecs_task_definition" "app" {
       ]
 
       environment = [
-        { name = "DB_SYNCHRONIZE", value = "false" },
-        { name = "NODE_ENV",       value = "production" },
+        { name = "DB_SYNCHRONIZE",  value = "false" },
+        { name = "NODE_ENV",        value = "production" },
+        { name = "SLACK_SOCKET_MODE", value = "false" },
         { name = "DB_HOST",        value = aws_db_instance.main.address },
         { name = "DB_PORT",        value = tostring(aws_db_instance.main.port) },
         { name = "REDIS_HOST",     value = aws_elasticache_cluster.main.cache_nodes[0].address },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 프로덕션 환경에서 HTTP 모드로 실행되어야 하나 환경변수 누락으로 Socket 모드로 기동되던 문제 수정

## 주요 변경 사항

### 항목

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
