### PR TITLE
feat(slack-ai): 동시 요청 방지 처리 중 플래그 추가

### DIFF
--- a/src/slack-ai/slack-ai.handler.ts
+++ b/src/slack-ai/slack-ai.handler.ts
@@ -107,9 +107,15 @@ export class SlackAiHandler {
     // 기존 키워드 핸들러가 처리하는 명령어 제외
     if (/^health$/i.test(text.trim())) return;
 
+    if (await this.slackAiService.isProcessing(slackId)) {
+      await say('⏳ 이전 답변을 생성하고 있어요! 잠시만 기다려 주세요 😊');
+      return;
+    }
+
     const channel = event.channel as string;
     const loadingMsg = await say('🤔 생각 중...');
 
+    await this.slackAiService.setProcessing(slackId);
     try {
       const reply = await this.slackAiService.handleMessage(
         slackId,
@@ -143,6 +149,8 @@ export class SlackAiHandler {
         ts: loadingMsg.ts as string,
         text: '죄송합니다. 요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
       });
+    } finally {
+      await this.slackAiService.clearProcessing(slackId);
     }
   }
 }

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -49,6 +49,23 @@ export class SlackAiService {
     return `slack-ai:history:${slackId}`;
   }
 
+  private processingKey(slackId: string): string {
+    return `slack-ai:processing:${slackId}`;
+  }
+
+  async isProcessing(slackId: string): Promise<boolean> {
+    return (await this.cache.get(this.processingKey(slackId))) === true;
+  }
+
+  async setProcessing(slackId: string): Promise<void> {
+    // 3분 TTL: 서버 크래시 시 플래그가 영구적으로 남지 않도록
+    await this.cache.set(this.processingKey(slackId), true, 3 * 60 * 1000);
+  }
+
+  async clearProcessing(slackId: string): Promise<void> {
+    await this.cache.del(this.processingKey(slackId));
+  }
+
   private async loadHistory(
     slackId: string,
   ): Promise<Anthropic.MessageParam[]> {


### PR DESCRIPTION
## 개요

AI 응답 생성 중에 추가 메시지를 보내면 두 요청이 동시에 처리되는 문제를 해결합니다.

## 동작 방식

Redis에 `slack-ai:processing:{slackId}` 키로 처리 중 여부를 관리합니다.

```
메시지 수신
  → 처리 중 플래그 확인
  → 플래그 있음: "이전 답변 생성 중" 안내 후 종료
  → 플래그 없음: 플래그 세팅 → AI 처리 → 플래그 해제 (finally)
```

## 변경 사항

- `SlackAiService`: `isProcessing` / `setProcessing` / `clearProcessing` 메서드 추가
- `SlackAiHandler`: 메시지 수신 시 처리 중 여부 체크 및 플래그 관리
- TTL 3분 — 서버 크래시 시 플래그가 영구적으로 남지 않도록 자동 해제

🤖 Generated with [Claude Code](https://claude.com/claude-code)