### PR TITLE
fix: 유저 코드 NOT NULL 제약 제거 (OAuth 가입 실패 수정)

### DIFF
--- a/src/migrations/1776800000001-RemoveNotNullFromUserCode.ts
+++ b/src/migrations/1776800000001-RemoveNotNullFromUserCode.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveNotNullFromUserCode1776800000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "code" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "code" SET NOT NULL`,
+    );
+  }
+}

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -38,7 +38,7 @@ export class User {
   @Column()
   name: string;
 
-  @Column({ unique: true })
+  @Column({ nullable: true, unique: true })
   code: string;
 
   @Column({


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- code는 가입 신청 시 입력되므로 초기 OAuth 로그인 후 임시 유저 생성 시 null 허용 필요
- user.code 컬럼 nullable: true 복원 (unique는 유지)
- 마이그레이션 추가: ALTER COLUMN code DROP NOT NULL

## 주요 변경 사항

### 항목

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] 로컬에서 로그인 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
