### PR TITLE
fix(infra): version-bump 워크플로우 dev 동기화 오류 수정

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         if: steps.bump-type.outputs.type != 'none'
@@ -56,7 +57,8 @@ jobs:
       - name: Sync version bump to dev
         if: steps.bump-type.outputs.type != 'none'
         run: |
+          NEW_VERSION=$(jq -r .version package.json)
           git fetch origin dev
           git checkout dev
-          git merge origin/main --no-ff -m "chore: sync version bump from main"
+          git merge origin/main --no-ff -m "chore: sync version bump v${NEW_VERSION} from main"
           git push origin dev


### PR DESCRIPTION
## 문제

PR #161에서 추가한 `main → dev` 자동 동기화 스텝이 아래 오류로 실패했습니다.

```
fatal: refusing to merge unrelated histories
```

## 원인

`actions/checkout@v4`의 기본 `fetch-depth: 1` (얕은 클론)으로 인해 나중에 `dev` 브랜치를 fetch할 때 공통 조상이 없어 git이 unrelated histories로 판단합니다.

## 수정

- `fetch-depth: 0`으로 전체 히스토리를 클론하도록 변경
- sync 머지 커밋 메시지에 릴리스 버전 포함 (`chore: sync version bump v1.x.x from main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)