### PR TITLE
fix: 채널 선택 시 비공개 채널 포함되도록 변경

### DIFF
--- a/src/schedule/schedule.view.ts
+++ b/src/schedule/schedule.view.ts
@@ -63,7 +63,14 @@ export class ScheduleView {
       mutedScheduleIds?: Set<number>;
     },
   ): View {
-    const { page, totalPages, total, selectedStatus, selectedTagIds, mutedScheduleIds = new Set() } = meta;
+    const {
+      page,
+      totalPages,
+      total,
+      selectedStatus,
+      selectedTagIds,
+      mutedScheduleIds = new Set(),
+    } = meta;
 
     const tagOptions = tags.map((t) => ({
       text: {
@@ -318,11 +325,12 @@ export class ScheduleView {
         block_id: 'notification_channels_block',
         optional: true,
         element: {
-          type: 'multi_channels_select',
+          type: 'multi_conversations_select',
           action_id: 'channels_select',
           placeholder: { type: 'plain_text', text: '알림 받을 채널 선택' },
+          filter: { include: ['public', 'private'] },
           ...(notificationChannelIds.length > 0
-            ? { initial_channels: notificationChannelIds }
+            ? { initial_conversations: notificationChannelIds }
             : {}),
         },
         label: { type: 'plain_text', text: '알림 채널' },

--- a/src/student-class/student-class.view.ts
+++ b/src/student-class/student-class.view.ts
@@ -143,7 +143,7 @@ export class StudentClassView {
             type: 'conversations_select',
             action_id: 'slack_channel_input',
             placeholder: { type: 'plain_text', text: '채널을 선택하세요' },
-            filter: { include: ['public'], exclude_bot_users: true },
+            filter: { include: ['public', 'private'] },
             ...(prefill.slackChannelId
               ? { initial_conversation: prefill.slackChannelId }
               : {}),


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 학과 워크스페이스의 반별 채널의 경우 private 채널이기에 해당 채널 선택을 위한 수정

## 주요 변경 사항

### 채널 선택 섹션 수정
- 반 편집, 시간표 알림 채널 설정에서 private 채널이 표시되지 않던 문제 수정.
- multi_channels_select → multi_conversations_select로 교체.

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] 로컬에서 비공개 채널 선택 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
