### PR TITLE
feat(infra): 버전 bump 후 dev 브랜치 자동 동기화

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -2,7 +2,7 @@ name: Version Bump
 
 on:
   pull_request:
-    types: [ closed ]
+    types: [closed]
     branches:
       - main
 
@@ -52,3 +52,11 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: bump version to v${NEW_VERSION}"
           git push origin main
+
+      - name: Sync version bump to dev
+        if: steps.bump-type.outputs.type != 'none'
+        run: |
+          git fetch origin dev
+          git checkout dev
+          git merge origin/main --no-ff -m "chore: sync version bump from main"
+          git push origin dev


### PR DESCRIPTION
## 개요

릴리스 후 `main`의 버전 bump 커밋이 `dev`에 자동으로 반영되지 않아, 새 피처 브랜치를 생성할 때 버전이 뒤처지는 문제를 해결합니다.

## 변경 사항

`version-bump.yml`에 `main → dev` 자동 머지 스텝 추가

- 버전 bump 커밋이 `main`에 push된 직후 `dev`에 머지
- `--no-ff` 옵션으로 머지 커밋 생성

## 동작 흐름

```
PR merged to main
  → version bump commit pushed to main
  → main을 dev에 자동 머지 (chore: sync version bump from main)
```

## 기대 효과

- 릴리스 후 새 피처 브랜치가 항상 최신 버전을 base로 시작
- 수동으로 dev를 동기화할 필요 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)