### PR TITLE
Feat/professor booking: 교수 상담 예약 기능 구현

### DIFF
--- a/src/google/google-calendar.service.ts
+++ b/src/google/google-calendar.service.ts
@@ -725,6 +725,36 @@ export class GoogleCalendarService {
     return busy.length > 0;
   }
 
+  // 유저 토큰으로 본인 primary 캘린더에서 기간 내 이벤트 조회
+  async listUserPrimaryEvents(
+    refreshToken: string,
+    timeMin: Date,
+    timeMax: Date,
+  ): Promise<calendar_v3.Schema$Event[]> {
+    const calendar = this.getUserCalendarClient(refreshToken);
+    const events: calendar_v3.Schema$Event[] = [];
+    let pageToken: string | undefined;
+
+    while (true) {
+      const response = await calendar.events.list({
+        calendarId: 'primary',
+        timeMin: timeMin.toISOString(),
+        timeMax: timeMax.toISOString(),
+        showDeleted: false,
+        singleEvents: true,
+        maxResults: 2500,
+        ...(pageToken ? { pageToken } : {}),
+      });
+
+      events.push(...(response.data.items ?? []));
+
+      if (!response.data.nextPageToken) break;
+      pageToken = response.data.nextPageToken;
+    }
+
+    return events;
+  }
+
   // 특정 사용자가 참석자인 이벤트 목록 조회 (여러 캘린더, 서비스 계정 사용)
   async getUserBookings(
     calendarIds: string[],
@@ -776,6 +806,19 @@ export class GoogleCalendarService {
   ): Promise<void> {
     const calendar = this.getUserCalendarClient(refreshToken);
     await calendar.events.delete({ calendarId, eventId, sendUpdates: 'none' });
+  }
+
+  // 교수 상담 취소 — primary 캘린더에서 삭제하고 교수에게 취소 알림 발송
+  async cancelConsultationEvent(
+    refreshToken: string,
+    eventId: string,
+  ): Promise<void> {
+    const calendar = this.getUserCalendarClient(refreshToken);
+    await calendar.events.delete({
+      calendarId: 'primary',
+      eventId,
+      sendUpdates: 'all',
+    });
   }
 
   // 이벤트 수정 (부분 업데이트)

--- a/src/migrations/1776700000000-AddBookingUrlToResource.ts
+++ b/src/migrations/1776700000000-AddBookingUrlToResource.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddBookingUrlToResource1776700000000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "resource" ADD COLUMN IF NOT EXISTS "bookingUrl" varchar NULL`,
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "resource" DROP COLUMN IF EXISTS "bookingUrl"`,
+    );
+  }
+}

