### PR TITLE
refactor: 반 표시 형식 통일 및 유틸 추출

### DIFF
--- a/src/common/class-label.util.ts
+++ b/src/common/class-label.util.ts
@@ -1,0 +1,18 @@
+export interface ClassInfo {
+  admissionYear: number;
+  section: string;
+  graduated?: boolean;
+}
+
+/**
+ * 반 표시 레이블 생성
+ * - 재학 중: "3학년 A반"
+ * - 졸업:    "졸업 A반"
+ */
+export function formatClassLabel(cls: ClassInfo): string {
+  if (cls.graduated) {
+    return `졸업 ${cls.section}반 (입학 ${cls.admissionYear})`;
+  }
+  const grade = new Date().getFullYear() - cls.admissionYear + 1;
+  return `${grade}학년 ${cls.section}반`;
+}

--- a/src/space/space.service.ts
+++ b/src/space/space.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { formatClassLabel } from '../common/class-label.util';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Space, SpaceStatus, SpaceType } from './space.entity';
@@ -163,14 +164,12 @@ export class SpaceService {
     ).filter((u): u is NonNullable<typeof u> => u !== null);
 
     const attendeeEmails = attendees.map((u) => u.email);
-    const currentYear = new Date().getFullYear();
     const description = attendees
       .map((u) => {
-        const admissionYear = u.studentClass?.name?.split('-')[0];
-        const gradePart = admissionYear
-          ? ` (${currentYear - parseInt(admissionYear) + 1}학년)`
+        const classPart = u.studentClass
+          ? ` (${formatClassLabel({ admissionYear: u.studentClass.admissionYear, section: u.studentClass.section })})`
           : '';
-        return `${u.name}${gradePart} | ${u.code ?? '-'} | ${u.email}`;
+        return `${u.name}${classPart} | ${u.code ?? '-'} | ${u.email}`;
       })
       .join('\n');
 
@@ -298,14 +297,12 @@ export class SpaceService {
     ).filter((u): u is NonNullable<typeof u> => u !== null);
 
     const attendeeEmails = attendees.map((u) => u.email);
-    const currentYear = new Date().getFullYear();
     const description = attendees
       .map((u) => {
-        const admissionYear = u.studentClass?.name?.split('-')[0];
-        const gradePart = admissionYear
-          ? ` (${currentYear - parseInt(admissionYear) + 1}학년)`
+        const classPart = u.studentClass
+          ? ` (${formatClassLabel({ admissionYear: u.studentClass.admissionYear, section: u.studentClass.section })})`
           : '';
-        return `${u.name}${gradePart} | ${u.code ?? '-'} | ${u.email}`;
+        return `${u.name}${classPart} | ${u.code ?? '-'} | ${u.email}`;
       })
       .join('\n');
 

