### PR TITLE
fix: Slack 채널 미연결 스케줄도 웹훅 미러링 실행

### DIFF
--- a/src/schedule/schedule-watch.controller.ts
+++ b/src/schedule/schedule-watch.controller.ts
@@ -8,7 +8,6 @@ import {
 } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
-import { ChannelService } from '../channel/channel.service';
 import { GoogleCalendarService } from '../google/google-calendar.service';
 import { ScheduleService } from './schedule.service';
 import {
@@ -25,7 +24,6 @@ export class ScheduleWatchController {
 
   constructor(
     private readonly scheduleService: ScheduleService,
-    private readonly channelService: ChannelService,
     private readonly notificationService: ScheduleNotificationService,
     private readonly spaceMirrorService: SpaceMirrorService,
     private readonly googleCalendarService: GoogleCalendarService,
@@ -51,12 +49,6 @@ export class ScheduleWatchController {
       this.logger.warn(`Unknown channelId: ${channelId}`);
       return;
     }
-
-    // 연결된 Slack 채널 없으면 조기 종료
-    const slackChannelIds = await this.channelService.getSlackChannelIds(
-      schedule.id,
-    );
-    if (slackChannelIds.length === 0) return;
 
     if (!schedule.syncToken) {
       this.logger.warn(


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 채널이 없으면 조기 종료 되어, 웹훅을 받아도 미러링을 실행하지 않던 문제 수정
- 채널 없으면 조기 종료하던 로직 제거, 미러링은 채널 유무와 무관하게 항상 실행되도록 수정
- 채널이 없는 경우는 `ScheduleNotificationService` 내부에서 확인

## 주요 변경 사항

### schedule-watch.controller.ts 수정
- 연결된 slack 채널 없으면 조기 종료 하던 로직 제거
- 채널 서비스 의존 제거

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
