### PR TITLE
feat(slack-ai): 스터디룸 AI 예약 어시스턴트 구현

### DIFF
--- a/src/resource/dto/study-room.dto.ts
+++ b/src/resource/dto/study-room.dto.ts
@@ -27,3 +27,14 @@ export interface BookingItem {
   endTime: Date;
   attendeeEmails: string[];
 }
+
+// 스터디룸별 예약 현황
+export interface RoomBooking {
+  startTime: string;
+  endTime: string;
+}
+
+export interface RoomAvailability {
+  roomName: string;
+  bookings: RoomBooking[];
+}

--- a/src/resource/service/study-room.service.ts
+++ b/src/resource/service/study-room.service.ts
@@ -142,11 +142,17 @@ export class StudyRoomService {
   }
 
   // 스터디룸 목록 조회
-  async getStudyRooms(): Promise<{ name: string; aliases: string[] }[]> {
+  async getStudyRooms(): Promise<
+    { id: number; name: string; aliases: string[] }[]
+  > {
     const rooms = await this.resourceService.findAllByType(
       ResourceType.STUDY_ROOM,
     );
-    return rooms.map((r) => ({ name: r.name, aliases: r.aliases ?? [] }));
+    return rooms.map((r) => ({
+      id: r.id,
+      name: r.name,
+      aliases: r.aliases ?? [],
+    }));
   }
 
   // 스터디룸별 예약 현황 조회 (지정 시간 범위 내 예약 목록 반환)

--- a/src/resource/service/study-room.service.ts
+++ b/src/resource/service/study-room.service.ts
@@ -14,6 +14,7 @@ import {
   BookResourceDto,
   BookingItem,
   ModifyBookingDto,
+  RoomAvailability,
 } from '../dto/study-room.dto';
 import { ResourceService } from './resource.service';
 
@@ -138,6 +139,47 @@ export class StudyRoomService {
         .filter((a) => !a.resource)
         .map((a) => a.email ?? ''),
     }));
+  }
+
+  // 스터디룸 목록 조회
+  async getStudyRooms(): Promise<{ name: string; aliases: string[] }[]> {
+    const rooms = await this.resourceService.findAllByType(
+      ResourceType.STUDY_ROOM,
+    );
+    return rooms.map((r) => ({ name: r.name, aliases: r.aliases ?? [] }));
+  }
+
+  // 스터디룸별 예약 현황 조회 (지정 시간 범위 내 예약 목록 반환)
+  async getRoomAvailability(
+    startTime: Date,
+    endTime: Date,
+    roomName?: string,
+  ): Promise<RoomAvailability[]> {
+    const allRooms = await this.resourceService.findAllByType(
+      ResourceType.STUDY_ROOM,
+    );
+    const rooms = roomName
+      ? allRooms.filter(
+          (r) => r.name === roomName || (r.aliases ?? []).includes(roomName),
+        )
+      : allRooms;
+
+    return Promise.all(
+      rooms.map(async (room) => {
+        const events = await this.googleEventsService.listEventsInRange(
+          room.calendarId,
+          startTime,
+          endTime,
+        );
+        const bookings = events
+          .filter((e) => e.status !== 'cancelled' && e.start?.dateTime)
+          .map((e) => ({
+            startTime: e.start!.dateTime!,
+            endTime: e.end!.dateTime!,
+          }));
+        return { roomName: room.name, bookings };
+      }),
+    );
   }
 
   // 예약 취소 (Google Calendar 이벤트 삭제)

