### PR TITLE
style: 시간표 섹션 '과목별' 버튼 레이블을 '과목 구독'으로 변경

### DIFF
--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -102,7 +102,7 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '과목별' },
+              text: { type: 'plain_text', text: '과목 구독' },
               style: 'primary',
               action_id: 'home:open-subscribe',
             },
@@ -234,7 +234,7 @@ export class HomeView {
           elements: [
             {
               type: 'button',
-              text: { type: 'plain_text', text: '과목별' },
+              text: { type: 'plain_text', text: '과목 구독' },
               style: 'primary',
               action_id: 'home:open-subscribe',
             },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 유저가 `과목별`일 경우 단순히 다른 `교수별`, `교실별` 등의 모달과 동일한 역할을 한다고 생각하여 누르지 않는다고 생각

## 주요 변경 사항

### 홈 탭 버튼 변경
- `과목별` -> `과목 구독`

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
