### PR TITLE
Feat/infra https: ALB HTTPS 리스너 추가

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -39,4 +39,5 @@ jobs:
             -var-file=prod.tfvars \
             -var="secrets_arn=${{ secrets.SECRETS_ARN }}" \
             -var="ecs_task_execution_role_arn=${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}" \
-            -var="ecs_task_role_arn=${{ secrets.ECS_TASK_ROLE_ARN }}"
+            -var="ecs_task_role_arn=${{ secrets.ECS_TASK_ROLE_ARN }}" \
+            -var="acm_certificate_arn=${{ secrets.ACM_CERTIFICATE_ARN }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -42,7 +42,8 @@ jobs:
             -var-file=prod.tfvars \
             -var="secrets_arn=${{ secrets.SECRETS_ARN }}" \
             -var="ecs_task_execution_role_arn=${{ secrets.ECS_TASK_EXECUTION_ROLE_ARN }}" \
-            -var="ecs_task_role_arn=${{ secrets.ECS_TASK_ROLE_ARN }}"
+            -var="ecs_task_role_arn=${{ secrets.ECS_TASK_ROLE_ARN }}" \
+            -var="acm_certificate_arn=${{ secrets.ACM_CERTIFICATE_ARN }}"
         continue-on-error: true
 
       - name: Comment plan on PR

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -35,6 +35,23 @@ resource "aws_lb_listener" "http" {
   protocol          = "HTTP"
 
   default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.acm_certificate_arn
+
+  default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.app.arn
   }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -34,28 +34,28 @@ resource "aws_ecs_task_definition" "app" {
       ]
 
       secrets = [
-        { name = "SLACK_BOT_TOKEN",                    valueFrom = "${var.secrets_arn}:SLACK_BOT_TOKEN::" },
-        { name = "SLACK_APP_TOKEN",                    valueFrom = "${var.secrets_arn}:SLACK_APP_TOKEN::" },
-        { name = "SLACK_SIGNING_SECRET",               valueFrom = "${var.secrets_arn}:SLACK_SIGNING_SECRET::" },
-        { name = "GOOGLE_CLIENT_ID",                   valueFrom = "${var.secrets_arn}:GOOGLE_CLIENT_ID::" },
-        { name = "GOOGLE_CLIENT_SECRET",               valueFrom = "${var.secrets_arn}:GOOGLE_CLIENT_SECRET::" },
-        { name = "GOOGLE_SERVICE_ACCOUNT_EMAIL",       valueFrom = "${var.secrets_arn}:GOOGLE_SERVICE_ACCOUNT_EMAIL::" },
+        { name = "SLACK_BOT_TOKEN", valueFrom = "${var.secrets_arn}:SLACK_BOT_TOKEN::" },
+        { name = "SLACK_APP_TOKEN", valueFrom = "${var.secrets_arn}:SLACK_APP_TOKEN::" },
+        { name = "SLACK_SIGNING_SECRET", valueFrom = "${var.secrets_arn}:SLACK_SIGNING_SECRET::" },
+        { name = "GOOGLE_CLIENT_ID", valueFrom = "${var.secrets_arn}:GOOGLE_CLIENT_ID::" },
+        { name = "GOOGLE_CLIENT_SECRET", valueFrom = "${var.secrets_arn}:GOOGLE_CLIENT_SECRET::" },
+        { name = "GOOGLE_SERVICE_ACCOUNT_EMAIL", valueFrom = "${var.secrets_arn}:GOOGLE_SERVICE_ACCOUNT_EMAIL::" },
         { name = "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY", valueFrom = "${var.secrets_arn}:GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY::" },
-        { name = "DB_USERNAME",                        valueFrom = "${var.secrets_arn}:DB_USERNAME::" },
-        { name = "DB_PASSWORD",                        valueFrom = "${var.secrets_arn}:DB_PASSWORD::" },
-        { name = "DB_DATABASE",                        valueFrom = "${var.secrets_arn}:DB_DATABASE::" },
-        { name = "ENCRYPTION_SECRET",                  valueFrom = "${var.secrets_arn}:ENCRYPTION_SECRET::" },
-        { name = "REDIS_PASSWORD",                     valueFrom = "${var.secrets_arn}:REDIS_PASSWORD::" },
+        { name = "DB_USERNAME", valueFrom = "${var.secrets_arn}:DB_USERNAME::" },
+        { name = "DB_PASSWORD", valueFrom = "${var.secrets_arn}:DB_PASSWORD::" },
+        { name = "DB_DATABASE", valueFrom = "${var.secrets_arn}:DB_DATABASE::" },
+        { name = "ENCRYPTION_SECRET", valueFrom = "${var.secrets_arn}:ENCRYPTION_SECRET::" },
+        { name = "REDIS_PASSWORD", valueFrom = "${var.secrets_arn}:REDIS_PASSWORD::" },
       ]
 
       environment = [
-        { name = "DB_SYNCHRONIZE",  value = "false" },
-        { name = "NODE_ENV",        value = "production" },
+        { name = "DB_SYNCHRONIZE", value = "false" },
+        { name = "NODE_ENV", value = "production" },
         { name = "SLACK_SOCKET_MODE", value = "false" },
-        { name = "DB_HOST",        value = aws_db_instance.main.address },
-        { name = "DB_PORT",        value = tostring(aws_db_instance.main.port) },
-        { name = "REDIS_HOST",     value = aws_elasticache_cluster.main.cache_nodes[0].address },
-        { name = "REDIS_PORT",     value = tostring(aws_elasticache_cluster.main.cache_nodes[0].port) },
+        { name = "DB_HOST", value = aws_db_instance.main.address },
+        { name = "DB_PORT", value = tostring(aws_db_instance.main.port) },
+        { name = "REDIS_HOST", value = aws_elasticache_cluster.main.cache_nodes[0].address },
+        { name = "REDIS_PORT", value = tostring(aws_elasticache_cluster.main.cache_nodes[0].port) },
       ]
 
       logConfiguration = {

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -14,3 +14,4 @@ db_instance_class = "db.t4g.micro"
 
 # ElastiCache
 cache_node_type = "cache.t4g.micro"
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,6 +71,12 @@ variable "cache_node_type" {
   default     = "cache.t4g.micro"
 }
 
+# ACM
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for HTTPS listener"
+  type        = string
+}
+
 # Secrets Manager
 variable "secrets_arn" {
   description = "Secrets Manager secret ARN containing app environment variables"


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- ALB HTTPS 리스너 추가

## 주요 변경 사항

### ALB
- HTTPS 리스너(443) 추가 및 ACM 인증서 연결
- HTTP(80)는 HTTPS로 301 리다이렉트 처리
- acm_certificate_arn 변수 추가

### GitHub Secret
- ACM 인증서 ARN을 GitHub Secrets(ACM_CERTIFICATE_ARN)로 주입

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
