### PR TITLE
Feat/class rep

### DIFF
--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -1257,4 +1257,324 @@ export class ScheduleController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
   }
+
+  // ========== 반 대표 과목 관리 ==========
+
+  private async buildClassRepListModal(slackUserId: string) {
+    const schedules =
+      await this.scheduleService.findSchedulesByClassRepSlackId(slackUserId);
+    const scheduleIds = schedules.map((s) => s.id);
+    const [channelMap, mutedSet] = await Promise.all([
+      Promise.all(
+        scheduleIds.map(async (id) => ({
+          id,
+          channels: await this.channelService.getSlackChannelIds(id),
+        })),
+      ),
+      this.scheduleNotificationService.getMutedSet(scheduleIds),
+    ]);
+    const channelsById = Object.fromEntries(
+      channelMap.map(({ id, channels }) => [id, channels]),
+    );
+
+    return ScheduleView.classRepScheduleListModal(
+      schedules.map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description,
+        channels: channelsById[s.id] ?? [],
+      })),
+      mutedSet,
+    );
+  }
+
+  @Action('home:open-class-rep-schedules')
+  async openClassRepSchedules({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: await this.buildClassRepListModal(body.user.id),
+    });
+  }
+
+  @Action(/^schedule:class-rep:edit:/)
+  async classRepOpenEdit({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    const authorized =
+      await this.scheduleService.isClassRepAuthorizedForSchedule(
+        body.user.id,
+        scheduleId,
+      );
+    if (!authorized) return;
+
+    const [schedule, notifChannelIds] = await Promise.all([
+      this.scheduleService.findById(scheduleId),
+      this.channelService.getSlackChannelIds(scheduleId),
+    ]);
+    if (!schedule) return;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: ScheduleView.classRepEditModal(
+        {
+          id: schedule.id,
+          name: schedule.name,
+          description: schedule.description,
+        },
+        notifChannelIds,
+      ),
+    });
+  }
+
+  @View('schedule:modal:class-rep:edit')
+  async classRepHandleEdit({
+    ack,
+    body,
+    view,
+    client,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const scheduleId = parseInt(view.private_metadata, 10);
+    const values = view.state.values;
+
+    const authorized =
+      await this.scheduleService.isClassRepAuthorizedForSchedule(
+        body.user.id,
+        scheduleId,
+      );
+    if (!authorized) {
+      await ack({ response_action: 'errors', errors: {} });
+      return;
+    }
+
+    const name = values.name_block.name_input.value?.trim() ?? '';
+    const description =
+      values.description_block.description_input.value?.trim() || undefined;
+    const channelIds =
+      values.notification_channels_block.channels_select
+        .selected_conversations ?? [];
+
+    if (!name) {
+      await ack({
+        response_action: 'errors',
+        errors: { name_block: '과목명을 입력해주세요.' },
+      });
+      return;
+    }
+
+    await ack();
+
+    await this.scheduleService.updateSchedule(scheduleId, {
+      name,
+      description,
+    });
+    await this.channelService.setScheduleChannels(scheduleId, channelIds);
+
+    if (body.view?.root_view_id) {
+      await client.views.update({
+        view_id: body.view.root_view_id,
+        view: await this.buildClassRepListModal(body.user.id),
+      });
+    }
+  }
+
+  @Action(/^schedule:class-rep:mute:/)
+  async classRepHandleMute({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    const authorized =
+      await this.scheduleService.isClassRepAuthorizedForSchedule(
+        body.user.id,
+        scheduleId,
+      );
+    if (!authorized) return;
+
+    await this.scheduleNotificationService.mute(scheduleId);
+
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: await this.buildClassRepListModal(body.user.id),
+      });
+    }
+  }
+
+  @Action(/^schedule:class-rep:unmute:/)
+  async classRepHandleUnmute({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    const authorized =
+      await this.scheduleService.isClassRepAuthorizedForSchedule(
+        body.user.id,
+        scheduleId,
+      );
+    if (!authorized) return;
+
+    await this.scheduleNotificationService.unmute(scheduleId);
+
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: await this.buildClassRepListModal(body.user.id),
+      });
+    }
+  }
+
+  @Action(/^schedule:class-rep:create-recurring:/)
+  async classRepOpenCreateRecurring({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    const authorized =
+      await this.scheduleService.isClassRepAuthorizedForSchedule(
+        body.user.id,
+        scheduleId,
+      );
+    if (!authorized) return;
+
+    const schedule = await this.scheduleService.findById(scheduleId);
+    if (!schedule) return;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: ScheduleView.createRecurringModal(
+        [{ id: schedule.id, name: schedule.name }],
+        schedule.id,
+      ),
+    });
+  }
+
+  @Action(/^schedule:class-rep:edit-recurring:/)
+  async classRepOpenEditRecurring({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    const authorized =
+      await this.scheduleService.isClassRepAuthorizedForSchedule(
+        body.user.id,
+        scheduleId,
+      );
+    if (!authorized) return;
+
+    const [schedule, groups] = await Promise.all([
+      this.scheduleService.findById(scheduleId),
+      this.scheduleService.findRecurrenceGroupsBySchedule(scheduleId),
+    ]);
+    if (!schedule) return;
+
+    if (groups.length === 0) {
+      await client.views.push({
+        trigger_id: body.trigger_id,
+        view: {
+          type: 'modal',
+          callback_id: 'noop',
+          title: { type: 'plain_text', text: '반복 일정 수정' },
+          close: { type: 'plain_text', text: '닫기' },
+          blocks: [
+            {
+              type: 'section',
+              text: { type: 'mrkdwn', text: '등록된 반복 일정이 없습니다.' },
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: ScheduleView.selectGroupForEditModal(
+        groups,
+        schedule.name,
+        scheduleId,
+      ),
+    });
+  }
+
+  @Action(/^schedule:class-rep:delete-recurring:/)
+  async classRepOpenDeleteRecurring({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { action_id: string };
+    const scheduleId = parseInt(action.action_id.split(':').pop()!, 10);
+
+    const authorized =
+      await this.scheduleService.isClassRepAuthorizedForSchedule(
+        body.user.id,
+        scheduleId,
+      );
+    if (!authorized) return;
+
+    const [schedule, groups] = await Promise.all([
+      this.scheduleService.findById(scheduleId),
+      this.scheduleService.findRecurrenceGroupsBySchedule(scheduleId),
+    ]);
+    if (!schedule) return;
+
+    if (groups.length === 0) {
+      await client.views.push({
+        trigger_id: body.trigger_id,
+        view: {
+          type: 'modal',
+          callback_id: 'noop',
+          title: { type: 'plain_text', text: '반복 일정 삭제' },
+          close: { type: 'plain_text', text: '닫기' },
+          blocks: [
+            {
+              type: 'section',
+              text: { type: 'mrkdwn', text: '등록된 반복 일정이 없습니다.' },
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: ScheduleView.deleteRecurringModal(groups, schedule.name),
+    });
+  }
 }

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -178,6 +178,44 @@ export class ScheduleService {
     });
   }
 
+  // 반 대표 슬랙 ID로 자기 반 태그가 달린 활성 스케줄 조회
+  async findSchedulesByClassRepSlackId(
+    slackUserId: string,
+  ): Promise<Schedule[]> {
+    const user = await this.userService.findBySlackIdWithClass(slackUserId);
+    if (!user?.studentClassId) return [];
+
+    const tag = await this.tagRepository.findOne({
+      where: { studentClassId: user.studentClassId },
+    });
+    if (!tag) return [];
+
+    return this.findActiveSchedulesByTagId(tag.id);
+  }
+
+  // 반 대표가 해당 과목에 대한 권한이 있는지 확인 (자기 반 태그 포함 여부)
+  async isClassRepAuthorizedForSchedule(
+    slackUserId: string,
+    scheduleId: number,
+  ): Promise<boolean> {
+    const user = await this.userService.findBySlackIdWithClass(slackUserId);
+    if (!user?.studentClassId) return false;
+
+    const tag = await this.tagRepository.findOne({
+      where: { studentClassId: user.studentClassId },
+    });
+    if (!tag) return false;
+
+    const count = await this.scheduleRepository
+      .createQueryBuilder('schedule')
+      .innerJoin('schedule.tags', 'tag')
+      .where('schedule.id = :scheduleId', { scheduleId })
+      .andWhere('tag.id = :tagId', { tagId: tag.id })
+      .getCount();
+
+    return count > 0;
+  }
+
   // 태그가 없는 활성 스케줄 목록 조회
   async findActiveSchedulesWithoutTags(): Promise<Schedule[]> {
     return this.scheduleRepository
@@ -594,7 +632,10 @@ export class ScheduleService {
     const slackChannelIds = await this.channelService.getSlackChannelIds(
       dto.scheduleId,
     );
-    if (slackChannelIds.length > 0 && !(await this.scheduleNotificationService.isManuallyMuted(dto.scheduleId))) {
+    if (
+      slackChannelIds.length > 0 &&
+      !(await this.scheduleNotificationService.isManuallyMuted(dto.scheduleId))
+    ) {
       const writerDisplay = await this.resolveWriterDisplay(
         schedule.calendarId,
       );
@@ -736,7 +777,11 @@ export class ScheduleService {
     const executorDisplay = executorSlackId
       ? `<@${executorSlackId}>`
       : '알 수 없음';
-    if (!(await this.scheduleNotificationService.isManuallyMuted(group.scheduleId))) {
+    if (
+      !(await this.scheduleNotificationService.isManuallyMuted(
+        group.scheduleId,
+      ))
+    ) {
       await Promise.allSettled(
         slackChannelIds.map((channel) =>
           this.slack.chat.postMessage({
@@ -912,7 +957,11 @@ export class ScheduleService {
       ? `<@${executorSlackId}>`
       : '알 수 없음';
 
-    if (!(await this.scheduleNotificationService.isManuallyMuted(group.scheduleId))) {
+    if (
+      !(await this.scheduleNotificationService.isManuallyMuted(
+        group.scheduleId,
+      ))
+    ) {
       await Promise.allSettled(
         slackChannelIds.map((channel) =>
           this.slack.chat.postMessage({
@@ -1219,8 +1268,9 @@ function buildRecurringUpdateBlocks(
   let professorText: string | null = null;
 
   if (locationChanged) {
-    const { room: beforeRoom, professor: beforeProfessor } =
-      parseLocationParts(group.location ?? '');
+    const { room: beforeRoom, professor: beforeProfessor } = parseLocationParts(
+      group.location ?? '',
+    );
 
     roomText =
       beforeRoom !== afterRoom

--- a/src/schedule/schedule.view.ts
+++ b/src/schedule/schedule.view.ts
@@ -254,6 +254,149 @@ export class ScheduleView {
     };
   }
 
+  // 반 대표 과목 목록 모달
+  static classRepScheduleListModal(
+    schedules: {
+      id: number;
+      name: string;
+      description?: string;
+      channels: string[];
+    }[],
+    mutedScheduleIds: Set<number> = new Set(),
+  ): View {
+    const blocks: View['blocks'] = [];
+
+    if (schedules.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '내 반 태그가 달린 과목이 없습니다.' },
+      });
+    } else {
+      for (const schedule of schedules) {
+        const channelText =
+          schedule.channels.length > 0
+            ? `\n알림 채널: ${schedule.channels.map((id) => `<#${id}>`).join('  ')}`
+            : '';
+        const description = schedule.description
+          ? `\n${schedule.description}`
+          : '';
+
+        blocks.push(
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*${schedule.name}*${description}${channelText}`,
+            },
+          },
+          {
+            type: 'actions',
+            elements: [
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '수정' },
+                action_id: `schedule:class-rep:edit:${schedule.id}`,
+              },
+              mutedScheduleIds.has(schedule.id)
+                ? {
+                    type: 'button',
+                    text: { type: 'plain_text', text: '🔔 알림 켜기' },
+                    action_id: `schedule:class-rep:unmute:${schedule.id}`,
+                  }
+                : {
+                    type: 'button',
+                    text: { type: 'plain_text', text: '🔕 알림 끄기 (30분)' },
+                    action_id: `schedule:class-rep:mute:${schedule.id}`,
+                  },
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '반복 일정 생성' },
+                action_id: `schedule:class-rep:create-recurring:${schedule.id}`,
+              },
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '반복 일정 수정' },
+                action_id: `schedule:class-rep:edit-recurring:${schedule.id}`,
+              },
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '반복 일정 삭제' },
+                action_id: `schedule:class-rep:delete-recurring:${schedule.id}`,
+                style: 'danger',
+              },
+            ],
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'schedule:modal:class-rep:list',
+      title: { type: 'plain_text', text: '내 반 과목 관리' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  // 반 대표 과목 수정 모달 (제목, 설명, 알림 채널만)
+  static classRepEditModal(
+    schedule: { id: number; name: string; description?: string },
+    notificationChannelIds: string[] = [],
+  ): View {
+    return {
+      type: 'modal',
+      callback_id: 'schedule:modal:class-rep:edit',
+      private_metadata: schedule.id.toString(),
+      title: { type: 'plain_text', text: '과목 수정' },
+      submit: { type: 'plain_text', text: '저장' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'input',
+          block_id: 'name_block',
+          element: {
+            type: 'plain_text_input',
+            action_id: 'name_input',
+            initial_value: schedule.name,
+          },
+          label: { type: 'plain_text', text: '과목명' },
+        },
+        {
+          type: 'input',
+          block_id: 'description_block',
+          optional: true,
+          element: {
+            type: 'plain_text_input',
+            action_id: 'description_input',
+            multiline: true,
+            ...(schedule.description
+              ? { initial_value: schedule.description }
+              : {}),
+          },
+          label: { type: 'plain_text', text: '설명' },
+        },
+        { type: 'divider' },
+        {
+          type: 'input',
+          block_id: 'notification_channels_block',
+          optional: true,
+          element: {
+            type: 'multi_conversations_select',
+            action_id: 'channels_select',
+            placeholder: { type: 'plain_text', text: '알림 받을 채널 선택' },
+            filter: { include: ['public', 'private'] },
+            ...(notificationChannelIds.length > 0
+              ? { initial_conversations: notificationChannelIds }
+              : {}),
+          },
+          label: { type: 'plain_text', text: '알림 채널' },
+        },
+      ],
+    };
+  }
+
   // 시간표 수정 모달 (정보 수정 + 편집자 관리)
   static editModal(
     schedule: EditScheduleItem,
@@ -738,7 +881,19 @@ export class ScheduleView {
     };
   }
 
-  static createRecurringModal(schedules: { id: number; name: string }[]): View {
+  static createRecurringModal(
+    schedules: { id: number; name: string }[],
+    initialScheduleId?: number,
+  ): View {
+    const options = schedules.map((s) => ({
+      text: { type: 'plain_text' as const, text: s.name },
+      value: String(s.id),
+    }));
+    const initialOption =
+      initialScheduleId !== undefined
+        ? options.find((o) => o.value === String(initialScheduleId))
+        : undefined;
+
     return {
       type: 'modal',
       callback_id: 'schedule:modal:create_recurring',
@@ -754,10 +909,8 @@ export class ScheduleView {
             type: 'static_select',
             action_id: 'schedule_input',
             placeholder: { type: 'plain_text', text: '시간표 선택' },
-            options: schedules.map((s) => ({
-              text: { type: 'plain_text', text: s.name },
-              value: String(s.id),
-            })),
+            options,
+            ...(initialOption ? { initial_option: initialOption } : {}),
           },
         },
         {

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -187,12 +187,19 @@ export class HomeView {
                 elements: [
                   {
                     type: 'button' as const,
-                    text: {
-                      type: 'plain_text' as const,
-                      text: '시간표 관리',
-                    },
+                    text: { type: 'plain_text' as const, text: '시간표 관리' },
                     style: 'primary' as const,
                     action_id: 'home:open-class-rep-schedules',
+                  },
+                  {
+                    type: 'button' as const,
+                    text: { type: 'plain_text' as const, text: '반원 목록' },
+                    action_id: 'home:open-class-rep-user-list',
+                  },
+                  {
+                    type: 'button' as const,
+                    text: { type: 'plain_text' as const, text: '가입 승인' },
+                    action_id: 'home:open-class-rep-approval',
                   },
                 ],
               },

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -1,5 +1,6 @@
 import type { View } from '@slack/types';
 import type { User } from '../user/user.entity';
+import { UserRole } from '../user/user.entity';
 
 export class HomeView {
   static registration(): View {
@@ -67,6 +68,8 @@ export class HomeView {
     const infoLine = [user.code, user.email, className]
       .filter(Boolean)
       .join('  |  ');
+
+    const isClassRep = user.role === UserRole.CLASS_REP;
 
     return {
       type: 'home',
@@ -160,6 +163,42 @@ export class HomeView {
           ],
         },
         { type: 'divider' },
+        ...(isClassRep
+          ? [
+              {
+                type: 'header' as const,
+                text: {
+                  type: 'plain_text' as const,
+                  text: '👑 반 대표',
+                  emoji: true,
+                },
+              },
+              {
+                type: 'context' as const,
+                elements: [
+                  {
+                    type: 'mrkdwn' as const,
+                    text: '내 반 태그가 달린 과목의 알림 채널, 반복 일정을 관리할 수 있어요.',
+                  },
+                ],
+              },
+              {
+                type: 'actions' as const,
+                elements: [
+                  {
+                    type: 'button' as const,
+                    text: {
+                      type: 'plain_text' as const,
+                      text: '시간표 관리',
+                    },
+                    style: 'primary' as const,
+                    action_id: 'home:open-class-rep-schedules',
+                  },
+                ],
+              },
+              { type: 'divider' as const },
+            ]
+          : []),
         {
           type: 'actions',
           elements: [

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -178,7 +178,7 @@ export class HomeView {
                 elements: [
                   {
                     type: 'mrkdwn' as const,
-                    text: '내 반 태그가 달린 과목의 알림 채널, 반복 일정을 관리할 수 있어요.',
+                    text: '내 반 태그가 달린 과목의 알림 채널·반복 일정을 관리하고, 반원 목록 조회 및 가입 승인을 할 수 있어요.',
                   },
                 ],
               },

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -607,4 +607,158 @@ export class UserController {
       }
     }
   }
+
+  // ========== 반 대표 유저 관리 ==========
+
+  private async getClassRepStudentClassId(slackUserId: string): Promise<number | null> {
+    const user = await this.userService.findBySlackIdWithClass(slackUserId);
+    if (!user || user.role !== UserRole.CLASS_REP || !user.studentClassId) return null;
+    return user.studentClassId;
+  }
+
+  @Action('home:open-class-rep-user-list')
+  async classRepOpenUserList({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const studentClassId = await this.getClassRepStudentClassId(body.user.id);
+    if (!studentClassId) return;
+
+    const user = await this.userService.findBySlackIdWithClass(body.user.id);
+    const className = user?.studentClass?.name ?? '';
+    const { users, total } = await this.userService.findByStudentClassId(studentClassId, 0, PAGE_SIZE);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: UserView.classRepUserListModal(
+        users.map((u) => ({
+          slackId: u.slackId,
+          name: u.name,
+          code: u.code,
+          role: u.role,
+          status: u.status,
+          className: u.studentClass?.name,
+        })),
+        { page: 0, pageSize: PAGE_SIZE, total },
+        className,
+      ),
+    });
+  }
+
+  @Action('user:class-rep:page-prev')
+  @Action('user:class-rep:page-next')
+  async classRepPageUserList({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const studentClassId = await this.getClassRepStudentClassId(body.user.id);
+    if (!studentClassId) return;
+
+    const action = body.actions[0] as { value: string };
+    const page = parseInt(action.value, 10);
+
+    const user = await this.userService.findBySlackIdWithClass(body.user.id);
+    const className = user?.studentClass?.name ?? '';
+    const { users, total } = await this.userService.findByStudentClassId(
+      studentClassId,
+      page * PAGE_SIZE,
+      PAGE_SIZE,
+    );
+
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: UserView.classRepUserListModal(
+          users.map((u) => ({
+            slackId: u.slackId,
+            name: u.name,
+            code: u.code,
+            role: u.role,
+            status: u.status,
+            className: u.studentClass?.name,
+          })),
+          { page, pageSize: PAGE_SIZE, total },
+          className,
+        ),
+      });
+    }
+  }
+
+  @Action('home:open-class-rep-approval')
+  async classRepOpenApproval({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const studentClassId = await this.getClassRepStudentClassId(body.user.id);
+    if (!studentClassId) return;
+
+    const pendingUsers = await this.userService.findPendingApprovalByStudentClassId(studentClassId);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: UserView.classRepPendingApprovalModal(
+        pendingUsers.map((u) => ({
+          slackId: u.slackId,
+          name: u.name,
+          email: u.email,
+          code: u.code,
+          role: u.role,
+          className: u.studentClass?.name,
+        })),
+      ),
+    });
+  }
+
+  @Action(/^user:class-rep:approve:/)
+  async classRepApproveUser({
+    ack,
+    body,
+    client,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const studentClassId = await this.getClassRepStudentClassId(body.user.id);
+    if (!studentClassId) return;
+
+    const action = body.actions[0] as { action_id: string };
+    const targetSlackId = action.action_id.split(':').pop()!;
+
+    // 해당 유저가 자기 반인지 확인
+    const targetUser = await this.userService.findBySlackId(targetSlackId);
+    if (!targetUser || targetUser.studentClassId !== studentClassId) return;
+
+    await this.userService.approveUser(targetSlackId);
+    await this.inviteToClassChannel(targetSlackId, targetUser.studentClassId);
+
+    await this.slackService.client.chat.postMessage({
+      channel: targetSlackId,
+      text: '가입이 승인되었습니다! 이제 서비스를 이용할 수 있습니다.',
+    });
+
+    if (body.view?.id) {
+      const pendingUsers = await this.userService.findPendingApprovalByStudentClassId(studentClassId);
+      await client.views.update({
+        view_id: body.view.id,
+        view: UserView.classRepPendingApprovalModal(
+          pendingUsers.map((u) => ({
+            slackId: u.slackId,
+            name: u.name,
+            email: u.email,
+            code: u.code,
+            role: u.role,
+            className: u.studentClass?.name,
+          })),
+        ),
+      });
+    }
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -162,6 +162,27 @@ export class UserService {
     });
   }
 
+  // 반 대표용: 자기 반 승인 대기 유저 조회
+  async findPendingApprovalByStudentClassId(studentClassId: number): Promise<User[]> {
+    return this.userRepository.find({
+      where: { status: UserStatus.PENDING_APPROVAL, studentClassId },
+      relations: ['studentClass'],
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  // 반 대표용: 자기 반 유저 목록 조회
+  async findByStudentClassId(studentClassId: number, skip: number, take: number) {
+    const [users, total] = await this.userRepository.findAndCount({
+      where: { studentClassId },
+      relations: ['studentClass'],
+      order: { name: 'ASC' },
+      skip,
+      take,
+    });
+    return { users, total };
+  }
+
   // 3단계: 관리자 승인 → ACTIVE
   async approveUser(slackId: string): Promise<User | null> {
     await this.userRepository.update(

--- a/src/user/user.view.ts
+++ b/src/user/user.view.ts
@@ -486,6 +486,120 @@ export class UserView {
     };
   }
 
+  // 반 대표: 자기 반 승인 대기 모달 (승인만, 거절 없음)
+  static classRepPendingApprovalModal(pendingUsers: PendingUser[]): View {
+    const blocks: View['blocks'] = [];
+
+    if (pendingUsers.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '승인 대기 중인 반원이 없습니다.' },
+      });
+    } else {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*승인 대기: ${pendingUsers.length}명*` },
+      });
+      blocks.push({ type: 'divider' });
+
+      for (const user of pendingUsers) {
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `<@${user.slackId}> (${user.email})\n${user.code} | ${ROLE_LABELS[user.role]}`,
+          },
+          accessory: {
+            type: 'button',
+            text: { type: 'plain_text', text: '승인' },
+            style: 'primary',
+            action_id: `user:class-rep:approve:${user.slackId}`,
+          },
+        } as any);
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'user:modal:class-rep:approval',
+      title: { type: 'plain_text', text: '가입 승인' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  // 반 대표: 자기 반 유저 목록 모달 (조회 전용)
+  static classRepUserListModal(
+    users: UserListItem[],
+    pagination: { page: number; pageSize: number; total: number },
+    className: string,
+  ): View {
+    const { page, pageSize, total } = pagination;
+    const totalPages = Math.max(1, Math.ceil(total / pageSize));
+    const blocks: View['blocks'] = [
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `총 *${total}명*  ·  ${page + 1} / ${totalPages} 페이지`,
+          },
+        ],
+      },
+      { type: 'divider' },
+    ];
+
+    if (users.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '반원이 없습니다.' },
+      });
+    } else {
+      for (const user of users) {
+        const roleLabel = user.role ? ROLE_LABELS[user.role] : '미지정';
+        const statusLabel = STATUS_LABELS[user.status];
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `<@${user.slackId}>\n${roleLabel}  ·  ${statusLabel}${user.code ? `  ·  ${user.code}` : ''}`,
+          },
+        });
+      }
+    }
+
+    blocks.push({ type: 'divider' });
+    const pageElements: any[] = [];
+    if (page > 0) {
+      pageElements.push({
+        type: 'button',
+        action_id: 'user:class-rep:page-prev',
+        text: { type: 'plain_text', text: '← 이전' },
+        value: String(page - 1),
+      });
+    }
+    if (page < totalPages - 1) {
+      pageElements.push({
+        type: 'button',
+        action_id: 'user:class-rep:page-next',
+        text: { type: 'plain_text', text: '다음 →' },
+        value: String(page + 1),
+      });
+    }
+    if (pageElements.length > 0) {
+      blocks.push({ type: 'actions', elements: pageElements } as any);
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'user:modal:class-rep:list',
+      private_metadata: String(page),
+      title: { type: 'plain_text', text: `${className} 반원 목록` },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
   // 관리자: 특정 유저 정보 편집 모달
   static editUserModal(prefill: EditUserPrefill): View {
     const classOptions =


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 반대표 학생을 위한 전용 홈 탭 섹션 추가
- 시간표 관리 및 반원 관리 기능 수행 가능

## 주요 변경 사항

### 홈 탭 - 반 대표 섹션 추가
- class_rep 역할일 때만 노출되는 반대표 섹션 추가
- 시간표 관리, 반원 목록, 가입 승인 버튼

### 시간표 관리 (반 대표)
- 자기 반 태그가 달린 과목 조회
- 과목 제목, 설명, 알림 채널 수정 가능
- 알림 뮤트/언뮤트 토글
- 반복 일정 생성, 수정, 삭제
- 모든 동작에 반 대표 권한 검증

### 반원 관리
- 반원 목록 모달: 자기 반 유저 목록 페이지네이션 조회 (읽기 전용)
- 가입 승인 모달: 자기 반 승인 대기 유저만 표시, 개별 승인 가능 (거절은 관리자 전용 유지)
- 승인 시 반 Slack 채널 초대 및 DM 알림 발송

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

### 반 대표 섹션

<img width="1164" height="250" alt="CleanShot 2026-04-29 at 18 10 06@2x" src="https://github.com/user-attachments/assets/cf38ccb6-c0c9-4f30-a688-1a5aa43881ac" />


### 과목 관리

<img width="1044" height="696" alt="CleanShot 2026-04-29 at 18 10 47@2x" src="https://github.com/user-attachments/assets/f4d6e48c-efa9-405e-abe8-5badd0a64066" />