--- a/src/slack-ai/slack-ai.handler.ts
+++ b/src/slack-ai/slack-ai.handler.ts
@@ -31,6 +31,7 @@ export class SlackAiHandler {
       const reply = await this.slackAiService.handleMessage(slackId, text);
       await say(reply);
     } catch (e) {
+      this.logger.error(`[handleDm] slackId=${slackId} error=${String(e)}`, e instanceof Error ? e.stack : undefined);
       await say(
         '죄송합니다. 요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
       );

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -71,64 +71,51 @@ export class SlackAiService {
       { role: 'user', content: text },
     ];
 
-    const response = await this.anthropic.messages.create({
-      model: MODEL,
-      max_tokens: 2048,
-      system: systemPrompt,
-      tools,
-      messages,
-    });
-
-    if (response.stop_reason !== 'tool_use') {
-      const replyText = this.extractText(response.content);
-      await this.saveHistory(slackId, [
-        ...messages,
-        { role: 'assistant', content: replyText },
-      ]);
-      return replyText;
-    }
-
-    const toolResults: Anthropic.ToolResultBlockParam[] = [];
-    for (const block of response.content) {
-      if (block.type !== 'tool_use') continue;
-
-      this.logger.log(`[handleMessage] 툴 실행: ${block.name}`);
-      const result = await this.toolsService.execute(
-        block.name,
-        block.input,
-        slackId,
-      );
-
-      toolResults.push({
-        type: 'tool_result',
-        tool_use_id: block.id,
-        content: JSON.stringify(result),
+    const MAX_ROUNDS = 10;
+    for (let round = 0; round < MAX_ROUNDS; round++) {
+      const response = await this.anthropic.messages.create({
+        model: MODEL,
+        max_tokens: 2048,
+        system: systemPrompt,
+        tools,
+        messages,
       });
-    }
 
-    const finalResponse = await this.anthropic.messages.create({
-      model: MODEL,
-      max_tokens: 2048,
-      system: systemPrompt,
-      tools,
-      messages: [
-        ...messages,
+      if (response.stop_reason !== 'tool_use') {
+        const replyText = this.extractText(response.content);
+        await this.saveHistory(slackId, [
+          ...messages,
+          { role: 'assistant', content: replyText },
+        ]);
+        this.logger.log(`[handleMessage] 완료 (${round + 1}라운드) length=${replyText.length}`);
+        return replyText;
+      }
+
+      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      for (const block of response.content) {
+        if (block.type !== 'tool_use') continue;
+
+        this.logger.log(`[handleMessage] 툴 실행: ${block.name} (${round + 1}라운드)`);
+        const result = await this.toolsService.execute(
+          block.name,
+          block.input,
+          slackId,
+        );
+
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: block.id,
+          content: JSON.stringify(result),
+        });
+      }
+
+      messages.push(
         { role: 'assistant', content: response.content },
         { role: 'user', content: toolResults },
-      ],
-    });
+      );
+    }
 
-    const finalText = this.extractText(finalResponse.content);
-    await this.saveHistory(slackId, [
-      ...messages,
-      { role: 'assistant', content: response.content },
-      { role: 'user', content: toolResults },
-      { role: 'assistant', content: finalText },
-    ]);
-    this.logger.log(
-      `[handleMessage] 최종 응답 완료 length=${finalText.length}`,
-    );
-    return finalText;
+    return '요청 처리 중 오류가 발생했습니다. 다시 시도해 주세요.';
   }
 
   private extractText(content: Anthropic.ContentBlock[]): string {

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -52,7 +52,12 @@ export class SlackAiService {
       (await this.cache.get<Anthropic.MessageParam[]>(
         this.historyKey(slackId),
       )) ?? [];
-    return history.slice(-MAX_HISTORY_MESSAGES);
+    const sliced = history.slice(-MAX_HISTORY_MESSAGES);
+    // 슬라이스로 tool_use/tool_result 쌍이 끊기면 첫 번째 일반 user 텍스트 메시지부터 시작하도록 앞부분을 제거
+    const firstCleanIdx = sliced.findIndex(
+      (m) => m.role === 'user' && typeof m.content === 'string',
+    );
+    return firstCleanIdx > 0 ? sliced.slice(firstCleanIdx) : sliced;
   }
 
   private async saveHistory(

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -9,13 +9,22 @@ const MODEL = 'claude-haiku-4-5-20251001';
 const HISTORY_TTL_MS = 60 * 60 * 1000; // 1시간
 const MAX_HISTORY_MESSAGES = 20; // 최근 10턴
 
-const buildSystemPrompt = (
-  userName: string | null,
-) => `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
+const buildSystemPrompt = (userName: string | null) => {
+  const now = new Date().toLocaleString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long',
+  });
+
+  return `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
 ${userName ? `현재 대화 중인 사용자의 이름은 "${userName}"입니다.` : ''}
+현재 날짜: ${now}
 사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 간결하게 한국어로 안내하세요.
 모든 날짜와 시간은 한국 표준시(KST, UTC+9) 기준으로 해석하고 표시하세요.
 날짜와 시간 표시 형식은 "2025년 5월 10일 오후 2시" 형식을 사용하세요.`;
+};
 
 @Injectable()
 export class SlackAiService {

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -23,7 +23,9 @@ ${userName ? `현재 대화 중인 사용자의 이름은 "${userName}"입니다
 현재 날짜: ${now}
 사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 간결하게 한국어로 안내하세요.
 모든 날짜와 시간은 한국 표준시(KST, UTC+9) 기준으로 해석하고 표시하세요.
-날짜와 시간 표시 형식은 "2025년 5월 10일 오후 2시" 형식을 사용하세요.`;
+날짜와 시간 표시 형식은 "2025년 5월 10일 오후 2시" 형식을 사용하세요.
+calendarId, eventId 등 내부 식별자는 절대 사용자에게 노출하지 마세요. 
+예약을 찾을 수 없거나 수정·취소 권한이 없는 경우 "해당 예약에 대한 권한이 없습니다" 형식으로 안내하세요.`;
 };
 
 @Injectable()
@@ -87,7 +89,9 @@ export class SlackAiService {
           ...messages,
           { role: 'assistant', content: replyText },
         ]);
