### PR TITLE
feat: 반복 일정 작업 시 자동 무음 처리 및 수동/자동 뮤트 키 분리

### DIFF
--- a/src/schedule/schedule-notification.service.ts
+++ b/src/schedule/schedule-notification.service.ts
@@ -25,13 +25,15 @@ export interface DebounceEntry {
 }
 
 const DEBOUNCE_KEY_PREFIX = 'calendar:debounce:';
-const MUTE_KEY_PREFIX = 'calendar:mute:';
+const MANUAL_MUTE_PREFIX = 'calendar:mute:manual:';
+const AUTO_MUTE_PREFIX = 'calendar:mute:auto:';
 const DEBOUNCE_MS = 10 * 60 * 1000;
 const MUTE_TTL_MS = 30 * 60 * 1000;
 const ENTRY_TTL_MS = 60 * 60 * 1000; // 1시간 안전 TTL
 
 const pendingKey = (key: string) => `${DEBOUNCE_KEY_PREFIX}${key}`;
-const muteKey = (scheduleId: number) => `${MUTE_KEY_PREFIX}${scheduleId}`;
+const manualMuteKey = (scheduleId: number) => `${MANUAL_MUTE_PREFIX}${scheduleId}`;
+const autoMuteKey = (scheduleId: number) => `${AUTO_MUTE_PREFIX}${scheduleId}`;
 
 @Injectable()
 export class ScheduleNotificationService {
@@ -175,23 +177,44 @@ export class ScheduleNotificationService {
     }
   }
 
+  // 수동 토글 — 30분 TTL, 수동 해제 가능
   async mute(scheduleId: number): Promise<void> {
-    await this.cache.set(muteKey(scheduleId), true, MUTE_TTL_MS);
-    this.logger.log(`Schedule ${scheduleId} muted`);
+    await this.cache.set(manualMuteKey(scheduleId), true, MUTE_TTL_MS);
+    this.logger.log(`Schedule ${scheduleId} manually muted`);
   }
 
   async unmute(scheduleId: number): Promise<void> {
-    await this.cache.del(muteKey(scheduleId));
-    this.logger.log(`Schedule ${scheduleId} unmuted`);
+    await this.cache.del(manualMuteKey(scheduleId));
+    this.logger.log(`Schedule ${scheduleId} manually unmuted`);
   }
 
+  // 반복 일정 작업 시 자동 무음 — 30분 TTL, 자동 만료
+  async autoMute(scheduleId: number): Promise<void> {
+    await this.cache.set(autoMuteKey(scheduleId), true, MUTE_TTL_MS);
+    this.logger.log(`Schedule ${scheduleId} auto-muted`);
+  }
+
+  // 수동 무음 여부만 (토글 버튼 상태용)
+  async isManuallyMuted(scheduleId: number): Promise<boolean> {
+    return (await this.cache.get<boolean>(manualMuteKey(scheduleId))) === true;
+  }
+
+  // 수동 또는 자동 무음 여부 (알림 발송 차단용)
   async isMuted(scheduleId: number): Promise<boolean> {
-    return (await this.cache.get<boolean>(muteKey(scheduleId))) === true;
+    const [manual, auto] = await Promise.all([
+      this.cache.get<boolean>(manualMuteKey(scheduleId)),
+      this.cache.get<boolean>(autoMuteKey(scheduleId)),
+    ]);
+    return manual === true || auto === true;
   }
 
+  // 토글 버튼 상태 표시용 — 수동 무음만 반영
   async getMutedSet(scheduleIds: number[]): Promise<Set<number>> {
     const results = await Promise.all(
-      scheduleIds.map(async (id) => ({ id, muted: await this.isMuted(id) })),
+      scheduleIds.map(async (id) => ({
+        id,
+        muted: await this.isManuallyMuted(id),
+      })),
     );
     return new Set(results.filter((r) => r.muted).map((r) => r.id));
   }

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -14,6 +14,7 @@ import { WebClient } from '@slack/web-api';
 import { KnownBlock } from '@slack/web-api';
 import { randomUUID } from 'crypto';
 import { RRule, Weekday } from 'rrule';
+import { ScheduleNotificationService } from './schedule-notification.service';
 
 export interface CreateScheduleDto {
   name: string;
@@ -72,6 +73,7 @@ export class ScheduleService {
     private readonly channelService: ChannelService,
     private readonly googleCalendarService: GoogleCalendarService,
     private readonly userService: UserService,
+    private readonly scheduleNotificationService: ScheduleNotificationService,
   ) {}
 
   // 스케줄 생성 (Google Calendar도 함께 생성)
@@ -586,11 +588,13 @@ export class ScheduleService {
       recurrenceType: dto.recurrenceType,
     });
 