--- a/src/resource/resource.controller.ts
+++ b/src/resource/resource.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Logger } from '@nestjs/common';
 import { Action, Command, View } from 'nestjs-slack-bolt';
 import type {
   AllMiddlewareArgs,
@@ -18,6 +18,8 @@ import { PermissionService } from '../user/permission.service';
 
 @Controller()
 export class ResourceController {
+  private readonly logger = new Logger(ResourceController.name);
+
   constructor(
     private readonly resourceService: ResourceService,
     private readonly userService: UserService,
@@ -276,13 +278,10 @@ export class ResourceController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const user = await this.userService.findBySlackId(userId);
 
     const [bookings, consultations] = await Promise.all([
       this.resourceService.getMyBookings(userId),
-      user?.email
-        ? this.resourceService.getProfessorConsultations(user.email)
-        : Promise.resolve([]),
+      this.resourceService.getProfessorConsultations(userId),
     ]);
 
     await client.views.open({
@@ -447,6 +446,36 @@ export class ResourceController {
     ack,
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
+  }
+
+  @Action(/^consultation:cancel:/)
+  async cancelConsultation({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const userId = body.user.id;
+    const eventId = (body.actions[0] as any).action_id.replace('consultation:cancel:', '');
+
+    try {
+      await this.resourceService.cancelConsultation(userId, eventId);
+      await client.views.update({
+        view_id: body.view!.id,
+        view: await this.buildMyBookingsView(userId),
+      });
+    } catch (e) {
+      this.logger.error('교수 상담 취소 실패', e);
+    }
+  }
+
+  private async buildMyBookingsView(userId: string) {
+    const [bookings, consultations] = await Promise.all([
+      this.resourceService.getMyBookings(userId),
+      this.resourceService.getProfessorConsultations(userId),
+    ]);
+    return ResourceView.myBookingsModal(bookings, consultations);
   }
 
   @Action('home:open-classroom-schedule')

--- a/src/resource/resource.controller.ts
+++ b/src/resource/resource.controller.ts
@@ -276,10 +276,36 @@ export class ResourceController {
     await ack();
 
     const userId = 'user_id' in body ? body.user_id : body.user.id;
-    const bookings = await this.resourceService.getMyBookings(userId);
+    const user = await this.userService.findBySlackId(userId);
+
+    const [bookings, consultations] = await Promise.all([
+      this.resourceService.getMyBookings(userId),
+      user?.email
+        ? this.resourceService.getProfessorConsultations(user.email)
+        : Promise.resolve([]),
+    ]);
+
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: ResourceView.myBookingsModal(bookings),
+      view: ResourceView.myBookingsModal(bookings, consultations),
+    });
+  }
+
+  @Action('home:open-professor-booking-pages')
+  async openProfessorBookingPages({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const professors = await this.resourceService.findAllByType(
+      ResourceType.PROFESSOR,
+      true,
+    );
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: ResourceView.professorBookingPagesModal(professors),
     });
   }
 
@@ -416,7 +442,7 @@ export class ResourceController {
   }
 
   // URL 링크 버튼 — Slack 경고 방지용 ack
-  @Action(/^space:action:view-|^study-room:action:view-calendar$/)
+  @Action(/^space:action:view-|^study-room:action:view-calendar$|^professor:booking:|^consultation:view-/)
   async ackViewLinkButtons({
     ack,
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
@@ -536,6 +562,8 @@ export class ResourceController {
       values.description_block.description_input.value ?? null;
     const status = values.status_block.status_select.selected_option
       ?.value as ResourceStatus;
+    const bookingUrl =
+      values.booking_url_block?.booking_url_input?.value?.trim() || null;
 
     await this.resourceService.rename(roomId, name);
     await this.resourceService.updateInfo(roomId, {
@@ -543,6 +571,7 @@ export class ResourceController {
       status,
       aliases,
       type,
+      bookingUrl,
     });
     await client.chat.postMessage({
       channel: body.user.id,

--- a/src/resource/resource.entity.ts
+++ b/src/resource/resource.entity.ts
@@ -57,6 +57,9 @@ export class Resource {
   @Column({ default: false })
   isDefault: boolean = false;
 
+  @Column({ type: 'varchar', nullable: true })
+  bookingUrl: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/resource/resource.service.ts
+++ b/src/resource/resource.service.ts
@@ -25,7 +25,7 @@ export interface BookResourceDto {
 }
 
 export interface ConsultationItem {
-  professorName: string;
+  eventId: string;
   summary: string;
   startTime: Date;
   endTime: Date;
@@ -276,40 +276,51 @@ export class ResourceService {
   }
 
   async getProfessorConsultations(
-    userEmail: string,
+    slackId: string,
   ): Promise<ConsultationItem[]> {
-    const professors = await this.findAllByType(ResourceType.PROFESSOR, true);
+    const user = await this.userService.findBySlackId(slackId);
+    if (!user) return [];
+
+    const refreshToken = this.userService.getDecryptedRefreshToken(user);
+    if (!refreshToken) return [];
+
     const now = new Date();
     const future = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
-    const results: ConsultationItem[] = [];
 
-    await Promise.all(
-      professors.map(async (prof) => {
-        const events = await this.googleCalendarService.listEventsInRange(
-          prof.calendarId,
-          now,
-          future,
-        );
-        for (const ev of events) {
-          if (ev.status === 'cancelled') continue;
-          const isAttendee = ev.attendees?.some(
-            (a) => a.email?.toLowerCase() === userEmail.toLowerCase(),
-          );
-          if (!isAttendee) continue;
-          const start = new Date(ev.start?.dateTime ?? ev.start?.date ?? '');
-          const end = new Date(ev.end?.dateTime ?? ev.end?.date ?? '');
-          results.push({
-            professorName: prof.name,
-            summary: ev.summary ?? '(제목 없음)',
-            startTime: start,
-            endTime: end,
-            htmlLink: ev.htmlLink ?? undefined,
-          });
-        }
-      }),
+    const events = await this.googleCalendarService.listUserPrimaryEvents(
+      refreshToken,
+      now,
+      future,
     );
 
-    return results.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+    const results: ConsultationItem[] = [];
+    for (const ev of events) {
+      if (ev.status === 'cancelled') continue;
+      if (ev.extendedProperties?.shared?.['goo.createdBySet'] !== 'default_cita') continue;
+      const start = new Date(ev.start?.dateTime ?? ev.start?.date ?? '');
+      const end = new Date(ev.end?.dateTime ?? ev.end?.date ?? '');
+      results.push({
+        eventId: ev.id!,
+        summary: ev.summary ?? '(제목 없음)',
+        startTime: start,
+        endTime: end,
+        htmlLink: ev.htmlLink ?? undefined,
+      });
+    }
+
+    return results.sort(
+      (a, b) => a.startTime.getTime() - b.startTime.getTime(),
+    );
+  }
+
+  async cancelConsultation(slackId: string, eventId: string): Promise<void> {
+    const user = await this.userService.findBySlackId(slackId);
+    if (!user) throw new BusinessError(ErrorCode.USER_NOT_FOUND);
+
+    const refreshToken = this.userService.getDecryptedRefreshToken(user);
+    if (!refreshToken) throw new BusinessError(ErrorCode.CALENDAR_WRITER_NO_TOKEN);
+
+    await this.googleCalendarService.cancelConsultationEvent(refreshToken, eventId);
   }
 
   async addEditor(id: number, email: string): Promise<void> {

--- a/src/resource/resource.service.ts
+++ b/src/resource/resource.service.ts
@@ -24,6 +24,14 @@ export interface BookResourceDto {
   attendeeSlackIds: string[];
 }
 
+export interface ConsultationItem {
+  professorName: string;
+  summary: string;
+  startTime: Date;
+  endTime: Date;
+  htmlLink?: string;
+}
+
 export interface BookingItem {
   calendarId: string;
   eventId: string;
@@ -261,9 +269,47 @@ export class ResourceService {
       status?: ResourceStatus;
       aliases?: string[];
       type?: ResourceType;
+      bookingUrl?: string | null;
     },
   ): Promise<void> {
     await this.resourceRepository.update(id, dto as any);
+  }
+
+  async getProfessorConsultations(
+    userEmail: string,
+  ): Promise<ConsultationItem[]> {
+    const professors = await this.findAllByType(ResourceType.PROFESSOR, true);
+    const now = new Date();
+    const future = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
+    const results: ConsultationItem[] = [];
+
+    await Promise.all(
+      professors.map(async (prof) => {
+        const events = await this.googleCalendarService.listEventsInRange(
+          prof.calendarId,
+          now,
+          future,
+        );
+        for (const ev of events) {
+          if (ev.status === 'cancelled') continue;
+          const isAttendee = ev.attendees?.some(
+            (a) => a.email?.toLowerCase() === userEmail.toLowerCase(),
+          );
+          if (!isAttendee) continue;
+          const start = new Date(ev.start?.dateTime ?? ev.start?.date ?? '');
+          const end = new Date(ev.end?.dateTime ?? ev.end?.date ?? '');
+          results.push({
+            professorName: prof.name,
+            summary: ev.summary ?? '(제목 없음)',
+            startTime: start,
+            endTime: end,
+            htmlLink: ev.htmlLink ?? undefined,
+          });
+        }
+      }),
+    );
+
+    return results.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
   }
 
   async addEditor(id: number, email: string): Promise<void> {

--- a/src/resource/resource.view.ts
+++ b/src/resource/resource.view.ts
@@ -1,6 +1,6 @@
 import type { View } from '@slack/types';
 import { Resource, ResourceStatus, ResourceType } from './resource.entity';
-import { BookingItem } from './resource.service';
+import { BookingItem, ConsultationItem } from './resource.service';
 import { toKST } from '../utils/date.util';
 import { multiUsersSelectBlock } from '../common/blocks';
 
@@ -300,15 +300,24 @@ export class ResourceView {
     };
   }
 
-  static myBookingsModal(bookings: BookingItem[]): View {
+  static myBookingsModal(
+    bookings: BookingItem[],
+    consultations: ConsultationItem[] = [],
+  ): View {
     const blocks: View['blocks'] = [];
 
-    if (bookings.length === 0) {
+    if (bookings.length === 0 && consultations.length === 0) {
       blocks.push({
         type: 'section',
         text: { type: 'mrkdwn', text: '예약 내역이 없습니다.' },
       });
-    } else {
+    }
+
+    if (bookings.length > 0) {
+      blocks.push({
+        type: 'header',
+        text: { type: 'plain_text', text: '📚 스터디룸 예약', emoji: true },
+      });
       for (const booking of bookings) {
         const start = toKST(booking.startTime);
         const end = toKST(booking.endTime);
@@ -361,6 +370,37 @@ export class ResourceView {
           },
           { type: 'divider' },
         );
+      }
+    }
+
+    if (consultations.length > 0) {
+      blocks.push({
+        type: 'header',
+        text: { type: 'plain_text', text: '👨‍🏫 교수 상담 예약', emoji: true },
+      });
+      for (const c of consultations) {
+        const start = toKST(c.startTime);
+        const end = toKST(c.endTime);
+        const dateStr = `${start.getUTCFullYear()}.${String(start.getUTCMonth() + 1).padStart(2, '0')}.${String(start.getUTCDate()).padStart(2, '0')}`;
+        const startStr = `${String(start.getUTCHours()).padStart(2, '0')}:${String(start.getUTCMinutes()).padStart(2, '0')}`;
+        const endStr = `${String(end.getUTCHours()).padStart(2, '0')}:${String(end.getUTCMinutes()).padStart(2, '0')}`;
+
+        const sectionBlock: any = {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${c.summary}*\n${c.professorName} | ${dateStr} ${startStr}~${endStr}`,
+          },
+        };
+        if (c.htmlLink) {
+          sectionBlock.accessory = {
+            type: 'button',
+            text: { type: 'plain_text', text: '캘린더에서 보기 ❐' },
+            url: c.htmlLink,
+            action_id: `consultation:view-${start.getTime()}`,
+          };
+        }
+        blocks.push(sectionBlock, { type: 'divider' });
       }
     }
 
@@ -703,6 +743,34 @@ export class ResourceView {
         },
         {
           type: 'input',
+          block_id: 'booking_url_block',
+          label: { type: 'plain_text', text: '예약 페이지 URL (교수 전용)' },
+          optional: true,
+          hint: {
+            type: 'plain_text',
+            text: '교수 유형에서만 사용. Google Calendar 예약 페이지 링크를 입력하세요.',
+          },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'booking_url_input',
+            initial_value: resource.bookingUrl ?? '',
+            placeholder: {
+              type: 'plain_text',
+              text: 'https://calendar.google.com/calendar/appointments/...',
+            },
+          },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: '📎 교수 예약 페이지 설정 방법 → <https://support.google.com/calendar/answer/10729749|Google Calendar 가이드>',
+            },
+          ],
+        },
+        {
+          type: 'input',
           block_id: 'status_block',
           label: { type: 'plain_text', text: '상태' },
           element: {
@@ -873,6 +941,63 @@ export class ResourceView {
       type: 'modal',
       callback_id: 'space:modal:professor-schedule',
       title: { type: 'plain_text', text: '교수 시간표' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  static professorBookingPagesModal(professors: Resource[]): View {
+    const blocks: View['blocks'] = [];
+
+    const withUrl = professors.filter((p) => p.bookingUrl);
+
+    if (withUrl.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '등록된 교수 예약 페이지가 없습니다.\n관리자에게 문의해주세요.',
+        },
+      });
+    } else {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: 'Google Calendar 예약 페이지에서 상담 일정을 예약할 수 있어요.',
+          },
+        ],
+      });
+
+      for (const prof of withUrl) {
+        const aliasText =
+          prof.aliases?.length > 0 ? `\n별칭: ${prof.aliases.join(', ')}` : '';
+        blocks.push(
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: prof.description
+                ? `*${prof.name}*${aliasText}\n${prof.description}`
+                : `*${prof.name}*${aliasText}`,
+            },
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: '예약하기 ❐' },
+              url: prof.bookingUrl!,
+              action_id: `professor:booking:${prof.id}`,
+            },
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'professor:modal:booking-pages',
+      title: { type: 'plain_text', text: '교수 상담 예약' },
       close: { type: 'plain_text', text: '닫기' },
       blocks,
     };

--- a/src/resource/resource.view.ts
+++ b/src/resource/resource.view.ts
@@ -385,22 +385,44 @@ export class ResourceView {
         const startStr = `${String(start.getUTCHours()).padStart(2, '0')}:${String(start.getUTCMinutes()).padStart(2, '0')}`;
         const endStr = `${String(end.getUTCHours()).padStart(2, '0')}:${String(end.getUTCMinutes()).padStart(2, '0')}`;
 
-        const sectionBlock: any = {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `*${c.summary}*\n${c.professorName} | ${dateStr} ${startStr}~${endStr}`,
+        blocks.push(
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*${c.summary}*\n${dateStr} ${startStr}~${endStr}`,
+            },
           },
-        };
-        if (c.htmlLink) {
-          sectionBlock.accessory = {
-            type: 'button',
-            text: { type: 'plain_text', text: '캘린더에서 보기 ❐' },
-            url: c.htmlLink,
-            action_id: `consultation:view-${start.getTime()}`,
-          };
-        }
-        blocks.push(sectionBlock, { type: 'divider' });
+          {
+            type: 'actions',
+            elements: [
+              ...(c.htmlLink
+                ? [
+                    {
+                      type: 'button' as const,
+                      text: { type: 'plain_text' as const, text: '캘린더에서 보기 ❐' },
+                      url: c.htmlLink,
+                      action_id: `consultation:view-${start.getTime()}`,
+                    },
+                  ]
+                : []),
+              {
+                type: 'button' as const,
+                text: { type: 'plain_text' as const, text: '취소' },
+                style: 'danger' as const,
+                action_id: `consultation:cancel:${c.eventId}`,
+                confirm: {
+                  title: { type: 'plain_text' as const, text: '상담 취소' },
+                  text: { type: 'mrkdwn' as const, text: `*${c.summary}* 예약을 취소할까요?\n교수님께 취소 알림이 전송됩니다.` },
+                  confirm: { type: 'plain_text' as const, text: '취소하기' },
+                  deny: { type: 'plain_text' as const, text: '돌아가기' },
+                  style: 'danger' as const,
+                },
+              },
+            ],
+          },
+          { type: 'divider' },
+        );
       }
     }
 

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -133,7 +133,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '스터디룸 일정을 확인하고 *예약* 할 수 있어요. 내 예약을 확인하고 *수정·취소* 도 가능해요.',
+              text: '스터디룸 예약, 교수 상담 예약이 가능해요. 내 예약 현황도 여기서 확인할 수 있어요.',
             },
           ],
         },
@@ -142,13 +142,18 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '예약하기' },
+              text: { type: 'plain_text', text: '스터디룸 예약' },
               style: 'primary',
               action_id: 'home:open-booking',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '예약 수정' },
+              text: { type: 'plain_text', text: '교수 상담 예약' },
+              action_id: 'home:open-professor-booking-pages',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '내 예약' },
               action_id: 'home:open-my-bookings',
             },
           ],
@@ -395,7 +400,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '스터디룸을 *예약* 하거나 *생성·수정* 할 수 있어요. 내 예약을 확인하고 *수정·취소* 도 가능해요.',
+              text: '스터디룸 예약, 교수 상담 예약이 가능해요. 내 예약 현황도 여기서 확인할 수 있어요.',
             },
           ],
         },
@@ -404,13 +409,18 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '예약하기' },
+              text: { type: 'plain_text', text: '스터디룸 예약' },
               style: 'primary',
               action_id: 'home:open-booking',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '예약 수정' },