-        this.logger.log(`[handleMessage] 완료 (${round + 1}라운드) length=${replyText.length}`);
+        this.logger.log(
+          `[handleMessage] 완료 (${round + 1}라운드) length=${replyText.length}`,
+        );
         return replyText;
       }
 
@@ -95,7 +99,9 @@ export class SlackAiService {
       for (const block of response.content) {
         if (block.type !== 'tool_use') continue;
 
-        this.logger.log(`[handleMessage] 툴 실행: ${block.name} (${round + 1}라운드)`);
+        this.logger.log(
+          `[handleMessage] 툴 실행: ${block.name} (${round + 1}라운드)`,
+        );
         const result = await this.toolsService.execute(
           block.name,
           block.input,

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -16,6 +16,41 @@ export class BookingTool {
         required: [],
       },
     },
+    {
+      name: 'get_study_rooms',
+      description: '예약 가능한 스터디룸 목록과 alias를 조회합니다.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {},
+        required: [],
+      },
+    },
+    {
+      name: 'check_room_availability',
+      description:
+        '지정한 시간 범위 내 스터디룸별 예약 현황을 조회합니다. 빈 방과 예약된 방, 예약 시간대를 반환합니다.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          startDatetime: {
+            type: 'string',
+            description:
+              '조회 시작 일시 (ISO 8601, 예: 2025-05-10T09:00:00+09:00)',
+          },
+          endDatetime: {
+            type: 'string',
+            description:
+              '조회 종료 일시 (ISO 8601, 예: 2025-05-10T22:00:00+09:00)',
+          },
+          roomName: {
+            type: 'string',
+            description:
+              '특정 방만 조회할 경우 방 이름 또는 alias. 생략 시 전체 방 조회.',
+          },
+        },
+        required: ['startDatetime', 'endDatetime'],
+      },
+    },
   ];
 
   constructor(
@@ -25,7 +60,7 @@ export class BookingTool {
 
   async execute(
     name: string,
-    _input: unknown,
+    input: unknown,
     slackId: string,
   ): Promise<unknown> {
     if (name === 'get_my_bookings') {
@@ -52,6 +87,31 @@ export class BookingTool {
         }),
       );
     }
+    if (name === 'get_study_rooms') {
+      return this.studyRoomService.getStudyRooms();
+    }
+
+    if (name === 'check_room_availability') {
+      const { startDatetime, endDatetime, roomName } = input as {
+        startDatetime: string;
+        endDatetime: string;
+        roomName?: string;
+      };
+      const availability = await this.studyRoomService.getRoomAvailability(
+        new Date(startDatetime),
+        new Date(endDatetime),
+        roomName,
+      );
+      return availability.map((r) => ({
+        roomName: r.roomName,
+        available: r.bookings.length === 0,
+        bookings: r.bookings.map((b) => ({
+          startTime: toKSTString(new Date(b.startTime)),
+          endTime: toKSTString(new Date(b.endTime)),
+        })),
+      }));
+    }
+
     return null;
   }
 }

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -45,7 +45,7 @@ export class BookingTool {
     {
       name: 'check_room_availability',
       description:
-        '지정한 시간 범위 내 스터디룸별 예약 현황을 조회합니다. 빈 방과 예약된 방, 예약 시간대를 반환합니다.',
+        '지정한 시간 범위 내 스터디룸별 예약 현황을 조회합니다. 빈 방과 예약된 방, 예약 시간대를 반환합니다. roomName을 사용할 경우 반드시 이 툴보다 먼저 get_study_rooms를 호출해 정확한 이름을 확인하세요.',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -62,7 +62,7 @@ export class BookingTool {
           roomName: {
             type: 'string',
             description:
-              '특정 방만 조회할 경우 방 이름 또는 alias. 생략 시 전체 방 조회.',
+              '특정 방만 조회할 경우 방 이름 또는 alias. 반드시 get_study_rooms로 정확한 이름을 확인 후 입력. 생략 시 전체 방 조회.',
           },
         },
         required: ['startDatetime', 'endDatetime'],

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -18,7 +18,8 @@ export class BookingTool {
     },
     {
       name: 'get_study_rooms',
-      description: '예약 가능한 스터디룸 목록과 alias를 조회합니다.',
+      description:
+        '예약 가능한 스터디룸 목록과 alias를 조회합니다. roomName이 필요한 툴 호출 전 반드시 먼저 호출하여 정확한 이름을 확인하세요.',
       input_schema: {
         type: 'object' as const,
         properties: {},

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -109,6 +109,73 @@ export class BookingTool {
         ],
       },
     },
+    {
+      name: 'cancel_booking',
+      description:
+        '스터디룸 예약을 취소합니다. calendarId와 eventId는 get_my_bookings에서 확인하세요.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          calendarId: {
+            type: 'string',
+            description: 'get_my_bookings에서 반환된 calendarId',
+          },
+          eventId: {
+            type: 'string',
+            description: 'get_my_bookings에서 반환된 eventId',
+          },
+        },
+        required: ['calendarId', 'eventId'],
+      },
+    },
+    {
+      name: 'modify_booking',
+      description:
+        '스터디룸 예약을 수정합니다. calendarId와 eventId는 get_my_bookings에서 확인하세요. 시작/종료 시간은 반드시 15분 단위여야 합니다.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          calendarId: {
+            type: 'string',
+            description: 'get_my_bookings에서 반환된 calendarId',
+          },
+          eventId: {
+            type: 'string',
+            description: 'get_my_bookings에서 반환된 eventId',
+          },
+          title: {
+            type: 'string',
+            description: '예약 목적',
+          },
+          startDatetime: {
+            type: 'string',
+            description: '수정할 시작 일시 (ISO 8601, 15분 단위)',
+          },
+          endDatetime: {
+            type: 'string',
+            description: '수정할 종료 일시 (ISO 8601, 15분 단위)',
+          },
+          attendeeSlackIds: {
+            type: 'array',
+            items: { type: 'string' },
+            description: '수정할 참석자 슬랙 ID 목록 (예약자 본인 포함)',
+          },
+          resourceName: {
+            type: 'string',
+            description: '스터디룸 이름 (get_my_bookings의 resourceName)',
+          },
+        },
+        required: [
+          'calendarId',
+          'eventId',
+          'title',
+          'startDatetime',
+          'endDatetime',
+          'attendeeSlackIds',
+          'resourceName',
+        ],
+      },
+    },
   ];
 
   constructor(
@@ -136,6 +203,8 @@ export class BookingTool {
             .map((u) => ({ name: u.name, slackId: u.slackId, code: u.code }));
 
           return {
+            calendarId: b.calendarId,
+            eventId: b.eventId,
             resourceName: b.resourceName,
             summary: b.summary,
             startTime: toKSTString(b.startTime),
@@ -208,6 +277,55 @@ export class BookingTool {
         attendeeSlackIds,
       });
       return { success: true, eventId };
+    }
+
+    if (name === 'cancel_booking') {
+      const { calendarId, eventId } = input as {
+        calendarId: string;
+        eventId: string;
+      };
+      await this.studyRoomService.cancelBooking(calendarId, eventId);
+      return { success: true };
+    }
+
+    if (name === 'modify_booking') {
+      const {
+        calendarId,
+        eventId,
+        title,
+        startDatetime,
+        endDatetime,
+        attendeeSlackIds,
+        resourceName,
+      } = input as {
+        calendarId: string;
+        eventId: string;
+        title: string;
+        startDatetime: string;
+        endDatetime: string;
+        attendeeSlackIds: string[];
+        resourceName: string;
+      };
+      const start = new Date(startDatetime);
+      const end = new Date(endDatetime);
+      if (start.getMinutes() % 15 !== 0 || end.getMinutes() % 15 !== 0) {
+        return {
+          success: false,
+          error: '시작 및 종료 시간은 15분 단위여야 합니다.',
+        };
+      }
+      const result = await this.studyRoomService.modifyBooking(
+        calendarId,
+        eventId,
+        {
+          title,
+          startTime: start,
+          endTime: end,
+          attendeeSlackIds,
+          resourceName,
+        },
+      );
+      return { success: true, result };
     }
 
     return null;

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -17,6 +17,22 @@ export class BookingTool {
       },
     },
     {
+      name: 'find_user',
+      description:
+        '이름, 학번, 이메일로 ACTIVE 유저를 검색합니다. 여러 키워드를 한 번에 전달해 참석자를 일괄 조회할 수 있습니다.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          keywords: {
+            type: 'array',
+            items: { type: 'string' },
+            description: '검색할 이름, 학번, 이메일 목록 (부분 일치)',
+          },
+        },
+        required: ['keywords'],
+      },
+    },
+    {
       name: 'get_study_rooms',
       description:
         '예약 가능한 스터디룸 목록과 alias를 조회합니다. roomName이 필요한 툴 호출 전 반드시 먼저 호출하여 정확한 이름을 확인하세요.',
@@ -88,6 +104,17 @@ export class BookingTool {
         }),
       );
     }
