### PR TITLE
hotfix: 미가입 유저 안내 메시지 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,6 @@ CLOUDFLARE_TUNNEL_TOKEN=
 
 # Anthropic (AI 어시스턴트)
 ANTHROPIC_API_KEY=
+
+# 관리자 슬랙 아이디
+ADMIN_SLACK_ID=

--- a/src/slack-ai/slack-ai.handler.ts
+++ b/src/slack-ai/slack-ai.handler.ts
@@ -1,7 +1,9 @@
 import { Controller, Logger } from '@nestjs/common';
 import { Message } from 'nestjs-slack-bolt';
 import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from '@slack/bolt';
+import type { KnownBlock } from '@slack/types';
 import { SlackAiService } from './slack-ai.service';
+import { UserService } from '../user/service/user.service';
 
 function toSlackMrkdwn(text: string): string {
   return text
@@ -10,11 +12,19 @@ function toSlackMrkdwn(text: string): string {
     .replace(/^- /gm, '• '); // - list → • list
 }
 
+const HOME_GUIDE_IMAGE_URL =
+  'https://gsc-slack-app-045861054142-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/assets/images/home-tab-guide.png';
+const USER_GUIDE_URL =
+  'https://www.kyumin.dev/ko/posts/bannote-slack/user-guide';
+
 @Controller()
 export class SlackAiHandler {
   private readonly logger = new Logger(SlackAiHandler.name);
 
-  constructor(private readonly slackAiService: SlackAiService) {}
+  constructor(
+    private readonly slackAiService: SlackAiService,
+    private readonly userService: UserService,
+  ) {}
 
   @Message(/.*/)
   async handleDm({
@@ -34,6 +44,65 @@ export class SlackAiHandler {
     const text = (event.text as string) ?? '';
 
     if (!slackId || !text.trim()) return;
+
+    const user = await this.userService.findBySlackId(slackId);
+    if (!user) {
+      const adminSlackId = process.env.ADMIN_SLACK_ID;
+      const blocks: KnownBlock[] = [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '안녕하세요! 저는 GSC의 어시스턴트 *Bannote Bot* 이에요, 우선 회원가입이 필요해요 😊\n아래 *가입하기* 버튼을 눌러 회원가입 후 언제든지 편하게 말을 걸어 주세요! 자세한 설명은 유저 가이드를 참고해 주세요.',
+          },
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '가입하기' },
+              action_id: 'user:home:open_register_modal',
+              style: 'primary',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '유저 가이드' },
+              action_id: 'slack-ai:unregistered:user-guide:open-url',
+              url: USER_GUIDE_URL,
+            },
+          ],
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '상단의 *홈* 탭(아래 사진 참고)에서 더 많은 기능을 이용할 수 있어요‼️',
+          },
+        },
+        {
+          type: 'image',
+          image_url: HOME_GUIDE_IMAGE_URL,
+          alt_text: '슬랙 홈 탭 위치 안내',
+        },
+      ];
+
+      if (adminSlackId) {
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `🚨 문의 사항은 <@${adminSlackId}>에게 연락 해주세요`,
+          },
+        });
+      }
+
+      await say({
+        text: '서비스를 이용하려면 먼저 회원가입을 진행해 주세요.',
+        blocks,
+      });
+      return;
+    }
 
     // 기존 키워드 핸들러가 처리하는 명령어 제외
     if (/^health$/i.test(text.trim())) return;

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -59,6 +59,7 @@ resource "aws_ecs_task_definition" "app" {
         { name = "REDIS_HOST", value = aws_elasticache_cluster.main.cache_nodes[0].address },
         { name = "REDIS_PORT", value = tostring(aws_elasticache_cluster.main.cache_nodes[0].port) },
         { name = "GOOGLE_WEBHOOK_URL", value = "https://${var.app_domain}" },
+        { name = "ADMIN_SLACK_ID", value = var.admin_slack_id },
       ]
 
       logConfiguration = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -83,6 +83,13 @@ variable "acm_certificate_arn" {
   type        = string
 }
 
+# Admin
+variable "admin_slack_id" {
+  description = "Slack user ID of the admin (used for mentions in bot messages)"
+  type        = string
+  default     = "U0A4DCMHHKM"
+}
+
 # Secrets Manager
 variable "secrets_arn" {
   description = "Secrets Manager secret ARN containing app environment variables"


### PR DESCRIPTION
## 개요

- 미가입 유저가 AI 어시스턴트에 DM을 보낼 경우, 그대로 Claude API를 호출해 토큰을 소모했고 , 툴 실행 시 유저를 찾지 못해 모든 툴이 실패
- API 호출 전 DB에서 유저 여부를 먼저 확인하고, 미가입 유저는 회원가입 안내 메시지를 반환하도록 변경

## 주요 변경 사항

### 미가입 유저 안내 메시지 (slack-ai.handler.ts)

- DM 수신 시 DB에서 슬랙 ID로 유저 존재 여부를 먼저 확인
- 미가입 유저에게 아래 내용을 포함한 Block Kit 메시지 반환
  - 가입하기 버튼 (홈 탭 가입 모달 연결)
  - 유저 가이드 버튼 (외부 링크)
  - 가입 안내
  - 홈 탭 안내 이미지
  - `ADMIN_SLACK_ID` 환경변수 설정 시 관리자 멘션 표시

### 관리자 슬랙 ID 환경변수 추가 (terraform)

- `variables.tf`에 `admin_slack_id` 변수 추가
- `ecs.tf` 컨테이너 환경변수에 `ADMIN_SLACK_ID` 추가

## 관련 이슈

없음

## 테스트

- [x] 미가입 슬랙 계정으로 DM 전송 → 안내 메시지 확인
- [x] 가입하기 버튼 동작 확인
- [x] 유저 가이드 버튼 동작 확인
- [x] 관리자 멘션 표시 확인

## 스크린샷 (선택)

<img width="1602" height="1038" alt="CleanShot 2026-05-11 at 13 20 49@2x" src="https://github.com/user-attachments/assets/65d32ec9-bcd3-4587-86ec-b60943a42c7b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)