+              text: { type: 'plain_text', text: '교수 상담 예약' },
+              action_id: 'home:open-professor-booking-pages',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '내 예약' },
               action_id: 'home:open-my-bookings',
             },
             {


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 교수 상담 예약을 위한 Google Calendar 예약 페이지 입력 공간 추가
- 내 예약에서 상담 예약 일정 표시

## 주요 변경 사항

### Resource 엔티티 변경
- resource 엔티티에 bookingUrl 필드 추가 및 마이그레이션

### 교수 예약 페이지
- 교수 예약 페이지 목록 모달 추가 (bookingUrl 등록된 교수만 표시)
- 관리자 수정 모달에 bookingUrl 입력 필드 및 Google Calendar 가이드 링크 추가

### 내 예약
- 내 예약 모달에 교수 상담 예약 섹션 추가
- 유저 토큰으로 primary 캘린더 조회하여 예약 페이지 이벤트 식별
  (goo.createdBySet=default_cita 기반 필터링)
- 상담 취소 시 sendUpdates=all로 교수에게 취소 알림 자동 발송
- 취소 후 내 예약 모달 즉시 갱신

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

<img width="1042" height="934" alt="CleanShot 2026-04-26 at 23 15 23@2x" src="https://github.com/user-attachments/assets/f6383af3-7ee4-4b70-998d-c1bdea138b70" />