+    if (name === 'find_user') {
+      const { keywords } = input as { keywords: string[] };
+      const results = await Promise.all(
+        keywords.map(async (keyword) => ({
+          keyword,
+          users: await this.userService.findActiveByKeyword(keyword),
+        })),
+      );
+      return results;
+    }
+
     if (name === 'get_study_rooms') {
       return this.studyRoomService.getStudyRooms();
     }

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -68,6 +68,47 @@ export class BookingTool {
         required: ['startDatetime', 'endDatetime'],
       },
     },
+    {
+      name: 'book_room',
+      description:
+        '스터디룸을 예약합니다. 예약 전 반드시 check_room_availability로 시간대를 확인하세요. 참석자 slackId는 find_user로 조회하세요.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          roomId: {
+            type: 'number',
+            description: 'get_study_rooms에서 반환된 방 ID',
+          },
+          title: {
+            type: 'string',
+            description: '예약 목적 (예: 스터디, 팀 프로젝트 회의)',
+          },
+          startDatetime: {
+            type: 'string',
+            description:
+              '예약 시작 일시 (ISO 8601, 반드시 15분 단위, 예: 2025-05-10T14:00:00+09:00, 2025-05-10T14:15:00+09:00)',
+          },
+          endDatetime: {
+            type: 'string',
+            description:
+              '예약 종료 일시 (ISO 8601, 반드시 15분 단위, 예: 2025-05-10T16:00:00+09:00, 2025-05-10T15:45:00+09:00)',
+          },
+          attendeeSlackIds: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              '참석자 슬랙 ID 목록 (예약자 본인 제외, 혼자 예약 시 빈 배열 전달)',
+          },
+        },
+        required: [
+          'roomId',
+          'title',
+          'startDatetime',
+          'endDatetime',
+          'attendeeSlackIds',
+        ],
+      },
+    },
   ];
 
   constructor(
@@ -138,6 +179,35 @@ export class BookingTool {
           endTime: toKSTString(new Date(b.endTime)),
         })),
       }));
