### PR TITLE
feat: 비동기 작업 결과를 모달로 표시하는 공통 유틸 추가

### DIFF
--- a/src/common/modal-feedback.util.ts
+++ b/src/common/modal-feedback.util.ts
@@ -1,0 +1,48 @@
+import type { WebClient } from '@slack/web-api';
+import type { View } from '@slack/types';
+
+function buildResultModal(title: string, text: string): View {
+  return {
+    type: 'modal',
+    title: { type: 'plain_text', text: title, emoji: true },
+    close: { type: 'plain_text', text: '닫기' },
+    blocks: [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text },
+      },
+    ],
+  };
+}
+
+const processingModal: View = buildResultModal(
+  '처리 중',
+  '⏳ 처리하고 있습니다. 잠시만 기다려주세요...',
+);
+
+export async function withModalFeedback<T>(
+  params: {
+    ack: (response?: any) => Promise<void>;
+    client: WebClient;
+    viewId: string;
+    userId: string;
+  },
+  operation: () => Promise<T>,
+  handlers: {
+    successTitle?: string;
+    successText: (result: T) => string;
+  },
+): Promise<void> {
+  const { ack, client, viewId, userId } = params;
+  const successTitle = handlers.successTitle ?? '완료';
+
+  await ack({ response_action: 'update', view: processingModal });
+
+  const result = await operation();
+  const text = handlers.successText(result);
+
+  // 모달이 닫혀 있으면 DM으로 fallback
+  await client.views
+    .update({ view_id: viewId, view: buildResultModal(successTitle, text) })
+    .catch(() => client.chat.postMessage({ channel: userId, text }));
+}

--- a/src/common/slack-error.middleware.ts
+++ b/src/common/slack-error.middleware.ts
@@ -40,26 +40,41 @@ export const slackErrorMiddleware = async (
     const text =
       err instanceof Error ? `❌ ${err.message}` : '❌ 오류가 발생했습니다.';
 
+    const errorView = {
+      type: 'modal' as const,
+      title: { type: 'plain_text' as const, text: '오류' },
+      close: { type: 'plain_text' as const, text: '닫기' },
+      blocks,
+    };
+
+    const viewId: string | undefined = body?.view?.id;
+
+    // 모달이 열려 있으면 현재 뷰를 에러 모달로 교체 (ack 후 trigger_id 만료 케이스 포함)
+    if (viewId) {
+      const updated = await client.views
+        .update({ view_id: viewId, view: errorView })
+        .then(() => true)
+        .catch(() => false);
+      if (updated) return;
+    }
+
+    // viewId 없거나 update 실패 → trigger_id로 push/open 시도
     if (triggerId) {
       const isInsideModal = body?.view?.type === 'modal';
       const openOrPush = isInsideModal ? client.views.push : client.views.open;
-      await openOrPush({
+      const opened = await openOrPush({
         trigger_id: triggerId,
-        view: {
-          type: 'modal',
-          title: { type: 'plain_text', text: '오류' },
-          close: { type: 'plain_text', text: '닫기' },
-          blocks,
-        },
-      }).catch(async (e: unknown) => {
-        logger.warn('[ErrorModal] views failed, fallback to DM', e);
-        if (userId) {
-          await client.chat
-            .postMessage({ channel: userId, text, blocks })
-            .catch(() => {});
-        }
-      });
-    } else if (userId) {
+        view: errorView,
+      })
+        .then(() => true)
+        .catch((e: unknown) => {
+          logger.warn('[ErrorModal] views failed, fallback to DM', e);
+          return false;
+        });
+      if (opened) return;
+    }
+
+    if (userId) {
       await client.chat
         .postMessage({ channel: userId, text, blocks })
         .catch(() => {});

--- a/src/resource/resource.controller.ts
+++ b/src/resource/resource.controller.ts
@@ -13,6 +13,7 @@ import { UserService } from '../user/user.service';
 import { UserStatus } from '../user/user.entity';
 import { GoogleCalendarService } from '../google/google-calendar.service';
 import { PermissionService } from '../user/permission.service';
+import { withModalFeedback } from '../common/modal-feedback.util';
 
 @Controller()
 export class ResourceController {
@@ -234,24 +235,27 @@ export class ResourceController {
       return;
     }
 
-    await ack();
-
+    const viewId = body.view.id;
     const startTime = new Date(`${date}T${startTimeStr}:00+09:00`);
     const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
 
-    await this.resourceService.bookResource({
-      resourceId: roomId,
-      title,
-      startTime,
-      endTime,
-      bookerSlackId: body.user.id,
-      attendeeSlackIds,
-    });
-
-    await client.chat.postMessage({
-      channel: body.user.id,
-      text: `✅ 예약이 완료되었습니다.\n*${title}* | ${date} ${startTimeStr} (${durationMinutes}분)`,
-    });
+    await withModalFeedback(
+      { ack, client, viewId, userId: body.user.id },
+      () =>
+        this.resourceService.bookResource({
+          resourceId: roomId,
+          title,
+          startTime,
+          endTime,
+          bookerSlackId: body.user.id,
+          attendeeSlackIds,
+        }),
+      {
+        successTitle: '예약 완료',
+        successText: () =>
+          `✅ 예약이 완료되었습니다!\n\n*${title}*\n📅 ${date} ${startTimeStr} (${durationMinutes}분)`,
+      },
+    );
   }
 
   @Action('home:open-my-bookings')


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
- 비동기 작업의 결과가 DM 으로 발송 되어, DM을 보지 않아 작업의 성공/실패를 여부를 모르는 유저가 존재

## 주요 변경 사항

### 비동기 작업 플로우
1. 버튼을 클릭하여 비동기 작업을 실행할 경우 ack를 반환하며 현재 모달을 `처리중` 모달로 update
2. 비동기 작업 성공 시 `처리중` 모달을 성공 모달로 update
3. 비동기 작업 실패시 에러를 반환하며 전역 에러 핸들러에서 처리
4. (에러 핸들러) 열려있는 모달을 에러 모달로 update 하여 메시지 표시
5. `처리중` 모달이 열려있지 않는 경우 성공/실패 모두 DM 으로 발송

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->
Closes #124 

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
