### PR TITLE
refactor: 홈 탭 UI 개편

### DIFF
--- a/src/resource/resource.view.ts
+++ b/src/resource/resource.view.ts
@@ -376,7 +376,7 @@ export class ResourceView {
     if (consultations.length > 0) {
       blocks.push({
         type: 'header',
-        text: { type: 'plain_text', text: '👨‍🏫 교수 상담 예약', emoji: true },
+        text: { type: 'plain_text', text: '💬 교수 상담 예약', emoji: true },
       });
       for (const c of consultations) {
         const start = toKST(c.startTime);
@@ -400,7 +400,10 @@ export class ResourceView {
                 ? [
                     {
                       type: 'button' as const,
-                      text: { type: 'plain_text' as const, text: '캘린더에서 보기 ❐' },
+                      text: {
+                        type: 'plain_text' as const,
+                        text: '캘린더에서 보기 ❐',
+                      },
                       url: c.htmlLink,
                       action_id: `consultation:view-${start.getTime()}`,
                     },
@@ -413,7 +416,10 @@ export class ResourceView {
                 action_id: `consultation:cancel:${c.eventId}`,
                 confirm: {
                   title: { type: 'plain_text' as const, text: '상담 취소' },
-                  text: { type: 'mrkdwn' as const, text: `*${c.summary}* 예약을 취소할까요?\n교수님께 취소 알림이 전송됩니다.` },
+                  text: {
+                    type: 'mrkdwn' as const,
+                    text: `*${c.summary}* 예약을 취소할까요?\n교수님께 취소 알림이 전송됩니다.`,
+                  },
                   confirm: { type: 'plain_text' as const, text: '취소하기' },
                   deny: { type: 'plain_text' as const, text: '돌아가기' },
                   style: 'danger' as const,

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -102,23 +102,23 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '과목 시간표' },
+              text: { type: 'plain_text', text: '과목별' },
               style: 'primary',
               action_id: 'home:open-subscribe',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '교수 시간표' },
+              text: { type: 'plain_text', text: '교수별' },
               action_id: 'home:open-professor-schedule',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '교실 시간표' },
+              text: { type: 'plain_text', text: '교실별' },
               action_id: 'home:open-classroom-schedule',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '태그 시간표' },
+              text: { type: 'plain_text', text: '태그별' },
               action_id: 'home:open-tag-schedule',
             },
           ],
@@ -126,7 +126,7 @@ export class HomeView {
         { type: 'divider' },
         {
           type: 'header',
-          text: { type: 'plain_text', text: '📚 스터디룸', emoji: true },
+          text: { type: 'plain_text', text: '📋 예약', emoji: true },
         },
         {
           type: 'context',
@@ -142,13 +142,14 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '스터디룸 예약' },
+              text: { type: 'plain_text', text: '스터디룸' },
               style: 'primary',
               action_id: 'home:open-booking',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '교수 상담 예약' },
+              text: { type: 'plain_text', text: '교수 상담' },
+              style: 'primary',
               action_id: 'home:open-professor-booking-pages',
             },
             {
@@ -224,7 +225,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '시간표를 *구독* 하거나 *생성·수정* 할 수 있어요. 교실별/태그별 일정도 모아볼 수 있어요.',
+              text: '수업 일정을 조회하거나 구독할 수 있어요. 교수/교실/태그별로 시간표를 모아볼 수 있어요.',
             },
           ],
         },
@@ -233,35 +234,60 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '과목 시간표' },
+              text: { type: 'plain_text', text: '과목별' },
               style: 'primary',
               action_id: 'home:open-subscribe',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '교수 시간표' },
+              text: { type: 'plain_text', text: '교수별' },
               action_id: 'home:open-professor-schedule',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '교실 시간표' },
+              text: { type: 'plain_text', text: '교실별' },
               action_id: 'home:open-classroom-schedule',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '태그 시간표' },
+              text: { type: 'plain_text', text: '태그별' },
               action_id: 'home:open-tag-schedule',
             },
+          ],
+        },
+        { type: 'divider' },
+        {
+          type: 'header',
+          text: { type: 'plain_text', text: '📋 예약', emoji: true },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: '스터디룸 예약, 교수 상담 예약이 가능해요. 내 예약 현황도 여기서 확인할 수 있어요.',
+            },
+          ],
+        },
+        {
+          type: 'actions',
+          elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '생성' },
+              text: { type: 'plain_text', text: '스터디룸' },
               style: 'primary',
-              action_id: 'home:open-create-schedule',
+              action_id: 'home:open-booking',
             },
             {
               type: 'button',
-              text: { type: 'plain_text', text: '수정' },
-              action_id: 'home:open-schedule-list',
+              text: { type: 'plain_text', text: '교수 상담' },
+              style: 'primary',
+              action_id: 'home:open-professor-booking-pages',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '내 예약' },
+              action_id: 'home:open-my-bookings',
             },
           ],
         },
