### PR TITLE
feat: 시간표 알림 무음 토글 기능 추가

### DIFF
--- a/src/schedule/schedule-notification.service.ts
+++ b/src/schedule/schedule-notification.service.ts
@@ -25,10 +25,13 @@ export interface DebounceEntry {
 }
 
 const DEBOUNCE_KEY_PREFIX = 'calendar:debounce:';
+const MUTE_KEY_PREFIX = 'calendar:mute:';
 const DEBOUNCE_MS = 10 * 60 * 1000;
+const MUTE_TTL_MS = 30 * 60 * 1000;
 const ENTRY_TTL_MS = 60 * 60 * 1000; // 1시간 안전 TTL
 
 const pendingKey = (key: string) => `${DEBOUNCE_KEY_PREFIX}${key}`;
+const muteKey = (scheduleId: number) => `${MUTE_KEY_PREFIX}${scheduleId}`;
 
 @Injectable()
 export class ScheduleNotificationService {
@@ -113,6 +116,11 @@ export class ScheduleNotificationService {
       return;
     }
 
+    if (await this.isMuted(entry.scheduleId)) {
+      this.logger.log(`Notification suppressed (muted): ${key}`);
+      return;
+    }
+
     const slackChannelIds = await this.channelService.getSlackChannelIds(
       entry.scheduleId,
     );
@@ -165,6 +173,27 @@ export class ScheduleNotificationService {
     } catch {
       return undefined;
     }
+  }
+
+  async mute(scheduleId: number): Promise<void> {
+    await this.cache.set(muteKey(scheduleId), true, MUTE_TTL_MS);
+    this.logger.log(`Schedule ${scheduleId} muted`);
+  }
+
+  async unmute(scheduleId: number): Promise<void> {
+    await this.cache.del(muteKey(scheduleId));
+    this.logger.log(`Schedule ${scheduleId} unmuted`);
+  }
+
+  async isMuted(scheduleId: number): Promise<boolean> {
+    return (await this.cache.get<boolean>(muteKey(scheduleId))) === true;
+  }
+
+  async getMutedSet(scheduleIds: number[]): Promise<Set<number>> {
+    const results = await Promise.all(
+      scheduleIds.map(async (id) => ({ id, muted: await this.isMuted(id) })),
+    );
+    return new Set(results.filter((r) => r.muted).map((r) => r.id));
   }
 
   // 외부에서 현재 대기 entry 조회 (컨트롤러에서 중복 확인용)

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -15,6 +15,7 @@ import { ChannelService } from '../channel/channel.service';
 import { UserStatus, User } from '../user/user.entity';
 import { PermissionService } from '../user/permission.service';
 import { GoogleCalendarService } from '../google/google-calendar.service';
