### PR TITLE
fix: 프로덕션 환경에서 RDS SSL 연결 활성화

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,6 +43,10 @@ import { slackErrorMiddleware } from './common/slack-error.middleware';
       synchronize: process.env.DB_SYNCHRONIZE === 'true',
       migrations: [__dirname + '/migrations/*.js'],
       migrationsRun: process.env.DB_SYNCHRONIZE !== 'true',
+      ssl:
+        process.env.NODE_ENV === 'production'
+          ? { rejectUnauthorized: false }
+          : false,
     }),
     SlackModule.forRoot(
       httpReceiver


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- RDS는 기본적으로 SSL 연결만 허용하므로 NODE_ENV=production일 때 SSL 활성화 (인증서 검증 생략)

## 주요 변경 사항

### 항목

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