--- a/src/student-class/student-class.controller.ts
+++ b/src/student-class/student-class.controller.ts
@@ -43,6 +43,7 @@ export class StudentClassController {
         classes.map((c) => ({
           id: c.id,
           name: c.name,
+          section: c.section,
           admissionYear: c.admissionYear,
           graduationYear: c.graduationYear,
           status: c.status,
@@ -213,6 +214,7 @@ export class StudentClassController {
           classes.map((c) => ({
             id: c.id,
             name: c.name,
+            section: c.section,
             admissionYear: c.admissionYear,
             graduationYear: c.graduationYear,
             status: c.status,

--- a/src/student-class/student-class.view.ts
+++ b/src/student-class/student-class.view.ts
@@ -1,5 +1,6 @@
 import type { View } from '@slack/types';
 import { StudentClassStatus } from './student-class.entity';
+import { formatClassLabel } from '../common/class-label.util';
 
 export interface StudentClassEditPrefill {
   id: number;
@@ -11,6 +12,7 @@ export interface StudentClassEditPrefill {
 export interface StudentClassListItem {
   id: number;
   name: string;
+  section: string;
   admissionYear: number;
   graduationYear: number;
   status: StudentClassStatus;
@@ -54,10 +56,11 @@ export class StudentClassView {
         const toggleValue =
           cls.status === StudentClassStatus.ACTIVE ? 'graduate' : 'activate';
 
-        const gradeInfo =
-          cls.status === StudentClassStatus.GRADUATED
-            ? '졸업'
-            : `${new Date().getFullYear() - cls.admissionYear + 1}학년`;
+        const gradeLabel = formatClassLabel({
+          admissionYear: cls.admissionYear,
+          section: cls.section,
+          graduated: cls.status === StudentClassStatus.GRADUATED,
+        });
         const channelInfo = cls.slackChannelId
           ? ` | 채널: <#${cls.slackChannelId}>`
           : '';
@@ -66,7 +69,7 @@ export class StudentClassView {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `${statusEmoji} *${cls.name}* (${gradeInfo})\n졸업 연도: ${cls.graduationYear} | 상태: ${STATUS_LABELS[cls.status]}${channelInfo}`,
+            text: `${statusEmoji} *${gradeLabel}*\n졸업 연도: ${cls.graduationYear} | 상태: ${STATUS_LABELS[cls.status]}${channelInfo}`,
           },
           accessory: {
             type: 'overflow',

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Tag, TagStatus } from './tag.entity';
 import { StudentClassStatus } from '../student-class/student-class.entity';
+import { formatClassLabel } from '../common/class-label.util';
 
 export interface CreateTagDto {
   name: string;
@@ -107,10 +108,11 @@ export class TagService {
   // 표시용 이름 생성 (반 태그에 학년 정보 추가)
   static buildDisplayName(tag: Tag): string {
     if (!tag.studentClass) return tag.name;
-    if (tag.studentClass.status === StudentClassStatus.GRADUATED) {
-      return `${tag.name} (졸업)`;
-    }
-    const grade = new Date().getFullYear() - tag.studentClass.admissionYear + 1;
-    return `${tag.name} (${grade}학년)`;
+    const label = formatClassLabel({
+      admissionYear: tag.studentClass.admissionYear,
+      section: tag.studentClass.section,
+      graduated: tag.studentClass.status === StudentClassStatus.GRADUATED,
+    });
+    return label;
   }
 }

--- a/src/user/user.view.ts
+++ b/src/user/user.view.ts
@@ -1,5 +1,6 @@
 import type { View } from '@slack/types';
 import { UserRole, UserStatus } from './user.entity';
+import { formatClassLabel } from '../common/class-label.util';
 
 export interface ClassOption {
   id: number;
@@ -220,12 +221,10 @@ export class UserView {
             options:
               prefill.classes.length > 0
                 ? prefill.classes.map((cls) => {
-                    const grade =
-                      new Date().getFullYear() - cls.admissionYear + 1;
                     return {
                       text: {
                         type: 'plain_text' as const,
-                        text: `${grade}학년 ${cls.section}반`,
+                        text: formatClassLabel(cls),
                       },
                       value: String(cls.id),
                     };
@@ -351,16 +350,13 @@ export class UserView {
     ];
     const classFilterOptions = [
       { text: { type: 'plain_text' as const, text: '반 전체' }, value: 'all' },
-      ...classOptions.map((c) => {
-        const grade = new Date().getFullYear() - c.admissionYear + 1;
-        return {
-          text: {
-            type: 'plain_text' as const,
-            text: `${grade}학년 ${c.section}반`,
-          },
-          value: String(c.id),
-        };
-      }),
+      ...classOptions.map((c) => ({
+        text: {
+          type: 'plain_text' as const,
+          text: formatClassLabel(c),
+        },
+        value: String(c.id),
+      })),
     ];
 
     const blocks: View['blocks'] = [
@@ -494,16 +490,13 @@ export class UserView {
   static editUserModal(prefill: EditUserPrefill): View {
     const classOptions =
       prefill.classes.length > 0
-        ? prefill.classes.map((cls) => {
-            const grade = new Date().getFullYear() - cls.admissionYear + 1;
-            return {
-              text: {
-                type: 'plain_text' as const,
-                text: `${grade}학년 ${cls.section}반`,
-              },
-              value: String(cls.id),
-            };
-          })
+        ? prefill.classes.map((cls) => ({
+            text: {
+              type: 'plain_text' as const,
+              text: formatClassLabel(cls),
+            },
+            value: String(cls.id),
+          }))
         : [
             {
               text: { type: 'plain_text' as const, text: '등록된 반 없음' },
@@ -619,16 +612,13 @@ export class UserView {
   static myInfoModal(prefill: MyInfoPrefill): View {
     const classOptions =
       prefill.classes.length > 0
-        ? prefill.classes.map((cls) => {
-            const grade = new Date().getFullYear() - cls.admissionYear + 1;
-            return {
-              text: {
-                type: 'plain_text' as const,
-                text: `${grade}학년 ${cls.section}반`,
-              },
-              value: String(cls.id),
-            };
-          })
+        ? prefill.classes.map((cls) => ({
+            text: {
+              type: 'plain_text' as const,
+              text: formatClassLabel(cls),
+            },
+            value: String(cls.id),
+          }))
         : [
             {
               text: { type: 'plain_text' as const, text: '등록된 반 없음' },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 반 표시 이름 형식 통일

## 주요 변경 사항

### 반 표시 형식
- formatClassLabel 유틸 추가 (3학년 A반 / 졸업 A반 (입학 2024) 형식)
- user.view, student-class.view, tag.service, space.service 전체 적용
- 기존 admissionYear 기반 인라인 계산 코드 제거

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [ ] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