-    // 5. Slack 채널에 요약 알림 직접 발송
+    // 5. Slack 채널에 요약 알림 직접 발송 (웹훅 알림 차단용 auto-mute 선행)
+    await this.scheduleNotificationService.autoMute(dto.scheduleId);
+
     const slackChannelIds = await this.channelService.getSlackChannelIds(
       dto.scheduleId,
     );
-    if (slackChannelIds.length > 0) {
+    if (slackChannelIds.length > 0 && !(await this.scheduleNotificationService.isManuallyMuted(dto.scheduleId))) {
       const writerDisplay = await this.resolveWriterDisplay(
         schedule.calendarId,
       );
@@ -723,6 +727,8 @@ export class ScheduleService {
       await this.recurrenceGroupRepository.softDelete({ id: groupDbId });
     }
 
+    await this.scheduleNotificationService.autoMute(group.scheduleId);
+
     const slackChannelIds = await this.channelService.getSlackChannelIds(
       group.scheduleId,
     );
@@ -730,24 +736,26 @@ export class ScheduleService {
     const executorDisplay = executorSlackId
       ? `<@${executorSlackId}>`
       : '알 수 없음';
-    await Promise.allSettled(
-      slackChannelIds.map((channel) =>
-        this.slack.chat.postMessage({
-          channel,
-          text: `🗑️ ${schedule.name} 반복 일정 삭제 안내`,
-          blocks: buildRecurringDeleteBlocks(
-            schedule.name,
-            group,
-            scope,
-            filterOriginal,
-            deletedCount,
-            events.length,
-            executorDisplay,
-            writerDisplay,
-          ),
-        }),
-      ),
-    );
+    if (!(await this.scheduleNotificationService.isManuallyMuted(group.scheduleId))) {
+      await Promise.allSettled(
+        slackChannelIds.map((channel) =>
+          this.slack.chat.postMessage({
+            channel,
+            text: `🗑️ ${schedule.name} 반복 일정 삭제 안내`,
+            blocks: buildRecurringDeleteBlocks(
+              schedule.name,
+              group,
+              scope,
+              filterOriginal,
+              deletedCount,
+              events.length,
+              executorDisplay,
+              writerDisplay,
+            ),
+          }),
+        ),
+      );
+    }
 
     this.logger.log(
       `Recurring group deleted: groupId=${group.groupId}, scope=${scope}, deleted=${deletedCount}/${events.length}`,
@@ -894,6 +902,8 @@ export class ScheduleService {
       );
     }
 
+    await this.scheduleNotificationService.autoMute(group.scheduleId);
+
     const slackChannelIds = await this.channelService.getSlackChannelIds(
       group.scheduleId,
     );
@@ -901,24 +911,27 @@ export class ScheduleService {
     const executorDisplay = executorSlackId
       ? `<@${executorSlackId}>`
       : '알 수 없음';
-    await Promise.allSettled(
-      slackChannelIds.map((channel) =>
-        this.slack.chat.postMessage({
-          channel,
-          text: `🔄 ${schedule.name} 반복 일정 수정 안내`,
-          blocks: buildRecurringUpdateBlocks(
-            schedule.name,
-            group,
-            dto,
-            scope,
-            updatedCount,
-            events.length,
-            executorDisplay,
-            writerDisplay,
-          ),
-        }),
-      ),
-    );
+
+    if (!(await this.scheduleNotificationService.isManuallyMuted(group.scheduleId))) {
+      await Promise.allSettled(
+        slackChannelIds.map((channel) =>
+          this.slack.chat.postMessage({
+            channel,
+            text: `🔄 ${schedule.name} 반복 일정 수정 안내`,
+            blocks: buildRecurringUpdateBlocks(
+              schedule.name,
+              group,
+              dto,
+              scope,
+              updatedCount,
+              events.length,
+              executorDisplay,
+              writerDisplay,
+            ),
+          }),
+        ),
+      );
+    }
 
     this.logger.log(
       `Recurring group updated: groupId=${group.groupId}, scope=${scope}, updated=${updatedCount}/${events.length}`,


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 초기 시간표 설정의 경우 채널에 알림을 보낼 필요가 없기 때문에 반복 일정 알림 무음 설정 기능 추가

## 주요 변경 사항

### 수동 무음 설정
- 수동(manual)과 자동(auto) 뮤트를 별도 Redis 키로 분리하여 충돌 방지
- 반복 일정 생성·수정·삭제 시 autoMute(30분) 자동 적용
- 수동 뮤트 상태일 때 반복 일정 작업 알림도 함께 차단
- 토글 버튼 상태는 isManuallyMuted 기준으로만 표시

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
