### PR TITLE
feat: Slack DM AI 어시스턴트 구현 (내 예약 조회)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,6 @@ GOOGLE_WEBHOOK_URL=https://example.com
 
 # CloudFlare (개발 환경의 경우)
 CLOUDFLARE_TUNNEL_TOKEN=
+
+# Anthropic (AI 어시스턴트)
+ANTHROPIC_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.5",
       "license": "UNLICENSED",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.95.1",
         "@keyv/redis": "^5.1.6",
         "@nestjs/cache-manager": "^3.1.0",
         "@nestjs/common": "^11.0.1",
@@ -197,6 +198,27 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.95.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.1.tgz",
+      "integrity": "sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -658,6 +680,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2682,6 +2713,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@tokenizer/inflate": {
@@ -5639,6 +5676,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -7619,6 +7662,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -9672,6 +9728,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10198,6 +10264,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "migration:show": "typeorm-ts-node-commonjs migration:show -d data-source.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.95.1",
     "@keyv/redis": "^5.1.6",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { ResourceModule } from './resource/resource.module';
 import { httpReceiver } from './slack-receiver';
 import { slackErrorMiddleware } from './common/slack-error.middleware';
 import { CleaningModule } from './cleaning/cleaning.module';
+import { SlackAiModule } from './slack-ai/slack-ai.module';
 
 @Module({
   imports: [
@@ -71,6 +72,7 @@ import { CleaningModule } from './cleaning/cleaning.module';
     ChannelModule,
     ResourceModule,
     CleaningModule,
+    SlackAiModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/resource/dto/study-room.dto.ts
+++ b/src/resource/dto/study-room.dto.ts
@@ -25,4 +25,5 @@ export interface BookingItem {
   summary: string;
   startTime: Date;
   endTime: Date;
+  attendeeEmails: string[];
 }

--- a/src/resource/service/study-room.service.ts
+++ b/src/resource/service/study-room.service.ts
@@ -5,7 +5,11 @@ import { GoogleEventsService } from '../../google/calendar/events.service';
 import { GoogleAclService } from '../../google/calendar/acl.service';
 import { GoogleFreebusyService } from '../../google/calendar/freebusy.service';
 import { UserService } from '../../user/service/user.service';
-import { BusinessError, GoogleErrorCode, ResourceErrorCode } from '../../common/errors';
+import {
+  BusinessError,
+  GoogleErrorCode,
+  ResourceErrorCode,
+} from '../../common/errors';
 import {
   BookResourceDto,
   BookingItem,
@@ -33,7 +37,8 @@ export class StudyRoomService {
       .map((e) => e.email);
 
     const editor = await this.userService.findActiveByEmails(editorEmails);
-    if (!editor) throw new BusinessError(GoogleErrorCode.CALENDAR_WRITER_NOT_FOUND);
+    if (!editor)
+      throw new BusinessError(GoogleErrorCode.CALENDAR_WRITER_NOT_FOUND);
 
     const refreshToken = this.userService.getDecryptedRefreshToken(editor);
     if (!refreshToken)
@@ -45,7 +50,8 @@ export class StudyRoomService {
   // 스터디룸 예약 생성 (시간 충돌 확인 후 Google Calendar 이벤트 생성)
   async bookResource(dto: BookResourceDto): Promise<string> {
     const resource = await this.resourceService.findById(dto.resourceId);
-    if (!resource) throw new BusinessError(ResourceErrorCode.STUDY_ROOM_NOT_FOUND);
+    if (!resource)
+      throw new BusinessError(ResourceErrorCode.STUDY_ROOM_NOT_FOUND);
     if (resource.type === ResourceType.PROFESSOR) {
       throw new BusinessError(ResourceErrorCode.STUDY_ROOM_NOT_FOUND);
     }
@@ -128,6 +134,9 @@ export class StudyRoomService {
       summary: event.summary ?? '(제목 없음)',
       startTime: new Date(event.start!.dateTime!),
       endTime: new Date(event.end!.dateTime!),
+      attendeeEmails: (event.attendees ?? [])
+        .filter((a) => !a.resource)
+        .map((a) => a.email ?? ''),
     }));
   }
 

--- a/src/slack-ai/slack-ai.handler.ts
+++ b/src/slack-ai/slack-ai.handler.ts
@@ -1,0 +1,39 @@
+import { Controller, Logger } from '@nestjs/common';
+import { Message } from 'nestjs-slack-bolt';
+import type { SlackEventMiddlewareArgs } from '@slack/bolt';
+import { SlackAiService } from './slack-ai.service';
+
+@Controller()
+export class SlackAiHandler {
+  private readonly logger = new Logger(SlackAiHandler.name);
+
+  constructor(private readonly slackAiService: SlackAiService) {}
+
+  @Message(/.*/)
+  async handleDm({ body, say }: SlackEventMiddlewareArgs<'message'>) {
+    const event = body.event as unknown as Record<string, unknown>;
+
+    // DM 채널만 처리
+    if (event?.channel_type !== 'im') return;
+
+    // 봇 메시지 무시 (무한 루프 방지)
+    if (event?.bot_id) return;
+
+    const slackId = event.user as string;
+    const text = (event.text as string) ?? '';
+
+    if (!slackId || !text.trim()) return;
+
+    // 기존 키워드 핸들러가 처리하는 명령어 제외
+    if (/^health$/i.test(text.trim())) return;
+
+    try {
+      const reply = await this.slackAiService.handleMessage(slackId, text);
+      await say(reply);
+    } catch (e) {
+      await say(
+        '죄송합니다. 요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+    }
+  }
+}

--- a/src/slack-ai/slack-ai.module.ts
+++ b/src/slack-ai/slack-ai.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ToolsModule } from '../tools/tools.module';
+import { SlackAiService } from './slack-ai.service';
+import { SlackAiHandler } from './slack-ai.handler';
+
+@Module({
+  imports: [ToolsModule],
+  controllers: [SlackAiHandler],
+  providers: [SlackAiService],
+})
+export class SlackAiModule {}

--- a/src/slack-ai/slack-ai.module.ts
+++ b/src/slack-ai/slack-ai.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ToolsModule } from '../tools/tools.module';
+import { UserModule } from '../user/user.module';
 import { SlackAiService } from './slack-ai.service';
 import { SlackAiHandler } from './slack-ai.handler';
 
 @Module({
-  imports: [ToolsModule],
+  imports: [ToolsModule, UserModule],
   controllers: [SlackAiHandler],
   providers: [SlackAiService],
 })

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -1,8 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import Anthropic from '@anthropic-ai/sdk';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { ToolsService } from '../tools/tools.service';
 
 const MODEL = 'claude-haiku-4-5-20251001';
+const HISTORY_TTL_MS = 60 * 60 * 1000; // 1시간
 
 const SYSTEM_PROMPT = `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
 사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 간결하게 한국어로 안내하세요.
@@ -16,11 +19,28 @@ export class SlackAiService {
     apiKey: process.env.ANTHROPIC_API_KEY,
   });
 
-  constructor(private readonly toolsService: ToolsService) {}
+  constructor(
+    private readonly toolsService: ToolsService,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+  ) {}
+
+  private historyKey(slackId: string): string {
+    return `slack-ai:history:${slackId}`;
+  }
+
+  private async loadHistory(slackId: string): Promise<Anthropic.MessageParam[]> {
+    return (await this.cache.get<Anthropic.MessageParam[]>(this.historyKey(slackId))) ?? [];
+  }
+
+  private async saveHistory(slackId: string, messages: Anthropic.MessageParam[]): Promise<void> {
+    await this.cache.set(this.historyKey(slackId), messages, HISTORY_TTL_MS);
+  }
 
   async handleMessage(slackId: string, text: string): Promise<string> {
     const tools = this.toolsService.getDefinitions();
+    const history = await this.loadHistory(slackId);
     const messages: Anthropic.MessageParam[] = [
+      ...history,
       { role: 'user', content: text },
     ];
 
@@ -33,7 +53,12 @@ export class SlackAiService {
     });
 
     if (response.stop_reason !== 'tool_use') {
-      return this.extractText(response.content);
+      const text = this.extractText(response.content);
+      await this.saveHistory(slackId, [
+        ...messages,
+        { role: 'assistant', content: text },
+      ]);
+      return text;
     }
 
     const toolResults: Anthropic.ToolResultBlockParam[] = [];
@@ -67,9 +92,13 @@ export class SlackAiService {
     });
 
     const finalText = this.extractText(finalResponse.content);
-    this.logger.log(
-      `[handleMessage] 최종 응답 완료 length=${finalText.length}`,
-    );
+    await this.saveHistory(slackId, [
+      ...messages,
+      { role: 'assistant', content: response.content },
+      { role: 'user', content: toolResults },
+      { role: 'assistant', content: finalText },
+    ]);
+    this.logger.log(`[handleMessage] 최종 응답 완료 length=${finalText.length}`);
     return finalText;
   }
 

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -3,11 +3,13 @@ import Anthropic from '@anthropic-ai/sdk';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { ToolsService } from '../tools/tools.service';
+import { UserService } from '../user/service/user.service';
 
 const MODEL = 'claude-haiku-4-5-20251001';
 const HISTORY_TTL_MS = 60 * 60 * 1000; // 1시간
 
-const SYSTEM_PROMPT = `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
+const buildSystemPrompt = (userName: string | null) => `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
+${userName ? `현재 대화 중인 사용자의 이름은 "${userName}"입니다.` : ''}
 사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 간결하게 한국어로 안내하세요.
 모든 날짜와 시간은 한국 표준시(KST, UTC+9) 기준으로 해석하고 표시하세요.
 날짜와 시간 표시 형식은 "2025년 5월 10일 오후 2시" 형식을 사용하세요.`;
@@ -21,6 +23,7 @@ export class SlackAiService {
 
   constructor(
     private readonly toolsService: ToolsService,
+    private readonly userService: UserService,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
   ) {}
 
@@ -38,6 +41,9 @@ export class SlackAiService {
 
   async handleMessage(slackId: string, text: string): Promise<string> {
     const tools = this.toolsService.getDefinitions();
+    const user = await this.userService.findBySlackId(slackId);
+    const systemPrompt = buildSystemPrompt(user?.name ?? null);
+
     const history = await this.loadHistory(slackId);
     const messages: Anthropic.MessageParam[] = [
       ...history,
@@ -47,18 +53,18 @@ export class SlackAiService {
     const response = await this.anthropic.messages.create({
       model: MODEL,
       max_tokens: 1024,
-      system: SYSTEM_PROMPT,
+      system: systemPrompt,
       tools,
       messages,
     });
 
     if (response.stop_reason !== 'tool_use') {
-      const text = this.extractText(response.content);
+      const replyText = this.extractText(response.content);
       await this.saveHistory(slackId, [
         ...messages,
-        { role: 'assistant', content: text },
+        { role: 'assistant', content: replyText },
       ]);
-      return text;
+      return replyText;
     }
 
     const toolResults: Anthropic.ToolResultBlockParam[] = [];
@@ -82,7 +88,7 @@ export class SlackAiService {
     const finalResponse = await this.anthropic.messages.create({
       model: MODEL,
       max_tokens: 1024,
-      system: SYSTEM_PROMPT,
+      system: systemPrompt,
       tools,
       messages: [
         ...messages,

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -7,8 +7,11 @@ import { UserService } from '../user/service/user.service';
 
 const MODEL = 'claude-haiku-4-5-20251001';
 const HISTORY_TTL_MS = 60 * 60 * 1000; // 1시간
+const MAX_HISTORY_MESSAGES = 20; // 최근 10턴
 
-const buildSystemPrompt = (userName: string | null) => `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
+const buildSystemPrompt = (
+  userName: string | null,
+) => `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
 ${userName ? `현재 대화 중인 사용자의 이름은 "${userName}"입니다.` : ''}
 사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 간결하게 한국어로 안내하세요.
 모든 날짜와 시간은 한국 표준시(KST, UTC+9) 기준으로 해석하고 표시하세요.
@@ -31,11 +34,20 @@ export class SlackAiService {
     return `slack-ai:history:${slackId}`;
   }
 
-  private async loadHistory(slackId: string): Promise<Anthropic.MessageParam[]> {
-    return (await this.cache.get<Anthropic.MessageParam[]>(this.historyKey(slackId))) ?? [];
+  private async loadHistory(
+    slackId: string,
+  ): Promise<Anthropic.MessageParam[]> {
+    const history =
+      (await this.cache.get<Anthropic.MessageParam[]>(
+        this.historyKey(slackId),
+      )) ?? [];
+    return history.slice(-MAX_HISTORY_MESSAGES);
   }
 
-  private async saveHistory(slackId: string, messages: Anthropic.MessageParam[]): Promise<void> {
+  private async saveHistory(
+    slackId: string,
+    messages: Anthropic.MessageParam[],
+  ): Promise<void> {
     await this.cache.set(this.historyKey(slackId), messages, HISTORY_TTL_MS);
   }
 
@@ -52,7 +64,7 @@ export class SlackAiService {
 
     const response = await this.anthropic.messages.create({
       model: MODEL,
-      max_tokens: 1024,
+      max_tokens: 2048,
       system: systemPrompt,
       tools,
       messages,
@@ -87,7 +99,7 @@ export class SlackAiService {
 
     const finalResponse = await this.anthropic.messages.create({
       model: MODEL,
-      max_tokens: 1024,
+      max_tokens: 2048,
       system: systemPrompt,
       tools,
       messages: [
@@ -104,7 +116,9 @@ export class SlackAiService {
       { role: 'user', content: toolResults },
       { role: 'assistant', content: finalText },
     ]);
-    this.logger.log(`[handleMessage] 최종 응답 완료 length=${finalText.length}`);
+    this.logger.log(
+      `[handleMessage] 최종 응답 완료 length=${finalText.length}`,
+    );
     return finalText;
   }
 

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Anthropic from '@anthropic-ai/sdk';
+import { ToolsService } from '../tools/tools.service';
+
+const MODEL = 'claude-haiku-4-5-20251001';
+
+const SYSTEM_PROMPT = `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
+사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 간결하게 한국어로 안내하세요.
+모든 날짜와 시간은 한국 표준시(KST, UTC+9) 기준으로 해석하고 표시하세요.
+날짜와 시간 표시 형식은 "2025년 5월 10일 오후 2시" 형식을 사용하세요.`;
+
+@Injectable()
+export class SlackAiService {
+  private readonly logger = new Logger(SlackAiService.name);
+  private readonly anthropic = new Anthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+  });
+
+  constructor(private readonly toolsService: ToolsService) {}
+
+  async handleMessage(slackId: string, text: string): Promise<string> {
+    const tools = this.toolsService.getDefinitions();
+    const messages: Anthropic.MessageParam[] = [
+      { role: 'user', content: text },
+    ];
+
+    const response = await this.anthropic.messages.create({
+      model: MODEL,
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      tools,
+      messages,
+    });
+
+    if (response.stop_reason !== 'tool_use') {
+      return this.extractText(response.content);
+    }
+
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const block of response.content) {
+      if (block.type !== 'tool_use') continue;
+
+      this.logger.log(`[handleMessage] 툴 실행: ${block.name}`);
+      const result = await this.toolsService.execute(
+        block.name,
+        block.input,
+        slackId,
+      );
+
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: block.id,
+        content: JSON.stringify(result),
+      });
+    }
+
+    const finalResponse = await this.anthropic.messages.create({
+      model: MODEL,
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      tools,
+      messages: [
+        ...messages,
+        { role: 'assistant', content: response.content },
+        { role: 'user', content: toolResults },
+      ],
+    });
+
+    const finalText = this.extractText(finalResponse.content);
+    this.logger.log(
+      `[handleMessage] 최종 응답 완료 length=${finalText.length}`,
+    );
+    return finalText;
+  }
+
+  private extractText(content: Anthropic.ContentBlock[]): string {
+    return content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n');
+  }
+}

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import type Anthropic from '@anthropic-ai/sdk';
+import { StudyRoomService } from '../resource/service/study-room.service';
+import { UserService } from '../user/service/user.service';
+import { toKSTString } from '../utils/date.util';
+
+@Injectable()
+export class BookingTool {
+  readonly definitions: Anthropic.Tool[] = [
+    {
+      name: 'get_my_bookings',
+      description: '현재 사용자의 스터디룸 예약 목록을 조회합니다.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {},
+        required: [],
+      },
+    },
+  ];
+
+  constructor(
+    private readonly studyRoomService: StudyRoomService,
+    private readonly userService: UserService,
+  ) {}
+
+  async execute(
+    name: string,
+    _input: unknown,
+    slackId: string,
+  ): Promise<unknown> {
+    if (name === 'get_my_bookings') {
+      const bookings = await this.studyRoomService.getMyBookings(slackId);
+      return Promise.all(
+        bookings.map(async (b) => {
+          const attendees = (
+            await Promise.all(
+              b.attendeeEmails.map((email) =>
+                this.userService.findByEmail(email),
+              ),
+            )
+          )
+            .filter((u) => u !== null)
+            .map((u) => ({ name: u.name, slackId: u.slackId, code: u.code }));
+
+          return {
+            resourceName: b.resourceName,
+            summary: b.summary,
+            startTime: toKSTString(b.startTime),
+            endTime: toKSTString(b.endTime),
+            attendees,
+          };
+        }),
+      );
+    }
+    return null;
+  }
+}

--- a/src/tools/tools.module.ts
+++ b/src/tools/tools.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ResourceModule } from '../resource/resource.module';
+import { UserModule } from '../user/user.module';
+import { BookingTool } from './booking.tool';
+import { ToolsService } from './tools.service';
+
+@Module({
+  imports: [ResourceModule, UserModule],
+  providers: [BookingTool, ToolsService],
+  exports: [ToolsService],
+})
+export class ToolsModule {}

--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import type Anthropic from '@anthropic-ai/sdk';
+import { BookingTool } from './booking.tool';
+
+@Injectable()
+export class ToolsService {
+  private readonly tools: BookingTool[];
+
+  constructor(private readonly bookingTool: BookingTool) {
+    this.tools = [bookingTool];
+  }
+
+  getDefinitions(): Anthropic.Tool[] {
+    return this.tools.flatMap((t) => t.definitions);
+  }
+
+  async execute(
+    name: string,
+    input: unknown,
+    slackId: string,
+  ): Promise<unknown> {
+    for (const tool of this.tools) {
+      const result = await tool.execute(name, input, slackId);
+      if (result !== null) return result;
+    }
+    return { error: `알 수 없는 툴: ${name}` };
+  }
+}

--- a/src/utils/date.util.ts
+++ b/src/utils/date.util.ts
@@ -2,3 +2,16 @@
 export function toKST(date: Date): Date {
   return new Date(date.getTime() + 9 * 60 * 60 * 1000);
 }
+
+/** UTC Date → KST 한국어 문자열 (Claude tool result용) */
+export function toKSTString(date: Date): string {
+  return date.toLocaleString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}


### PR DESCRIPTION
## 개요

Slack DM으로 자연어 메시지를 보내면 Claude AI가 툴을 호출해 스터디룸 예약 정보를 조회하고 한국어로 안내하는 AI 어시스턴트를 구현합니다.

## 주요 변경 사항

### ToolsModule (신규)
- `BookingTool`: `get_my_bookings` 툴 정의 및 실행 (참석자 이름/슬랙ID/학번 반환)
- `ToolsService`: 툴 레지스트리 패턴 (getDefinitions, execute 위임)
- `ToolsModule`: ResourceModule, UserModule 의존

### SlackAiModule (신규)
- `SlackAiHandler`: DM 메시지 수신 및 라우팅 (`channel_type=im`, 봇 메시지 제외)
- `SlackAiService`: Claude API `tool_use` 루프 처리 및 자연어 응답 생성
- 대화 히스토리 Redis 저장 (TTL 1시간, 최근 10턴 슬라이딩 윈도우)
- 시스템 프롬프트에 유저 이름 동적 주입
- `max_tokens: 2048`

### 기존 파일 수정
- `BookingItem`에 `attendeeEmails: string[]` 추가
- `StudyRoomService.getMyBookings`에서 참석자 이메일 매핑
- `toKSTString` 유틸 추가 (Date → 한국어 로케일 문자열)
- `AppModule`에 `SlackAiModule` 등록

## 관련 이슈

Closes #145

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] Slack DM으로 "내 예약 보여줘" 전송 후 예약 목록 응답 확인
- [x] 예약 없는 유저 응답 확인
- [x] 대화 히스토리 연속성 확인 (이전 대화 맥락 유지)

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->