### PR TITLE
feat(slack-ai): 툴 실행 단계별 진행 상태 메시지 표시

### DIFF
--- a/src/slack-ai/slack-ai.handler.ts
+++ b/src/slack-ai/slack-ai.handler.ts
@@ -1,13 +1,13 @@
 import { Controller, Logger } from '@nestjs/common';
 import { Message } from 'nestjs-slack-bolt';
-import type { SlackEventMiddlewareArgs } from '@slack/bolt';
+import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from '@slack/bolt';
 import { SlackAiService } from './slack-ai.service';
 
 function toSlackMrkdwn(text: string): string {
   return text
-    .replace(/\*\*(.+?)\*\*/g, '*$1*')   // **bold** → *bold*
+    .replace(/\*\*(.+?)\*\*/g, '*$1*') // **bold** → *bold*
     .replace(/^#{1,6}\s+(.+)$/gm, '*$1*') // # heading → *heading*
-    .replace(/^- /gm, '• ');              // - list → • list
+    .replace(/^- /gm, '• '); // - list → • list
 }
 
 @Controller()
@@ -17,7 +17,11 @@ export class SlackAiHandler {
   constructor(private readonly slackAiService: SlackAiService) {}
 
   @Message(/.*/)
-  async handleDm({ body, say }: SlackEventMiddlewareArgs<'message'>) {
+  async handleDm({
+    body,
+    say,
+    client,
+  }: SlackEventMiddlewareArgs<'message'> & AllMiddlewareArgs) {
     const event = body.event as unknown as Record<string, unknown>;
 
     // DM 채널만 처리
@@ -34,14 +38,42 @@ export class SlackAiHandler {
     // 기존 키워드 핸들러가 처리하는 명령어 제외
     if (/^health$/i.test(text.trim())) return;
 
+    const channel = event.channel as string;
+    const loadingMsg = await say('🤔 생각 중...');
+
     try {
-      const reply = await this.slackAiService.handleMessage(slackId, text);
-      await say({ text: reply, blocks: [{ type: 'section', text: { type: 'mrkdwn', text: toSlackMrkdwn(reply) } }] });
-    } catch (e) {
-      this.logger.error(`[handleDm] slackId=${slackId} error=${String(e)}`, e instanceof Error ? e.stack : undefined);
-      await say(
-        '죄송합니다. 요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      const reply = await this.slackAiService.handleMessage(
+        slackId,
+        text,
+        async (msg) => {
+          await client.chat.update({
+            channel,
+            ts: loadingMsg.ts as string,
+            text: msg,
+          });
+        },
       );
+      await client.chat.update({
+        channel,
+        ts: loadingMsg.ts as string,
+        text: reply,
+        blocks: [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: toSlackMrkdwn(reply) },
+          },
+        ],
+      });
+    } catch (e) {
+      this.logger.error(
+        `[handleDm] slackId=${slackId} error=${String(e)}`,
+        e instanceof Error ? e.stack : undefined,
+      );
+      await client.chat.update({
+        channel,
+        ts: loadingMsg.ts as string,
+        text: '죄송합니다. 요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      });
     }
   }
 }

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -71,7 +71,21 @@ export class SlackAiService {
     await this.cache.set(this.historyKey(slackId), messages, HISTORY_TTL_MS);
   }
 
-  async handleMessage(slackId: string, text: string): Promise<string> {
+  private readonly TOOL_LABELS: Record<string, string> = {
+    get_my_bookings: '📋 내 예약 조회 중...',
+    find_user: '🔍 참석자 검색 중...',
+    get_study_rooms: '🏫 스터디룸 목록 조회 중...',
+    check_room_availability: '🗓️ 가용 여부 확인 중...',
+    book_room: '✏️ 예약 생성 중...',
+    cancel_booking: '🗑️ 예약 취소 중...',
+    modify_booking: '🔄 예약 수정 중...',
+  };
+
+  async handleMessage(
+    slackId: string,
+    text: string,
+    onProgress?: (msg: string) => Promise<void>,
+  ): Promise<string> {
     const tools = this.toolsService.getDefinitions();
     const user = await this.userService.findBySlackId(slackId);
     const systemPrompt = buildSystemPrompt(user?.name ?? null);
@@ -111,6 +125,10 @@ export class SlackAiService {
         this.logger.log(
           `[handleMessage] 툴 실행: ${block.name} (${round + 1}라운드)`,
         );
+        if (onProgress) {
+          const label = this.TOOL_LABELS[block.name] ?? '⚙️ 처리 중...';
+          await onProgress(label);
+        }
         const result = await this.toolsService.execute(
           block.name,
           block.input,


### PR DESCRIPTION
## 개요

AI 어시스턴트가 요청을 처리하는 동안 딜레이가 있어 사용자가 응답을 기다리는 느낌이 강했습니다.
DM 수신 즉시 임시 메시지를 전송하고, 각 툴 실행 단계마다 진행 상황을 실시간으로 업데이트합니다.

## 주요 변경 사항

### 즉시 로딩 메시지 표시

DM 수신 즉시 "🤔 생각 중..." 메시지를 전송하여 봇이 처리 중임을 즉각 알립니다.

### 툴 실행 단계별 메시지 업데이트

Claude가 툴을 호출할 때마다 해당 작업을 나타내는 메시지로 실시간 업데이트합니다.

| 툴 | 표시 메시지 |
|---|---|
| `get_my_bookings` | 📋 내 예약 조회 중... |
| `find_user` | 🔍 참석자 검색 중... |
| `get_study_rooms` | 🏫 스터디룸 목록 조회 중... |
| `check_room_availability` | 🗓️ 가용 여부 확인 중... |
| `book_room` | ✏️ 예약 생성 중... |
| `cancel_booking` | 🗑️ 예약 취소 중... |
| `modify_booking` | 🔄 예약 수정 중... |

처리 완료 시 `chat.update`로 임시 메시지를 최종 응답으로 교체합니다.

### 구현 방식

- `handleMessage`에 `onProgress` 콜백 파라미터 추가 (선택적)
- 핸들러에서 콜백으로 `chat.update` 호출 — 서비스 계층이 Slack에 직접 의존하지 않음

## 관련 이슈

없음

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 DM 전송 시 진행 상태 메시지 확인
- [x] 툴 호출이 여러 라운드 발생하는 요청에서 메시지가 단계별로 업데이트되는지 확인
- [x] 오류 발생 시 에러 메시지로 정상 교체되는지 확인

## 스크린샷 (선택)

없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)