@@ -275,7 +301,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '반복 수업 일정을 *생성* 하거나 *수정·삭제* 할 수 있어요.',
+              text: '과목 캘린더에 반복 수업 일정을 *생성* 하거나 *수정·삭제* 할 수 있어요.',
             },
           ],
         },
@@ -304,6 +330,47 @@ export class HomeView {
         { type: 'divider' },
         {
           type: 'header',
+          text: { type: 'plain_text', text: '🗂️ 캘린더 관리', emoji: true },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: '과목 시간표와 스터디룸·교수 캘린더를 *생성·관리* 할 수 있어요.',
+            },
+          ],
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '과목 생성' },
+              style: 'primary',
+              action_id: 'home:open-create-schedule',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '과목 목록' },
+              action_id: 'home:open-schedule-list',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '리소스 생성' },
+              style: 'primary',
+              action_id: 'home:open-create-study-room',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '리소스 목록' },
+              action_id: 'home:open-study-room-manage',
+            },
+          ],
+        },
+        { type: 'divider' },
+        {
+          type: 'header',
           text: { type: 'plain_text', text: '👥 유저 관리', emoji: true },
         },
         {
@@ -320,7 +387,7 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '유저 관리' },
+              text: { type: 'plain_text', text: '유저 목록' },
               action_id: 'home:open-user-management',
             },
             {
@@ -340,7 +407,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '반을 *생성* 하거나 목록을 *조회·관리* 할 수 있어요.',
+              text: '반을 *생성* 하거나 목록에서 *관리* 할 수 있어요.',
             },
           ],
         },
@@ -370,7 +437,7 @@ export class HomeView {
           elements: [
             {
               type: 'mrkdwn',
-              text: '시간표 분류에 사용할 태그를 *조회* 하고 *생성* 할 수 있어요.',
+              text: '시간표 분류에 사용할 태그를 *생성* 하거나 목록에서 *관리* 할 수 있어요.',
             },
           ],
         },
@@ -387,52 +454,6 @@ export class HomeView {
               type: 'button',
               text: { type: 'plain_text', text: '태그 목록' },
               action_id: 'home:open-tags',
-            },
-          ],
-        },
-        { type: 'divider' },
-        {
-          type: 'header',
-          text: { type: 'plain_text', text: '🏠 스터디룸', emoji: true },
-        },
-        {
-          type: 'context',
-          elements: [
-            {
-              type: 'mrkdwn',
-              text: '스터디룸 예약, 교수 상담 예약이 가능해요. 내 예약 현황도 여기서 확인할 수 있어요.',
-            },
-          ],
-        },
-        {
-          type: 'actions',
-          elements: [
-            {
-              type: 'button',
-              text: { type: 'plain_text', text: '스터디룸 예약' },
-              style: 'primary',
-              action_id: 'home:open-booking',
-            },
-            {
-              type: 'button',
-              text: { type: 'plain_text', text: '교수 상담 예약' },
-              action_id: 'home:open-professor-booking-pages',
-            },
-            {
-              type: 'button',
-              text: { type: 'plain_text', text: '내 예약' },
-              action_id: 'home:open-my-bookings',
-            },
-            {
-              type: 'button',
-              text: { type: 'plain_text', text: '생성' },
-              style: 'primary',
-              action_id: 'home:open-create-study-room',
-            },
-            {
-              type: 'button',
-              text: { type: 'plain_text', text: '수정' },
-              action_id: 'home:open-study-room-manage',
             },
           ],
         },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 기능 추가에 따른 홈 탭 UI 변경

## 주요 변경 사항

### 슬랙 홈
- 시간표 버튼 레이블 단축 (과목 시간표 → 과목별 등)
- 스터디룸 섹션을 예약 섹션으로 통합·개편
- 관리자 홈에 🗂️ 캘린더 관리 섹션 신설 (과목/리소스 생성·목록)
- 관리자 섹션 순서 재조정 (예약 → 반복일정 → 캘린더 관리 → 유저/반/태그)
- 교수 상담 예약 모달 헤더 이모지 변경 (👨‍🏫 → 💬)

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

학생
<img width="1304" height="764" alt="CleanShot 2026-04-27 at 01 58 16@2x" src="https://github.com/user-attachments/assets/c48f3dfe-b1ab-438b-928f-957b745728a9" />

관리자
<img width="717" height="1008" alt="CleanShot 2026-04-27 at 01 59 05" src="https://github.com/user-attachments/assets/064ef1e6-c7ff-495a-9e72-50867eb9afb8" />
