### PR TITLE
chore: 홈 탭 하단에 앱 버전 정보 자동 표시 추가

### DIFF
--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -1,6 +1,12 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import type { View } from '@slack/types';
 import type { User } from '../user/user.entity';
 import { UserRole } from '../user/user.entity';
+
+const APP_VERSION: string = JSON.parse(
+  readFileSync(join(__dirname, '../../package.json'), 'utf-8'),
+).version;
 
 export class HomeView {
   static registration(): View {
@@ -64,11 +70,6 @@ export class HomeView {
   }
 
   static activeStudent(user: User): View {
-    const className = user.studentClass?.name ?? '';
-    const infoLine = [user.code, user.email, className]
-      .filter(Boolean)
-      .join('  |  ');
-
     const isClassRep = user.role === UserRole.CLASS_REP;
 
     return {
@@ -203,9 +204,8 @@ export class HomeView {
                   },
                 ],
               },
-              { type: 'divider' as const },
             ]
-          : []),
+          : [{ type: 'divider' as const }]),
         {
           type: 'actions',
           elements: [
@@ -238,6 +238,15 @@ export class HomeView {
               text: { type: 'plain_text', text: '✨ 기능 제안' },
               action_id: 'home:request-feature',
               url: 'https://github.com/kyumin1227/gsc-slack-app/issues/new?template=feature_request.yml',
+            },
+          ],
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `v${APP_VERSION}  ·  © 2026 GSC`,
             },
           ],
         },
@@ -536,6 +545,15 @@ export class HomeView {
               text: { type: 'plain_text', text: '✨ 기능 제안' },
               action_id: 'home:request-feature',
               url: 'https://github.com/kyumin1227/gsc-slack-app/issues/new?template=feature_request.yml',
+            },
+          ],
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `v${APP_VERSION}  ·  © 2026 GSC`,
             },
           ],
         },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- activeStudent/activeStaff 하단에 버전 context 블록 추가
- package.json에서 버전을 읽어 자동 반영

## 주요 변경 사항

### 항목

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

<img width="1222" height="186" alt="CleanShot 2026-04-29 at 18 48 38@2x" src="https://github.com/user-attachments/assets/dec10190-4d50-4e1a-995f-a29ce2cffae5" />
