### PR TITLE
feat(resource): 내 예약 수정/취소 비동기 처리 및 모달 새로고침

### DIFF
--- a/src/common/date.util.ts
+++ b/src/common/date.util.ts
@@ -3,6 +3,12 @@ export function toKST(date: Date): Date {
   return new Date(date.getTime() + 9 * 60 * 60 * 1000);
 }
 
+/** Date → KST HH:mm 문자열 */
+export function toKSTTimeStr(date: Date): string {
+  const kst = toKST(date);
+  return `${String(kst.getUTCHours()).padStart(2, '0')}:${String(kst.getUTCMinutes()).padStart(2, '0')}`;
+}
+
 /** UTC Date → KST 한국어 문자열 (Claude tool result용) */
 export function toKSTString(date: Date): string {
   return date.toLocaleString('ko-KR', {
@@ -14,4 +20,9 @@ export function toKSTString(date: Date): string {
     hour: '2-digit',
     minute: '2-digit',
   });
+}
+
+/** 시작 시간에 이용 시간(분)을 더해 종료 시간 반환 */
+export function addMinutes(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60 * 1000);
 }

--- a/src/resource/controller/study-room.controller.ts
+++ b/src/resource/controller/study-room.controller.ts
@@ -6,6 +6,7 @@ import type {
   SlackViewMiddlewareArgs,
   BlockAction,
 } from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
 import { ResourceService } from '../service/resource.service';
 import { StudyRoomService } from '../service/study-room.service';
 import { ProfessorService } from '../service/professor.service';
@@ -26,6 +27,36 @@ export class StudyRoomController {
     private readonly userService: UserService,
     private readonly googleEventsService: GoogleEventsService,
   ) {}
+
+  private async withMyBookingsFeedback<T>(
+    params: {
+      ack: (response?: any) => Promise<void>;
+      client: WebClient;
+      viewId: string;
+      userId: string;
+      parentViewId?: string;
+    },
+    operation: () => Promise<T>,
+    handlers: {
+      successTitle?: string;
+      successText: (result: T) => string;
+    },
+  ): Promise<void> {
+    await withModalFeedback(params, operation, handlers);
+
+    if (params.parentViewId) {
+      const [bookings, consultations] = await Promise.all([
+        this.studyRoomService.getMyBookings(params.userId),
+        this.professorService.getConsultations(params.userId),
+      ]);
+      await params.client.views
+        .update({
+          view_id: params.parentViewId,
+          view: ResourceView.myBookingsModal(bookings, consultations),
+        })
+        .catch(() => {});
+    }
+  }
 
   // 스터디룸 예약 목록 모달 열기 (활성 유저만)
   @Action('home:open-booking')
@@ -163,9 +194,14 @@ export class StudyRoomController {
     }
 
     if (view.callback_id === 'study-room:modal:modify-booking') {
-      const { calendarId, eventId, roomName } = JSON.parse(
+      const { calendarId, eventId, roomName, parentViewId } = JSON.parse(
         view.private_metadata,
-      ) as { calendarId: string; eventId: string; roomName: string };
+      ) as {
+        calendarId: string;
+        eventId: string;
+        roomName: string;
+        parentViewId: string;
+      };
 
       const summary = values.title_block?.title_input?.value ?? '';
       const attendeeSlackIds =
@@ -182,7 +218,15 @@ export class StudyRoomController {
         view_id: view.id,
         hash: view.hash,
         view: StudyRoomView.modifyBookingModal(
-          { calendarId, eventId, roomName, summary, startTime, endTime },
+          {
+            calendarId,
+            eventId,
+            roomName,
+            summary,
+            startTime,
+            endTime,
+            parentViewId,
+          },
           attendeeSlackIds,
         ),
       });
@@ -243,6 +287,7 @@ export class StudyRoomController {
           summary: event?.summary ?? '',
           startTime: new Date(startIso),
           endTime: new Date(endIso),
+          parentViewId: body.view?.id ?? '',
         },
         initialAttendeeSlackIds,
       ),
@@ -257,9 +302,14 @@ export class StudyRoomController {
     body,
   }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
     const values = body.view.state.values;
