### PR TITLE
infra(ci): ECS 배포 시 최신 태스크 정의 ARN 명시 및 에러 처리 추가

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -86,9 +86,19 @@ jobs:
 
       - name: Force new ECS deployment
         run: |
+          TASK_DEF_ARN=$(aws ecs describe-task-definition \
+            --task-definition bannote-prod-task \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text \
+            --region ap-northeast-2)
+          if [ -z "$TASK_DEF_ARN" ]; then
+            echo "Failed to retrieve task definition ARN" >&2
+            exit 1
+          fi
           aws ecs update-service \
             --cluster bannote-prod-cluster \
             --service bannote-prod-service \
+            --task-definition "$TASK_DEF_ARN" \
             --force-new-deployment \
             --region ap-northeast-2
 


### PR DESCRIPTION
## 개요

ECS 배포 시 Terraform이 생성한 최신 태스크 정의 리비전이 실제 서비스에 반영되지 않는 문제를 수정합니다.

## 문제

`ignore_changes = [task_definition]`으로 인해 Terraform이 새 태스크 정의 리비전을 생성해도 ECS 서비스는 이전 리비전을 그대로 사용합니다. 기존 `--force-new-deployment`만으로는 현재 서비스에 등록된 구 리비전으로 재배포되어 변경사항(새 환경변수, 시크릿 등)이 반영되지 않습니다.

## 주요 변경 사항

### .github/workflows/docker-publish.yml
- Terraform apply 직후 `describe-task-definition`으로 최신 태스크 정의 ARN을 조회
- `update-service`에 `--task-definition`으로 최신 ARN을 명시적으로 전달
- ARN 조회 실패 시 빈 값으로 계속 진행하지 않도록 검증 및 `exit 1` 처리 추가
- 변수 참조 시 따옴표 적용 (shell best practice)

## 관련 이슈

없음

## 테스트

- [ ] 릴리즈 배포 시 ECS 서비스가 최신 태스크 정의 리비전으로 업데이트되는지 확인
