### PR TITLE
feat(terraform): Google OAuth 리다이렉트 URI 환경변수 추가

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -52,6 +52,7 @@ resource "aws_ecs_task_definition" "app" {
         { name = "DB_SYNCHRONIZE", value = "false" },
         { name = "NODE_ENV", value = "production" },
         { name = "SLACK_SOCKET_MODE", value = "false" },
+        { name = "GOOGLE_REDIRECT_URI", value = "https://${var.app_domain}/auth/google/callback" },
         { name = "DB_HOST", value = aws_db_instance.main.address },
         { name = "DB_PORT", value = tostring(aws_db_instance.main.port) },
         { name = "REDIS_HOST", value = aws_elasticache_cluster.main.cache_nodes[0].address },

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,4 +1,5 @@
 aws_region  = "ap-northeast-2"
+app_domain  = "bannote.gsc-lab.io"
 app_name    = "bannote"
 environment = "prod"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,6 +71,12 @@ variable "cache_node_type" {
   default     = "cache.t4g.micro"
 }
 
+# Domain
+variable "app_domain" {
+  description = "Application domain (e.g. app.example.com)"
+  type        = string
+}
+
 # ACM
 variable "acm_certificate_arn" {
   description = "ACM certificate ARN for HTTPS listener"


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- app_domain 변수 추가 및 prod.tfvars에 bannote.gsc-lab.io 설정
- ECS 태스크에 GOOGLE_REDIRECT_URI 환경변수 주입

## 주요 변경 사항

### 항목

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [ ] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