-    const { calendarId, eventId, roomName } = JSON.parse(
+    const { calendarId, eventId, roomName, parentViewId } = JSON.parse(
       body.view.private_metadata,
-    ) as { calendarId: string; eventId: string; roomName: string };
+    ) as {
+      calendarId: string;
+      eventId: string;
+      roomName: string;
+      parentViewId: string;
+    };
 
     const title = values.title_block.title_input.value ?? '';
     const date = values.date_block.date_select.selected_date ?? '';
@@ -284,38 +334,37 @@ export class StudyRoomController {
       return;
     }
 
-    await ack();
-
     const startTime = new Date(`${date}T${startTimeStr}:00+09:00`);
     const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
 
-    const result = await this.studyRoomService.modifyBooking(
-      calendarId,
-      eventId,
+    await this.withMyBookingsFeedback(
       {
-        title,
-        startTime,
-        endTime,
-        attendeeSlackIds,
+        ack,
+        client,
+        viewId: body.view.id,
+        userId: body.user.id,
+        parentViewId,
+      },
+      () =>
+        this.studyRoomService.modifyBooking(calendarId, eventId, {
+          title,
+          startTime,
+          endTime,
+          attendeeSlackIds,
+        }),
+      {
+        successTitle: '예약 수정 완료',
+        successText: (result) =>
+          result === 'cancelled'
+            ? `🗑️ 참석자가 없어 *${roomName}* 예약이 취소되었습니다.`
+            : `✅ *${roomName}* 예약이 수정되었습니다.\n${date} ${startTimeStr} (${durationMinutes}분)`,
       },
     );
-
-    if (result === 'cancelled') {
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `🗑️ 참석자가 없어 *${roomName}* 예약이 취소되었습니다.\n${date} ${startTimeStr} (${durationMinutes}분)`,
-      });
-    } else {
-      await client.chat.postMessage({
-        channel: body.user.id,
-        text: `✅ *${roomName}* 예약이 수정되었습니다.\n${date} ${startTimeStr} (${durationMinutes}분)`,
-      });
-    }
   }
 
-  // 예약 취소 처리
+  // 예약 취소 확인 모달 열기
   @Action('study-room:action:cancel')
