### PR TITLE
fix: ECS 태스크에 GOOGLE_WEBHOOK_URL 환경변수 추가

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -57,6 +57,7 @@ resource "aws_ecs_task_definition" "app" {
         { name = "DB_PORT", value = tostring(aws_db_instance.main.port) },
         { name = "REDIS_HOST", value = aws_elasticache_cluster.main.cache_nodes[0].address },
         { name = "REDIS_PORT", value = tostring(aws_elasticache_cluster.main.cache_nodes[0].port) },
+        { name = "GOOGLE_WEBHOOK_URL", value = "https://${var.app_domain}" },
       ]
 
       logConfiguration = {


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 환경변수 누락으로 캘린더 watch 등록이 스킵되던 문제 수정

## 주요 변경 사항

### 항목

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
