### PR TITLE
fix: 일정 보기 버튼 ack 중복 호출 수정

### DIFF
--- a/src/resource/resource.controller.ts
+++ b/src/resource/resource.controller.ts
@@ -441,7 +441,7 @@ export class ResourceController {
   }
 
   // URL 링크 버튼 — Slack 경고 방지용 ack
-  @Action(/^space:action:view-|^study-room:action:view-calendar$|^professor:booking:|^consultation:view-/)
+  @Action(/^space:action:view-|^professor:booking:|^consultation:view-/)
   async ackViewLinkButtons({
     ack,
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- study-room:action:view-calendar가 app.controller와 resource.controller 양쪽 핸들러에 매칭되어 ack가 두 번 호출되는 문제 수정
- resource.controller 정규식에서 중복 패턴 제거


## 주요 변경 사항

### 항목

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [ ] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