-  async cancelBooking({
+  async openCancelConfirm({
     ack,
     client,
     body,
@@ -327,11 +376,49 @@ export class StudyRoomController {
       (action as { value: string }).value,
     ) as { calendarId: string; eventId: string; roomName: string };
 
-    await this.studyRoomService.cancelBooking(calendarId, eventId);
-    await client.chat.postMessage({
-      channel: body.user.id,
-      text: `✅ *${roomName}* 예약이 취소되었습니다.`,
+    const parentViewId = body.view?.id ?? '';
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: StudyRoomView.cancelConfirmModal({
+        calendarId,
+        eventId,
+        roomName,
+        parentViewId,
+      }),
     });
+  }
+
+  // 예약 취소 확인 모달 제출 처리
+  @View('study-room:modal:cancel-confirm')
+  async submitCancelBooking({
+    ack,
+    client,
+    body,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const { calendarId, eventId, roomName, parentViewId } = JSON.parse(
+      body.view.private_metadata,
+    ) as {
+      calendarId: string;
+      eventId: string;
+      roomName: string;
+      parentViewId: string;
+    };
+
+    await this.withMyBookingsFeedback(
+      {
+        ack,
+        client,
+        viewId: body.view.id,
+        userId: body.user.id,
+        parentViewId,
+      },
+      () => this.studyRoomService.cancelBooking(calendarId, eventId),
+      {
+        successTitle: '예약 취소 완료',
+        successText: () => `🗑️ *${roomName}* 예약이 취소되었습니다.`,
+      },
+    );
   }
 
   // 내 예약 모달 열기 (스터디룸 예약 + 교수 상담 통합)

--- a/src/resource/controller/study-room.controller.ts
+++ b/src/resource/controller/study-room.controller.ts
@@ -17,6 +17,7 @@ import { UserStatus } from '../../user/user.entity';
 import { GoogleEventsService } from '../../google/calendar/events.service';
 import { ResourceType } from '../resource.entity';
 import { withModalFeedback } from '../../common/modal-feedback.util';
+import { addMinutes, toKSTTimeStr } from '../../common/date.util';
 
 @Controller()
 export class StudyRoomController {
@@ -44,6 +45,7 @@ export class StudyRoomController {
   ): Promise<void> {
     await withModalFeedback(params, operation, handlers);
 
+    // 열려있던 내 예약 모달 갱신
     if (params.parentViewId) {
       const [bookings, consultations] = await Promise.all([
         this.studyRoomService.getMyBookings(params.userId),
@@ -141,7 +143,7 @@ export class StudyRoomController {
 
     const viewId = body.view.id;
     const startTime = new Date(`${date}T${startTimeStr}:00+09:00`);
-    const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
+    const endTime = addMinutes(startTime, durationMinutes);
 
     await withModalFeedback(
       { ack, client, viewId, userId: body.user.id },
@@ -212,7 +214,7 @@ export class StudyRoomController {
           ? new Date(`${dateStr}T${startTimeStr}:00+09:00`)
           : new Date();
       const durationMin = durationStr ? parseInt(durationStr, 10) : 60;
-      const endTime = new Date(startTime.getTime() + durationMin * 60 * 1000);
+      const endTime = addMinutes(startTime, durationMin);
 
       await client.views.update({
         view_id: view.id,
@@ -335,7 +337,8 @@ export class StudyRoomController {
     }
 
     const startTime = new Date(`${date}T${startTimeStr}:00+09:00`);
-    const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
+    const endTime = addMinutes(startTime, durationMinutes);
+    const endTimeStr = toKSTTimeStr(endTime);
 
     await this.withMyBookingsFeedback(
       {
@@ -357,7 +360,7 @@ export class StudyRoomController {
         successText: (result) =>
           result === 'cancelled'
             ? `🗑️ 참석자가 없어 *${roomName}* 예약이 취소되었습니다.`
-            : `✅ *${roomName}* 예약이 수정되었습니다.\n${date} ${startTimeStr} (${durationMinutes}분)`,
+            : `✅ *${roomName}* 예약이 수정되었습니다.\n${date} ${startTimeStr}~${endTimeStr}`,
       },
     );
   }

--- a/src/resource/view/resource.view.ts
+++ b/src/resource/view/resource.view.ts
@@ -3,7 +3,7 @@ import { Resource, ResourceStatus, ResourceType } from '../resource.entity';
 import { multiUsersSelectBlock } from '../../common/blocks';
 import { BookingItem } from '../dto/study-room.dto';
 import { ConsultationItem } from '../dto/professor.dto';
-import { toKST } from '../../utils/date.util';
+import { toKST } from '../../common/date.util';
 
 export class ResourceView {
   // 리소스 생성 모달

--- a/src/resource/view/resource.view.ts
+++ b/src/resource/view/resource.view.ts
@@ -471,16 +471,6 @@ export class ResourceView {
                 action_id: 'study-room:action:cancel',
                 style: 'danger',
                 value: meta,
-                confirm: {
-                  title: { type: 'plain_text', text: '예약 취소' },
-                  text: {
-                    type: 'mrkdwn',
-                    text: `*${booking.summary}* 예약을 취소하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`,
-                  },
-                  confirm: { type: 'plain_text', text: '취소하기' },
-                  deny: { type: 'plain_text', text: '돌아가기' },
-                  style: 'danger',
-                },
               },
             ],
           },

--- a/src/resource/view/study-room.view.ts
+++ b/src/resource/view/study-room.view.ts
@@ -198,6 +198,7 @@ export class StudyRoomView {
       summary: string;
       startTime: Date;
       endTime: Date;
+      parentViewId?: string;
     },
     initialAttendeeSlackIds: string[] = [],
   ): View {
@@ -221,6 +222,7 @@ export class StudyRoomView {
         calendarId: booking.calendarId,
         eventId: booking.eventId,
         roomName: booking.roomName,
+        parentViewId: booking.parentViewId ?? '',
       }),
       blocks: [
         {
@@ -297,6 +299,32 @@ export class StudyRoomView {
           initialUsers: initialAttendeeSlackIds,
           optional: true,
         }),
+      ],
+    };
+  }
+
+  // 예약 취소 확인 모달
+  static cancelConfirmModal(params: {
+    calendarId: string;
+    eventId: string;
+    roomName: string;
+    parentViewId: string;
+  }): View {
+    return {
+      type: 'modal',
+      callback_id: 'study-room:modal:cancel-confirm',
+      title: { type: 'plain_text', text: '예약 취소' },
+      submit: { type: 'plain_text', text: '취소하기' },
+      close: { type: 'plain_text', text: '돌아가기' },
+      private_metadata: JSON.stringify(params),
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${params.roomName}* 예약을 취소하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`,
+          },
+        },
       ],
     };
   }

--- a/src/resource/view/study-room.view.ts
+++ b/src/resource/view/study-room.view.ts
@@ -1,6 +1,6 @@
 import type { View } from '@slack/types';
 import { Resource } from '../resource.entity';
-import { toKST } from '../../utils/date.util';
+import { toKST } from '../../common/date.util';
 import { multiUsersSelectBlock } from '../../common/blocks';
 import { CALENDAR_COLORS } from '../../common/constants';
 

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import type Anthropic from '@anthropic-ai/sdk';
 import { StudyRoomService } from '../resource/service/study-room.service';
 import { UserService } from '../user/service/user.service';
-import { toKSTString } from '../utils/date.util';
+import { toKSTString } from '../common/date.util';
 
 @Injectable()
 export class BookingTool {


### PR DESCRIPTION
## 개요

기존 내 예약 모달에서 수정/취소 액션이 동기적으로 처리되어 결과를 DM으로 전송하던 방식을 개선했습니다.
예약 생성과 동일하게 `withModalFeedback` 패턴으로 비동기 처리하고, 완료 후 내 예약 모달을 자동으로 새로고침합니다.

## 변경 사항

### 수정/취소 비동기 처리
- `withMyBookingsFeedback` 래퍼 메서드 추가 — `withModalFeedback` 호출 후 부모 모달(내 예약)을 자동 새로고침
- 수정 완료 시 DM 대신 수정 모달에 결과 표시
- 성공 메시지 형식: `시작시간~종료시간` 으로 변경

### 취소 확인 모달 도입
- 기존 native `confirm` 다이얼로그 → `views.push` 방식의 확인 모달로 교체
- 취소 완료 시 DM 대신 확인 모달에 결과 표시

### 부모 모달 새로고침 체인
- `private_metadata`에 부모 view_id(`parentViewId`) 포함
- 수정/취소 완료 후 내 예약 목록 자동 갱신

### date 유틸 정리
- `src/utils/date.util.ts` → `src/common/date.util.ts` 이동
- `addMinutes(date, minutes)` 추가 — 시작 시간 + 이용 시간으로 종료 시간 계산
- `toKSTTimeStr(date)` 추가 — Date → KST `HH:mm` 문자열 변환

## 테스트

- [x] 내 예약 모달에서 수정 버튼 → 수정 모달 제출 → 처리 중 표시 → 수정 완료 메시지 표시 → 내 예약 목록 자동 갱신
- [x] 내 예약 모달에서 취소 버튼 → 취소 확인 모달 → 취소하기 제출 → 처리 중 표시 → 취소 완료 메시지 표시 → 내 예약 목록 자동 갱신
- [x] 참석자 없는 경우 수정 시 예약 취소 안내 메시지 표시

## 스크린샷

### 수정
<img width="714" height="800" alt="CleanShot 2026-05-14 at 12 11 41" src="https://github.com/user-attachments/assets/2f8bf02c-8274-442d-89d5-a1ddc262f0b3" />

### 삭제
<img width="800" height="713" alt="CleanShot 2026-05-14 at 12 15 15" src="https://github.com/user-attachments/assets/fab698c3-93d3-41f4-bbea-c988cca4e3ad" />

### 수정 실패
<img width="677" height="800" alt="CleanShot 2026-05-14 at 12 20 36" src="https://github.com/user-attachments/assets/f0d9ab45-3c94-492e-baaa-77c131ed3057" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)