### PR TITLE
chore: 교수별·교실별 시간표 모달 상단에 임시 안내 문구 추가

### DIFF
--- a/src/resource/resource.view.ts
+++ b/src/resource/resource.view.ts
@@ -841,7 +841,17 @@ export class ResourceView {
           '&ctz=Asia%2FSeoul&mode=WEEK'
         : undefined;
 
-    const blocks: View['blocks'] = [];
+    const blocks: View['blocks'] = [
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: '⚠️ 로직 변경으로 현재 일부 일정이 정확하지 않을 수 있습니다. \n빠른 시일 내에 수정하겠습니다.',
+          },
+        ],
+      },
+    ];
 
     if (combinedCalendarUrl) {
       blocks.push({
@@ -909,7 +919,17 @@ export class ResourceView {
           '&ctz=Asia%2FSeoul&mode=WEEK'
         : undefined;
 
-    const blocks: View['blocks'] = [];
+    const blocks: View['blocks'] = [
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: '⚠️ 로직 변경으로 현재 일부 일정이 정확하지 않을 수 있습니다. \n빠른 시일 내에 수정하겠습니다.',
+          },
+        ],
+      },
+    ];
 
     if (combinedCalendarUrl) {
       blocks.push({


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 복수 장소 및 복수 교수 설정 기능 추가로 인해 기존 로직의 작동이 정확하지 않음을 확인
- Google Calendar의 limit 제한도 영향이 있는것으로 추측

## 주요 변경 사항

### 교수별/교실별 모달 안내 추가
- 로직 변경으로 일부 일정이 부정확할 수 있음을 사용자에게 안내

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