+    }
+
+    if (name === 'book_room') {
+      const { roomId, title, startDatetime, endDatetime, attendeeSlackIds } =
+        input as {
+          roomId: number;
+          title: string;
+          startDatetime: string;
+          endDatetime: string;
+          attendeeSlackIds: string[];
+        };
+      const start = new Date(startDatetime);
+      const end = new Date(endDatetime);
+      if (start.getMinutes() % 15 !== 0 || end.getMinutes() % 15 !== 0) {
+        return {
+          success: false,
+          error: '시작 및 종료 시간은 15분 단위여야 합니다.',
+        };
+      }
+
+      const eventId = await this.studyRoomService.bookResource({
+        resourceId: roomId,
+        title,
+        startTime: start,
+        endTime: end,
+        bookerSlackId: slackId,
+        attendeeSlackIds,
+      });
+      return { success: true, eventId };
     }
 
     return null;

--- a/src/user/service/user.service.ts
+++ b/src/user/service/user.service.ts
@@ -158,4 +158,19 @@ export class UserService {
   async deleteViewId(slackUserId: string): Promise<void> {
     this.viewIdStore.delete(slackUserId);
   }
+
+  // 이름, 학번, 이메일로 ACTIVE 유저 검색
+  async findActiveByKeyword(
+    keyword: string,
+  ): Promise<Pick<User, 'slackId' | 'name' | 'code' | 'email'>[]> {
+    return this.userRepository
+      .createQueryBuilder('user')
+      .select(['user.slackId', 'user.name', 'user.code', 'user.email'])
+      .where('user.status = :status', { status: UserStatus.ACTIVE })
+      .andWhere(
+        '(user.name LIKE :keyword OR user.code LIKE :keyword OR user.email LIKE :keyword)',
+        { keyword: `%${keyword}%` },
+      )
+      .getMany();
+  }
 }