+import { ScheduleNotificationService } from './schedule-notification.service';
 
 const CALENDAR_COLORS = [
   '%234285F4',
@@ -43,6 +44,7 @@ export class ScheduleController {
     private readonly channelService: ChannelService,
     private readonly permissionService: PermissionService,
     private readonly googleCalendarService: GoogleCalendarService,
+    private readonly scheduleNotificationService: ScheduleNotificationService,
   ) {}
 
   // 활성 사용자 확인 헬퍼
@@ -84,37 +86,40 @@ export class ScheduleController {
 
     const displayTagMap = new Map(displayTags.map((t) => [t.id, t.name]));
 
-    const schedulesWithMeta = await Promise.all(
-      schedules.map(async (s) => {
-        const [channels, acl] = await Promise.all([
-          this.channelService.getSlackChannelIds(s.id),
-          this.googleCalendarService
-            .getCalendarAcl(s.calendarId)
-            .catch(() => []),
-        ]);
+    const [schedulesWithMeta, mutedScheduleIds] = await Promise.all([
+      Promise.all(
+        schedules.map(async (s) => {
+          const [channels, acl] = await Promise.all([
+            this.channelService.getSlackChannelIds(s.id),
+            this.googleCalendarService
+              .getCalendarAcl(s.calendarId)
+              .catch(() => []),
+          ]);
 
-        const writerEmails = acl
-          .filter((e) => e.role === 'writer' || e.role === 'owner')
-          .map((e) => e.email);
-        const writers =
-          await this.userService.mapEmailsToSlackIds(writerEmails);
+          const writerEmails = acl
+            .filter((e) => e.role === 'writer' || e.role === 'owner')
+            .map((e) => e.email);
+          const writers =
+            await this.userService.mapEmailsToSlackIds(writerEmails);
 
-        return {
-          id: s.id,
-          name: s.name,
-          description: s.description,
-          status: s.status,
-          tags: s.tags.map((t) => ({
-            id: t.id,
-            name: displayTagMap.get(t.id) ?? t.name,
-          })),
-          createdBy: { name: s.createdBy?.name ?? '알 수 없음' },
-          channels,
-          writers,
-          createdAt: s.createdAt,
-        };
-      }),
-    );
+          return {
+            id: s.id,
+            name: s.name,
+            description: s.description,
+            status: s.status,
+            tags: s.tags.map((t) => ({
+              id: t.id,
+              name: displayTagMap.get(t.id) ?? t.name,
+            })),
+            createdBy: { name: s.createdBy?.name ?? '알 수 없음' },
+            channels,
+            writers,
+            createdAt: s.createdAt,
+          };
+        }),
+      ),
+      this.scheduleNotificationService.getMutedSet(schedules.map((s) => s.id)),
+    ]);
 
     return ScheduleView.listModal(schedulesWithMeta, displayTags, {
       page: safePage,
@@ -122,6 +127,7 @@ export class ScheduleController {
       total,
       selectedStatus: status,
       selectedTagIds: tagIds,
+      mutedScheduleIds,
     });
   }
 
@@ -510,6 +516,48 @@ export class ScheduleController {
   }
 
   // 삭제 버튼 → 확인 모달 열기
+  @Action(/^schedule:list:mute:/)
+  async handleMute({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    await this.scheduleNotificationService.mute(scheduleId);
+
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: await this.buildListModal(0, 'all', []),
+      });
+    }
+  }
+
+  @Action(/^schedule:list:unmute:/)
+  async handleUnmute({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    await this.scheduleNotificationService.unmute(scheduleId);
+
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: await this.buildListModal(0, 'all', []),
+      });
+    }
+  }
+
   @Action(/^schedule:list:delete:/)
   async handleOpenDelete({
     ack,

--- a/src/schedule/schedule.view.ts
+++ b/src/schedule/schedule.view.ts
@@ -60,9 +60,10 @@ export class ScheduleView {
       total: number;
       selectedStatus?: string;
       selectedTagIds?: number[];
+      mutedScheduleIds?: Set<number>;
     },
   ): View {
-    const { page, totalPages, total, selectedStatus, selectedTagIds } = meta;
+    const { page, totalPages, total, selectedStatus, selectedTagIds, mutedScheduleIds = new Set() } = meta;
 
     const tagOptions = tags.map((t) => ({
       text: {
@@ -178,6 +179,17 @@ export class ScheduleView {
               action_id: `schedule:list:toggle:${schedule.id}`,
               value: toggleValue,
             },
+            mutedScheduleIds.has(schedule.id)
+              ? {
+                  type: 'button',
+                  text: { type: 'plain_text', text: '🔔 알림 켜기' },
+                  action_id: `schedule:list:unmute:${schedule.id}`,
+                }
+              : {
+                  type: 'button',
+                  text: { type: 'plain_text', text: '🔕 알림 끄기 (30분)' },
+                  action_id: `schedule:list:mute:${schedule.id}`,
+                },
             {
               type: 'button',
               text: { type: 'plain_text', text: '삭제' },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 초기 설정, 휴일 휴강 처리 등 알림이 필요 없는 변경의 경우 알림을 보내지 않는 무음 설정이 필요

## 주요 변경 사항

### 과목별 알림 무음 토글 기능
- 시간표 목록에서 과목별로 알림을 30분간 끄거나 즉시 해제할 수 있는 토글 버튼 추가.
- Redis에 무음 상태 저장, 알림 발송 직전 체크하여 드랍.

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

<img width="1042" height="458" alt="CleanShot 2026-04-28 at 20 53 17@2x" src="https://github.com/user-attachments/assets/a6520ef2-f271-44fe-acb0-e828e3047419" />