### PR DESCRIPTION
## 개요

Slack DM으로 자연어 요청을 처리하는 스터디룸 예약 AI 어시스턴트를 구현합니다. Claude Haiku API의 tool_use를 활용한 멀티 라운드 에이전틱 루프로 예약 조회·생성·수정·취소를 지원합니다.

## 주요 변경 사항

### SlackAiModule — Slack DM AI 핸들러
- `@Message(/.*/)`로 DM 수신, 봇 메시지·비DM 채널 필터링
- 오류 발생 시 slackId + 스택 트레이스 로깅

### SlackAiService — Claude API 에이전틱 루프
- 최대 10 라운드 멀티 라운드 tool_use 루프
- 시스템 프롬프트: 유저 이름, 현재 KST 날짜, 내부 식별자 미노출 지침 포함
- Redis 대화 히스토리 (TTL 1시간, 최근 10턴 슬라이딩 윈도우)
- 슬라이스 시 고아 `tool_result`가 앞에 남지 않도록 정합성 보정

### ToolsService + BookingTool — 7개 툴 레지스트리
| 툴 | 설명 |
|---|---|
| `get_my_bookings` | 내 예약 목록 조회 (calendarId, eventId 포함) |
| `get_study_rooms` | 스터디룸 목록 및 alias 조회 |
| `check_room_availability` | 지정 시간 범위 내 예약 현황 조회 |
| `find_user` | 이름·학번·이메일로 ACTIVE 유저 일괄 검색 |
| `book_room` | 스터디룸 예약 (15분 단위 검증) |
| `cancel_booking` | 예약 취소 |
| `modify_booking` | 예약 수정 |

### StudyRoomService / UserService 수정
- `getStudyRooms()`: alias 필드 포함 반환
- `getRoomAvailability()`: roomName alias 필터링 지원
- `getMyBookings()`: attendeeEmails 필드 추가
- `findActiveByKeyword()`: 이름·학번·이메일 LIKE 검색

### 기타
- `toKSTString` 유틸 추가 (Date → KST 한국어 로케일)
- `.env.example`에 `ANTHROPIC_API_KEY` 추가

## 관련 이슈

없음

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] DM으로 예약 조회·생성·수정·취소 전체 플로우 확인
- [x] 대화 히스토리 연속 대화 동작 확인