### PR TITLE
Feat/청소규칙 관리 기능 구현

### DIFF
--- a/src/cleaning/cleaning-rule.entity.ts
+++ b/src/cleaning/cleaning-rule.entity.ts
@@ -26,8 +26,8 @@ export class CleaningRule {
   @Column()
   needPeoples: number;
 
-  @Column()
-  dayOfWeek: number;
+  @Column('int', { array: true })
+  daysOfWeek: number[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/cleaning/cleaning-rule.service.ts
+++ b/src/cleaning/cleaning-rule.service.ts
@@ -14,7 +14,7 @@ export interface CreateRuleDto {
   studentClassId: number;
   cycle: number;
   needPeoples: number;
-  dayOfWeek: number;
+  daysOfWeek: number[];
   resourceId: number;
   slackUserIds: string[];
 }
@@ -22,7 +22,7 @@ export interface CreateRuleDto {
 export interface UpdateRuleDto {
   cycle: number;
   needPeoples: number;
-  dayOfWeek: number;
+  daysOfWeek: number[];
   resourceId: number;
 }
 
@@ -97,7 +97,7 @@ export class CleaningRuleService {
         studentClassId: dto.studentClassId,
         cycle: dto.cycle,
         needPeoples: dto.needPeoples,
-        dayOfWeek: dto.dayOfWeek,
+        daysOfWeek: dto.daysOfWeek,
       }),
     );
 
@@ -117,7 +117,7 @@ export class CleaningRuleService {
     await this.ruleRepo.update(id, {
       cycle: dto.cycle,
       needPeoples: dto.needPeoples,
-      dayOfWeek: dto.dayOfWeek,
+      daysOfWeek: dto.daysOfWeek,
     });
 
     const existing = await this.ruleResourceRepo.findOne({

--- a/src/cleaning/cleaning-rule.service.ts
+++ b/src/cleaning/cleaning-rule.service.ts
@@ -1,0 +1,190 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { CleaningRule } from './cleaning-rule.entity';
+import { CleaningRuleUser } from './cleaning-rule-user.entity';
+import { CleaningRuleResource } from './cleaning-rule-resource.entity';
+import { UserService } from '../user/service/user.service';
+import { UserAdminService } from '../user/service/user-admin.service';
+import { UserStatus } from '../user/user.entity';
+import { StudentClassStatus } from '../student-class/student-class.entity';
+import { formatClassLabel } from '../common/class-label.util';
+
+export interface CreateRuleDto {
+  studentClassId: number;
+  cycle: number;
+  needPeoples: number;
+  dayOfWeek: number;
+  resourceId: number;
+  slackUserIds: string[];
+}
+
+export interface UpdateRuleDto {
+  cycle: number;
+  needPeoples: number;
+  dayOfWeek: number;
+  resourceId: number;
+}
+
+export interface RuleWithDetails extends CleaningRule {
+  ruleUsers: CleaningRuleUser[];
+  ruleResource: CleaningRuleResource | undefined;
+}
+
+@Injectable()
+export class CleaningRuleService {
+  constructor(
+    @InjectRepository(CleaningRule)
+    private readonly ruleRepo: Repository<CleaningRule>,
+    @InjectRepository(CleaningRuleUser)
+    private readonly ruleUserRepo: Repository<CleaningRuleUser>,
+    @InjectRepository(CleaningRuleResource)
+    private readonly ruleResourceRepo: Repository<CleaningRuleResource>,
+    private readonly userService: UserService,
+    private readonly userAdminService: UserAdminService,
+  ) {}
+
+  async findAllWithDetails(studentClassId?: number): Promise<RuleWithDetails[]> {
+    const rules = await this.ruleRepo.find({
+      where: studentClassId ? { studentClassId } : undefined,
+      relations: ['studentClass'],
+      order: { id: 'ASC' },
+    });
+
+    if (rules.length === 0) return [];
+
+    const ruleIds = rules.map((r) => r.id);
+
+    const [ruleUsers, ruleResources] = await Promise.all([
+      this.ruleUserRepo.find({
+        where: { ruleId: In(ruleIds) },
+        relations: ['user'],
+      }),
+      this.ruleResourceRepo.find({
+        where: { ruleId: In(ruleIds) },
+        relations: ['resource'],
+      }),
+    ]);
+
+    return rules.map((rule) => ({
+      ...rule,
+      ruleUsers: ruleUsers.filter((ru) => ru.ruleId === rule.id),
+      ruleResource: ruleResources.find((rr) => rr.ruleId === rule.id),
+    }));
+  }
+
+  async findOneWithDetails(id: number): Promise<RuleWithDetails | null> {
+    const rule = await this.ruleRepo.findOne({
+      where: { id },
+      relations: ['studentClass'],
+    });
+    if (!rule) return null;
+
+    const [ruleUsers, ruleResource] = await Promise.all([
+      this.ruleUserRepo.find({ where: { ruleId: id }, relations: ['user'] }),
+      this.ruleResourceRepo.findOne({
+        where: { ruleId: id },
+        relations: ['resource'],
+      }),
+    ]);
+
+    return { ...rule, ruleUsers, ruleResource: ruleResource ?? undefined };
+  }
+
+  async create(dto: CreateRuleDto): Promise<CleaningRule> {
+    const rule = await this.ruleRepo.save(
+      this.ruleRepo.create({
+        studentClassId: dto.studentClassId,
+        cycle: dto.cycle,
+        needPeoples: dto.needPeoples,
+        dayOfWeek: dto.dayOfWeek,
+      }),
+    );
+
+    await this.ruleResourceRepo.save(
+      this.ruleResourceRepo.create({
+        ruleId: rule.id,
+        resourceId: dto.resourceId,
+      }),
+    );
+
+    await this.setUsers(rule.id, dto.slackUserIds);
+
+    return rule;
+  }
+
+  async update(id: number, dto: UpdateRuleDto): Promise<void> {
+    await this.ruleRepo.update(id, {
+      cycle: dto.cycle,
+      needPeoples: dto.needPeoples,
+      dayOfWeek: dto.dayOfWeek,
+    });
+
+    const existing = await this.ruleResourceRepo.findOne({
+      where: { ruleId: id },
+    });
+    if (existing) {
+      await this.ruleResourceRepo.update(existing.id, {
+        resourceId: dto.resourceId,
+      });
+    } else {
+      await this.ruleResourceRepo.save(
+        this.ruleResourceRepo.create({ ruleId: id, resourceId: dto.resourceId }),
+      );
+    }
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.ruleRepo.softDelete(id);
+  }
+
+  async setUsers(ruleId: number, slackUserIds: string[]): Promise<void> {
+    await this.ruleUserRepo.delete({ ruleId });
+
+    if (slackUserIds.length === 0) return;
+
+    const users = await Promise.all(
+      slackUserIds.map((slackId) => this.userService.findBySlackId(slackId)),
+    );
+
+    const validUsers = users.filter(Boolean);
+    if (validUsers.length === 0) return;
+
+    await this.ruleUserRepo.save(
+      validUsers.map((user) =>
+        this.ruleUserRepo.create({ ruleId, userId: user!.id }),
+      ),
+    );
+  }
+
+  async getUserSlackIds(ruleId: number): Promise<string[]> {
+    const ruleUsers = await this.ruleUserRepo.find({
+      where: { ruleId },
+      relations: ['user'],
+    });
+    return ruleUsers.map((ru) => ru.user.slackId);
+  }
+
+  async getUserOptions(
+    studentClassId?: number,
+  ): Promise<{ label: string; value: string }[]> {
+    const { users } = await this.userAdminService.findFiltered(
+      { status: UserStatus.ACTIVE, ...(studentClassId ? { studentClassId } : {}) },
+      0,
+      1000,
+    );
+    return users.map((u) => {
+      const classLabel = u.studentClass
+        ? formatClassLabel({
+            admissionYear: u.studentClass.admissionYear,
+            section: u.studentClass.section,
+            graduated:
+              u.studentClass.status === StudentClassStatus.GRADUATED,
+          })
+        : null;
+      const parts = [classLabel, u.code].filter(Boolean).join(' | ');
+      const label = parts ? `${u.name} (${parts})` : u.name;
+      return { label, value: u.slackId };
+    });
+  }
+}

--- a/src/cleaning/cleaning.controller.ts
+++ b/src/cleaning/cleaning.controller.ts
@@ -1,4 +1,371 @@
 import { Controller } from '@nestjs/common';
+import { Action, View } from 'nestjs-slack-bolt';
+import type {
+  AllMiddlewareArgs,
+  SlackActionMiddlewareArgs,
+  SlackViewMiddlewareArgs,
+  BlockAction,
+} from '@slack/bolt';
+import { CleaningRuleService } from './cleaning-rule.service';
+import { CleaningView } from './cleaning.view';
+import { PermissionService } from '../user/service/permission.service';
+import { StudentClassService } from '../student-class/student-class.service';
+import { ResourceService } from '../resource/service/resource.service';
+import { formatClassLabel } from '../common/class-label.util';
+import { StudentClassStatus } from '../student-class/student-class.entity';
+import { UserRole } from '../user/user.entity';
 
-@Controller('cleaning')
-export class CleaningController {}
+@Controller()
+export class CleaningController {
+  constructor(
+    private readonly cleaningRuleService: CleaningRuleService,
+    private readonly permissionService: PermissionService,
+    private readonly studentClassService: StudentClassService,
+    private readonly resourceService: ResourceService,
+  ) {}
+
+  // ── 홈 버튼: 추가 ──────────────────────────────────────────────
+  @Action('cleaning:rule:open-create')
+  async openCreate({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireCleaningAccess(
+      body.user.id,
+    );
+    const resources = await this.resourceService.findAll();
+
+    if (resources.length === 0) {
+      await client.chat.postMessage({
+        channel: body.user.id,
+        text: '청소 구역(리소스)이 등록되어 있지 않습니다. 먼저 리소스를 등록해주세요.',
+      });
+      return;
+    }
+
+    if (user.role === UserRole.CLASS_REP) {
+      const cls = user.studentClass;
+      const label = formatClassLabel({
+        admissionYear: cls.admissionYear,
+        section: cls.section,
+        graduated: cls.status === StudentClassStatus.GRADUATED,
+      });
+      const userOptions = await this.cleaningRuleService.getUserOptions(
+        user.studentClassId,
+      );
+      await client.views.open({
+        trigger_id: body.trigger_id,
+        view: CleaningView.createModal(resources, userOptions, undefined, {
+          id: user.studentClassId,
+          label,
+        }),
+      });
+    } else {
+      const [classes, userOptions] = await Promise.all([
+        this.studentClassService.findActiveClasses(),
+        this.cleaningRuleService.getUserOptions(),
+      ]);
+      if (classes.length === 0) {
+        await client.chat.postMessage({
+          channel: body.user.id,
+          text: '활성화된 반이 없습니다. 먼저 반을 생성해주세요.',
+        });
+        return;
+      }
+      await client.views.open({
+        trigger_id: body.trigger_id,
+        view: CleaningView.createModal(resources, userOptions, classes),
+      });
+    }
+  }
+
+  // ── 홈 버튼: 수정 (목록) ────────────────────────────────────────
+  @Action('cleaning:rule:open-edit-list')
+  async openEditList({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireCleaningAccess(
+      body.user.id,
+    );
+    const classId =
+      user.role === UserRole.CLASS_REP ? user.studentClassId : undefined;
+    const rules = await this.cleaningRuleService.findAllWithDetails(classId);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: CleaningView.editListModal(rules),
+    });
+  }
+
+  // ── 홈 버튼: 삭제 (목록) ────────────────────────────────────────
+  @Action('cleaning:rule:open-delete-list')
+  async openDeleteList({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireCleaningAccess(
+      body.user.id,
+    );
+    const classId =
+      user.role === UserRole.CLASS_REP ? user.studentClassId : undefined;
+    const rules = await this.cleaningRuleService.findAllWithDetails(classId);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: CleaningView.deleteListModal(rules),
+    });
+  }
+
+  // ── 수정 목록 → 수정 모달 ───────────────────────────────────────
+  @Action('cleaning:rule:edit')
+  async selectEdit({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireCleaningAccess(
+      body.user.id,
+    );
+    const action = body.actions[0] as { value: string };
+    const ruleId = parseInt(action.value, 10);
+
+    const [rule, resources, slackIds] = await Promise.all([
+      this.cleaningRuleService.findOneWithDetails(ruleId),
+      this.resourceService.findAll(true),
+      this.cleaningRuleService.getUserSlackIds(ruleId),
+    ]);
+    if (!rule) return;
+    if (
+      user.role === UserRole.CLASS_REP &&
+      rule.studentClassId !== user.studentClassId
+    )
+      return;
+
+    const userOptions = await this.cleaningRuleService.getUserOptions(
+      rule.studentClassId,
+    );
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningView.editModal(rule, resources, slackIds, userOptions),
+    });
+  }
+
+  // ── 삭제 목록 → 삭제 확인 모달 ─────────────────────────────────
+  @Action('cleaning:rule:delete')
+  async selectDelete({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireCleaningAccess(
+      body.user.id,
+    );
+    const action = body.actions[0] as { value: string };
+    const ruleId = parseInt(action.value, 10);
+
+    const rule = await this.cleaningRuleService.findOneWithDetails(ruleId);
+    if (!rule) return;
+    if (
+      user.role === UserRole.CLASS_REP &&
+      rule.studentClassId !== user.studentClassId
+    )
+      return;
+
+    const label = formatClassLabel({
+      admissionYear: rule.studentClass.admissionYear,
+      section: rule.studentClass.section,
+      graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+    });
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningView.deleteConfirmModal(ruleId, label),
+    });
+  }
+
+  // ── 생성 모달 제출 ──────────────────────────────────────────────
+  @View('cleaning:modal:create')
+  async handleCreate({
+    ack,
+    body,
+    view,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const values = view.state.values;
+
+    const fixedClassId = view.private_metadata
+      ? parseInt(view.private_metadata, 10)
+      : NaN;
+    const studentClassId = !isNaN(fixedClassId)
+      ? fixedClassId
+      : parseInt(
+          values.class_block?.class_select?.selected_option?.value ?? '',
+          10,
+        );
+
+    const cycle = parseInt(values.cycle_block.cycle_input.value ?? '', 10);
+    const needPeoples = parseInt(
+      values.need_peoples_block.need_peoples_input.value ?? '',
+      10,
+    );
+    const dayOfWeek = parseInt(
+      values.day_of_week_block.day_of_week_select.selected_option?.value ?? '',
+      10,
+    );
+    const resourceId = parseInt(
+      values.resource_block.resource_select.selected_option?.value ?? '',
+      10,
+    );
+    const slackUserIds: string[] = (
+      (values.users_block.users_select as any).selected_options ?? []
+    ).map((o: { value: string }) => o.value);
+
+    if (isNaN(cycle) || cycle < 1) {
+      await ack({
+        response_action: 'errors',
+        errors: { cycle_block: '1 이상의 숫자를 입력해주세요.' },
+      });
+      return;
+    }
+    if (isNaN(needPeoples) || needPeoples < 1) {
+      await ack({
+        response_action: 'errors',
+        errors: { need_peoples_block: '1 이상의 숫자를 입력해주세요.' },
+      });
+      return;
+    }
+
+    await ack();
+
+    await this.cleaningRuleService.create({
+      studentClassId,
+      cycle,
+      needPeoples,
+      dayOfWeek,
+      resourceId,
+      slackUserIds,
+    });
+
+    logger.info(`CleaningRule created by ${body.user.id}`);
+  }
+
+  // ── 수정 모달 제출 ──────────────────────────────────────────────
+  @View('cleaning:modal:edit')
+  async handleEdit({
+    ack,
+    body,
+    view,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const ruleId = parseInt(view.private_metadata, 10);
+    const values = view.state.values;
+
+    const cycle = parseInt(values.cycle_block.cycle_input.value ?? '', 10);
+    const needPeoples = parseInt(
+      values.need_peoples_block.need_peoples_input.value ?? '',
+      10,
+    );
+    const dayOfWeek = parseInt(
+      values.day_of_week_block.day_of_week_select.selected_option?.value ?? '',
+      10,
+    );
+    const resourceId = parseInt(
+      values.resource_block.resource_select.selected_option?.value ?? '',
+      10,
+    );
+
+    if (isNaN(cycle) || cycle < 1) {
+      await ack({
+        response_action: 'errors',
+        errors: { cycle_block: '1 이상의 숫자를 입력해주세요.' },
+      });
+      return;
+    }
+    if (isNaN(needPeoples) || needPeoples < 1) {
+      await ack({
+        response_action: 'errors',
+        errors: { need_peoples_block: '1 이상의 숫자를 입력해주세요.' },
+      });
+      return;
+    }
+
+    await ack();
+
+    const slackUserIds: string[] = (
+      (values.users_block.users_select as any).selected_options ?? []
+    ).map((o: { value: string }) => o.value);
+
+    await Promise.all([
+      this.cleaningRuleService.update(ruleId, {
+        cycle,
+        needPeoples,
+        dayOfWeek,
+        resourceId,
+      }),
+      this.cleaningRuleService.setUsers(ruleId, slackUserIds),
+    ]);
+
+    const user = await this.permissionService.requireCleaningAccess(
+      body.user.id,
+    );
+    const classId =
+      user.role === UserRole.CLASS_REP ? user.studentClassId : undefined;
+    const rules = await this.cleaningRuleService.findAllWithDetails(classId);
+
+    if (body.view?.root_view_id) {
+      await client.views.update({
+        view_id: body.view.root_view_id,
+        view: CleaningView.editListModal(rules),
+      });
+    }
+
+    logger.info(`CleaningRule ${ruleId} updated by ${body.user.id}`);
+  }
+
+  // ── 삭제 확인 모달 제출 ─────────────────────────────────────────
+  @View('cleaning:modal:delete')
+  async handleDelete({
+    ack,
+    body,
+    view,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    await ack();
+
+    const ruleId = parseInt(view.private_metadata, 10);
+    await this.cleaningRuleService.delete(ruleId);
+
+    const user = await this.permissionService.requireCleaningAccess(
+      body.user.id,
+    );
+    const classId =
+      user.role === UserRole.CLASS_REP ? user.studentClassId : undefined;
+    const rules = await this.cleaningRuleService.findAllWithDetails(classId);
+
+    if (body.view?.root_view_id) {
+      await client.views.update({
+        view_id: body.view.root_view_id,
+        view: CleaningView.deleteListModal(rules),
+      });
+    }
+
+    logger.info(`CleaningRule ${ruleId} deleted by ${body.user.id}`);
+  }
+}

--- a/src/cleaning/cleaning.controller.ts
+++ b/src/cleaning/cleaning.controller.ts
@@ -33,10 +33,10 @@ export class CleaningController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    const user = await this.permissionService.requireCleaningAccess(
+    const user = await this.permissionService.requireAdminOrClassRep(
       body.user.id,
     );
-    const resources = await this.resourceService.findAll();
+    const resources = await this.resourceService.findSpaces();
 
     if (resources.length === 0) {
       await client.chat.postMessage({
@@ -91,7 +91,7 @@ export class CleaningController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    const user = await this.permissionService.requireCleaningAccess(
+    const user = await this.permissionService.requireAdminOrClassRep(
       body.user.id,
     );
     const classId =
@@ -113,7 +113,7 @@ export class CleaningController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    const user = await this.permissionService.requireCleaningAccess(
+    const user = await this.permissionService.requireAdminOrClassRep(
       body.user.id,
     );
     const classId =
@@ -135,7 +135,7 @@ export class CleaningController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    const user = await this.permissionService.requireCleaningAccess(
+    const user = await this.permissionService.requireAdminOrClassRep(
       body.user.id,
     );
     const action = body.actions[0] as { value: string };
@@ -143,7 +143,7 @@ export class CleaningController {
 
     const [rule, resources, slackIds] = await Promise.all([
       this.cleaningRuleService.findOneWithDetails(ruleId),
-      this.resourceService.findAll(true),
+      this.resourceService.findSpaces(true),
       this.cleaningRuleService.getUserSlackIds(ruleId),
     ]);
     if (!rule) return;
@@ -172,7 +172,7 @@ export class CleaningController {
   }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
     await ack();
 
-    const user = await this.permissionService.requireCleaningAccess(
+    const user = await this.permissionService.requireAdminOrClassRep(
       body.user.id,
     );
     const action = body.actions[0] as { value: string };
@@ -223,10 +223,9 @@ export class CleaningController {
       values.need_peoples_block.need_peoples_input.value ?? '',
       10,
     );
-    const dayOfWeek = parseInt(
-      values.day_of_week_block.day_of_week_select.selected_option?.value ?? '',
-      10,
-    );
+    const daysOfWeek: number[] = (
+      (values.day_of_week_block.day_of_week_select as any).selected_options ?? []
+    ).map((o: { value: string }) => parseInt(o.value, 10));
     const resourceId = parseInt(
       values.resource_block.resource_select.selected_option?.value ?? '',
       10,
@@ -256,7 +255,7 @@ export class CleaningController {
       studentClassId,
       cycle,
       needPeoples,
-      dayOfWeek,
+      daysOfWeek,
       resourceId,
       slackUserIds,
     });
@@ -281,10 +280,9 @@ export class CleaningController {
       values.need_peoples_block.need_peoples_input.value ?? '',
       10,
     );
-    const dayOfWeek = parseInt(
-      values.day_of_week_block.day_of_week_select.selected_option?.value ?? '',
-      10,
-    );
+    const daysOfWeek: number[] = (
+      (values.day_of_week_block.day_of_week_select as any).selected_options ?? []
+    ).map((o: { value: string }) => parseInt(o.value, 10));
     const resourceId = parseInt(
       values.resource_block.resource_select.selected_option?.value ?? '',
       10,
@@ -315,13 +313,13 @@ export class CleaningController {
       this.cleaningRuleService.update(ruleId, {
         cycle,
         needPeoples,
-        dayOfWeek,
+        daysOfWeek,
         resourceId,
       }),
       this.cleaningRuleService.setUsers(ruleId, slackUserIds),
     ]);
 
-    const user = await this.permissionService.requireCleaningAccess(
+    const user = await this.permissionService.requireAdminOrClassRep(
       body.user.id,
     );
     const classId =
@@ -352,7 +350,7 @@ export class CleaningController {
     const ruleId = parseInt(view.private_metadata, 10);
     await this.cleaningRuleService.delete(ruleId);
 
-    const user = await this.permissionService.requireCleaningAccess(
+    const user = await this.permissionService.requireAdminOrClassRep(
       body.user.id,
     );
     const classId =

--- a/src/cleaning/cleaning.module.ts
+++ b/src/cleaning/cleaning.module.ts
@@ -2,18 +2,20 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CleaningController } from './cleaning.controller';
 import { CleaningService } from './cleaning.service';
+import { CleaningRuleService } from './cleaning-rule.service';
 import { CleaningRule } from './cleaning-rule.entity';
 import { CleaningRuleResource } from './cleaning-rule-resource.entity';
 import { CleaningRuleUser } from './cleaning-rule-user.entity';
 import { CleaningSchedule } from './cleaning-schedule.entity';
 import { CleaningAssignment } from './cleaning-assignment.entity';
 import { CleaningTrade } from './cleaning-trade.entity';
-import { Resource } from '../resource/resource.entity';
+import { UserModule } from '../user/user.module';
+import { StudentClassModule } from '../student-class/student-class.module';
+import { ResourceModule } from '../resource/resource.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      Resource,
       CleaningRule,
       CleaningRuleResource,
       CleaningRuleUser,
@@ -21,8 +23,11 @@ import { Resource } from '../resource/resource.entity';
       CleaningAssignment,
       CleaningTrade,
     ]),
+    UserModule,
+    StudentClassModule,
+    ResourceModule,
   ],
   controllers: [CleaningController],
-  providers: [CleaningService],
+  providers: [CleaningService, CleaningRuleService],
 })
 export class CleaningModule {}

--- a/src/cleaning/cleaning.view.ts
+++ b/src/cleaning/cleaning.view.ts
@@ -7,7 +7,8 @@ import { RuleWithDetails } from './cleaning-rule.service';
 
 type UserOption = { label: string; value: string };
 
-const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'];
+// 0=일, 1=월, ..., 6=토 (JS Date.getDay() 기준)
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
 const DAY_OPTIONS = DAY_LABELS.map((label, index) => ({
   text: { type: 'plain_text' as const, text: `${label}요일` },
@@ -23,9 +24,9 @@ function ruleLabel(rule: RuleWithDetails): string {
 }
 
 function ruleInfoText(rule: RuleWithDetails): string {
-  const dayLabel = DAY_LABELS[rule.dayOfWeek] ?? '?';
+  const dayLabel = rule.daysOfWeek.map((d) => DAY_LABELS[d] ?? '?').join('/') + '요일';
   const resourceName = rule.ruleResource?.resource?.name ?? '미지정';
-  return `*${ruleLabel(rule)}* | ${rule.cycle}주 주기 | ${rule.needPeoples}명 | ${dayLabel}요일 | ${resourceName}`;
+  return `*${ruleLabel(rule)}* | ${rule.cycle}주 주기 | ${rule.needPeoples}명 | ${dayLabel} | ${resourceName}`;
 }
 
 export class CleaningView {
@@ -180,7 +181,7 @@ export class CleaningView {
           block_id: 'day_of_week_block',
           label: { type: 'plain_text', text: '청소 요일' },
           element: {
-            type: 'static_select',
+            type: 'multi_static_select',
             action_id: 'day_of_week_select',
             placeholder: { type: 'plain_text', text: '요일을 선택하세요' },
             options: DAY_OPTIONS,
@@ -228,7 +229,6 @@ export class CleaningView {
     }));
 
     const currentResource = rule.ruleResource?.resource;
-    const currentDay = rule.dayOfWeek;
 
     return {
       type: 'modal',
@@ -263,16 +263,13 @@ export class CleaningView {
           block_id: 'day_of_week_block',
           label: { type: 'plain_text', text: '청소 요일' },
           element: {
-            type: 'static_select',
+            type: 'multi_static_select',
             action_id: 'day_of_week_select',
             options: DAY_OPTIONS,
-            initial_option: {
-              text: {
-                type: 'plain_text',
-                text: `${DAY_LABELS[currentDay]}요일`,
-              },
-              value: String(currentDay),
-            },
+            initial_options: rule.daysOfWeek.map((d) => ({
+              text: { type: 'plain_text' as const, text: `${DAY_LABELS[d]}요일` },
+              value: String(d),
+            })),
           },
         },
         {

--- a/src/cleaning/cleaning.view.ts
+++ b/src/cleaning/cleaning.view.ts
@@ -1,0 +1,344 @@
+import type { View } from '@slack/types';
+import { StudentClass } from '../student-class/student-class.entity';
+import { StudentClassStatus } from '../student-class/student-class.entity';
+import { Resource } from '../resource/resource.entity';
+import { formatClassLabel } from '../common/class-label.util';
+import { RuleWithDetails } from './cleaning-rule.service';
+
+type UserOption = { label: string; value: string };
+
+const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'];
+
+const DAY_OPTIONS = DAY_LABELS.map((label, index) => ({
+  text: { type: 'plain_text' as const, text: `${label}요일` },
+  value: String(index),
+}));
+
+function ruleLabel(rule: RuleWithDetails): string {
+  return formatClassLabel({
+    admissionYear: rule.studentClass.admissionYear,
+    section: rule.studentClass.section,
+    graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+  });
+}
+
+function ruleInfoText(rule: RuleWithDetails): string {
+  const dayLabel = DAY_LABELS[rule.dayOfWeek] ?? '?';
+  const resourceName = rule.ruleResource?.resource?.name ?? '미지정';
+  return `*${ruleLabel(rule)}* | ${rule.cycle}주 주기 | ${rule.needPeoples}명 | ${dayLabel}요일 | ${resourceName}`;
+}
+
+export class CleaningView {
+  static editListModal(rules: RuleWithDetails[]): View {
+    const blocks: View['blocks'] = [];
+
+    if (rules.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '등록된 청소 규칙이 없습니다.' },
+      });
+    } else {
+      for (const rule of rules) {
+        blocks.push(
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: ruleInfoText(rule) },
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: '수정' },
+              action_id: 'cleaning:rule:edit',
+              value: String(rule.id),
+            },
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:edit-list',
+      title: { type: 'plain_text', text: '청소 규칙 수정' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  static deleteListModal(rules: RuleWithDetails[]): View {
+    const blocks: View['blocks'] = [];
+
+    if (rules.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '등록된 청소 규칙이 없습니다.' },
+      });
+    } else {
+      for (const rule of rules) {
+        blocks.push(
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: ruleInfoText(rule) },
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: '삭제' },
+              action_id: 'cleaning:rule:delete',
+              style: 'danger',
+              value: String(rule.id),
+            },
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:delete-list',
+      title: { type: 'plain_text', text: '청소 규칙 삭제' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  static createModal(
+    resources: Resource[],
+    userOptions: UserOption[],
+    classes?: StudentClass[],
+    fixedClass?: { id: number; label: string },
+  ): View {
+    const resourceOptions = resources.map((r) => ({
+      text: { type: 'plain_text' as const, text: r.name },
+      value: String(r.id),
+    }));
+
+    const classBlock: View['blocks'] = fixedClass
+      ? [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: `*반:* ${fixedClass.label}` },
+          },
+        ]
+      : [
+          {
+            type: 'input',
+            block_id: 'class_block',
+            label: { type: 'plain_text', text: '반' },
+            element: {
+              type: 'static_select',
+              action_id: 'class_select',
+              placeholder: { type: 'plain_text', text: '반을 선택하세요' },
+              options: (classes ?? []).map((c) => ({
+                text: {
+                  type: 'plain_text' as const,
+                  text: formatClassLabel({
+                    admissionYear: c.admissionYear,
+                    section: c.section,
+                    graduated: c.status === StudentClassStatus.GRADUATED,
+                  }),
+                },
+                value: String(c.id),
+              })),
+            },
+          },
+        ];
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:create',
+      private_metadata: fixedClass ? String(fixedClass.id) : '',
+      title: { type: 'plain_text', text: '청소 규칙 추가' },
+      submit: { type: 'plain_text', text: '추가' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        ...classBlock,
+        {
+          type: 'input',
+          block_id: 'cycle_block',
+          label: { type: 'plain_text', text: '주기 (주)' },
+          hint: {
+            type: 'plain_text',
+            text: '몇 주마다 청소하는지 입력하세요 (예: 2)',
+          },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'cycle_input',
+            placeholder: { type: 'plain_text', text: '2' },
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'need_peoples_block',
+          label: { type: 'plain_text', text: '필요 인원 (명)' },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'need_peoples_input',
+            placeholder: { type: 'plain_text', text: '2' },
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'day_of_week_block',
+          label: { type: 'plain_text', text: '청소 요일' },
+          element: {
+            type: 'static_select',
+            action_id: 'day_of_week_select',
+            placeholder: { type: 'plain_text', text: '요일을 선택하세요' },
+            options: DAY_OPTIONS,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'resource_block',
+          label: { type: 'plain_text', text: '청소 구역' },
+          element: {
+            type: 'static_select',
+            action_id: 'resource_select',
+            placeholder: { type: 'plain_text', text: '구역을 선택하세요' },
+            options: resourceOptions,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'users_block',
+          optional: true,
+          label: { type: 'plain_text', text: '담당자' },
+          element: {
+            type: 'multi_static_select',
+            action_id: 'users_select',
+            placeholder: { type: 'plain_text', text: '담당자를 선택하세요' },
+            options: userOptions.map((u) => ({
+              text: { type: 'plain_text' as const, text: u.label },
+              value: u.value,
+            })),
+          },
+        },
+      ],
+    };
+  }
+
+  static editModal(
+    rule: RuleWithDetails,
+    resources: Resource[],
+    currentSlackIds: string[],
+    userOptions: UserOption[],
+  ): View {
+    const resourceOptions = resources.map((r) => ({
+      text: { type: 'plain_text' as const, text: r.name },
+      value: String(r.id),
+    }));
+
+    const currentResource = rule.ruleResource?.resource;
+    const currentDay = rule.dayOfWeek;
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:edit',
+      private_metadata: String(rule.id),
+      title: { type: 'plain_text', text: '청소 규칙 수정' },
+      submit: { type: 'plain_text', text: '저장' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'input',
+          block_id: 'cycle_block',
+          label: { type: 'plain_text', text: '주기 (주)' },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'cycle_input',
+            initial_value: String(rule.cycle),
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'need_peoples_block',
+          label: { type: 'plain_text', text: '필요 인원 (명)' },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'need_peoples_input',
+            initial_value: String(rule.needPeoples),
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'day_of_week_block',
+          label: { type: 'plain_text', text: '청소 요일' },
+          element: {
+            type: 'static_select',
+            action_id: 'day_of_week_select',
+            options: DAY_OPTIONS,
+            initial_option: {
+              text: {
+                type: 'plain_text',
+                text: `${DAY_LABELS[currentDay]}요일`,
+              },
+              value: String(currentDay),
+            },
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'resource_block',
+          label: { type: 'plain_text', text: '청소 구역' },
+          element: {
+            type: 'static_select',
+            action_id: 'resource_select',
+            options: resourceOptions,
+            ...(currentResource
+              ? {
+                  initial_option: {
+                    text: { type: 'plain_text', text: currentResource.name },
+                    value: String(currentResource.id),
+                  },
+                }
+              : {}),
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'users_block',
+          optional: true,
+          label: { type: 'plain_text', text: '담당자' },
+          element: {
+            type: 'multi_static_select',
+            action_id: 'users_select',
+            placeholder: { type: 'plain_text', text: '담당자를 선택하세요' },
+            options: userOptions.map((u) => ({
+              text: { type: 'plain_text' as const, text: u.label },
+              value: u.value,
+            })),
+            ...(currentSlackIds.length > 0
+              ? {
+                  initial_options: userOptions
+                    .filter((u) => currentSlackIds.includes(u.value))
+                    .map((u) => ({
+                      text: { type: 'plain_text' as const, text: u.label },
+                      value: u.value,
+                    })),
+                }
+              : {}),
+          },
+        },
+      ],
+    };
+  }
+
+  static deleteConfirmModal(ruleId: number, label: string): View {
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:delete',
+      private_metadata: String(ruleId),
+      title: { type: 'plain_text', text: '규칙 삭제' },
+      submit: { type: 'plain_text', text: '삭제' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${label}* 청소 규칙을 삭제하시겠습니까?\n\n⚠️ 되돌릴 수 없습니다.`,
+          },
+        },
+      ],
+    };
+  }
+}

--- a/src/common/errors/user.errors.ts
+++ b/src/common/errors/user.errors.ts
@@ -2,6 +2,7 @@ import { createErrorDomain } from './base.error';
 
 const { codes, messages } = createErrorDomain('USER', {
   ADMIN_REQUIRED: '이 기능은 조교 이상 권한이 필요합니다.',
+  ADMIN_OR_CLASS_REP_REQUIRED: '이 기능은 교수, 조교 또는 반대표만 사용할 수 있습니다.',
   ACTIVE_REQUIRED:
     '활성화된 사용자만 이용 가능합니다. 먼저 회원가입을 완료해주세요.',
   USER_NOT_FOUND: '사용자 정보를 찾을 수 없습니다.',

--- a/src/migrations/1778064597031-AddCleaningEntities.ts
+++ b/src/migrations/1778064597031-AddCleaningEntities.ts
@@ -5,7 +5,7 @@ export class AddCleaningEntities1778064597031 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "cleaning_rules" ("id" SERIAL NOT NULL, "studentClassId" integer NOT NULL, "cycle" integer NOT NULL, "needPeoples" integer NOT NULL, "dayOfWeek" integer NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, CONSTRAINT "PK_cleaning_rules" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "cleaning_rules" ("id" SERIAL NOT NULL, "studentClassId" integer NOT NULL, "cycle" integer NOT NULL, "needPeoples" integer NOT NULL, "daysOfWeek" integer[] NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, CONSTRAINT "PK_cleaning_rules" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE TABLE "cleaning_rule_resources" ("id" SERIAL NOT NULL, "ruleId" integer NOT NULL, "resourceId" integer NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, CONSTRAINT "UQ_cleaning_rule_resources_ruleId" UNIQUE ("ruleId"), CONSTRAINT "PK_cleaning_rule_resources" PRIMARY KEY ("id"))`,

--- a/src/resource/service/resource.service.ts
+++ b/src/resource/service/resource.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Resource, ResourceStatus, ResourceType } from '../resource.entity';
 import { GoogleCalendarsService } from '../../google/calendar/calendars.service';
 import { GoogleAclService } from '../../google/calendar/acl.service';
@@ -49,6 +49,17 @@ export class ResourceService {
   async findAll(onlyActive = false): Promise<Resource[]> {
     return this.resourceRepository.find({
       where: onlyActive ? { status: ResourceStatus.ACTIVE } : {},
+      order: { name: 'ASC' },
+    });
+  }
+
+  // 청소 구역 조회 (classroom + study_room만)
+  async findSpaces(onlyActive = false): Promise<Resource[]> {
+    return this.resourceRepository.find({
+      where: {
+        type: In([ResourceType.CLASSROOM, ResourceType.STUDY_ROOM]),
+        ...(onlyActive ? { status: ResourceStatus.ACTIVE } : {}),
+      },
       order: { name: 'ASC' },
     });
   }

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -204,6 +204,36 @@ export class HomeView {
                   },
                 ],
               },
+              { type: 'divider' as const },
+              {
+                type: 'section' as const,
+                text: {
+                  type: 'mrkdwn' as const,
+                  text: '*📍청소 규칙 관리*\n청소 규칙(주기, 요일 등)을 *추가・수정・삭제* 할 수 있어요.',
+                },
+              },
+              {
+                type: 'actions' as const,
+                elements: [
+                  {
+                    type: 'button' as const,
+                    text: { type: 'plain_text' as const, text: '추가', emoji: true },
+                    style: 'primary' as const,
+                    action_id: 'cleaning:rule:open-create',
+                  },
+                  {
+                    type: 'button' as const,
+                    text: { type: 'plain_text' as const, text: '수정', emoji: true },
+                    action_id: 'cleaning:rule:open-edit-list',
+                  },
+                  {
+                    type: 'button' as const,
+                    text: { type: 'plain_text' as const, text: '삭제', emoji: true },
+                    style: 'danger' as const,
+                    action_id: 'cleaning:rule:open-delete-list',
+                  },
+                ],
+              },
             ]
           : [{ type: 'divider' as const }]),
         {
@@ -509,6 +539,36 @@ export class HomeView {
               type: 'button',
               text: { type: 'plain_text', text: '태그 목록' },
               action_id: 'home:open-tags',
+            },
+          ],
+        },
+        { type: 'divider' },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*📜청소 규칙 관리*\n청소 규칙(주기, 요일 등)을 *추가・수정・삭제* 할 수 있어요.',
+          },
+        },
+        {
+          type: 'actions',
+          elements: [
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '추가', emoji: true },
+              style: 'primary',
+              action_id: 'cleaning:rule:open-create',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '수정', emoji: true },
+              action_id: 'cleaning:rule:open-edit-list',
+            },
+            {
+              type: 'button',
+              text: { type: 'plain_text', text: '삭제', emoji: true },
+              style: 'danger',
+              action_id: 'cleaning:rule:open-delete-list',
             },
           ],
         },

--- a/src/user/service/permission.service.ts
+++ b/src/user/service/permission.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { UserService } from './user.service';
-import { User, UserStatus } from '../user.entity';
+import { User, UserRole, UserStatus } from '../user.entity';
 import { BusinessError, UserErrorCode } from '../../common/errors';
 
 @Injectable()
@@ -19,6 +19,16 @@ export class PermissionService {
     const user = await this.userService.findBySlackIdWithClass(userId);
     if (!user || user.status !== UserStatus.ACTIVE) {
       throw new BusinessError(UserErrorCode.ACTIVE_REQUIRED);
+    }
+    return user;
+  }
+
+  /** 청소 시스템 접근 권한 확인 (교수/조교/반대표) — User 반환, 없으면 BusinessError throw */
+  async requireCleaningAccess(slackId: string): Promise<User> {
+    const user = await this.userService.findBySlackIdWithClass(slackId);
+    const allowed = [UserRole.PROFESSOR, UserRole.TA, UserRole.CLASS_REP];
+    if (!user || user.status !== UserStatus.ACTIVE || !allowed.includes(user.role)) {
+      throw new BusinessError(UserErrorCode.ADMIN_REQUIRED);
     }
     return user;
   }

--- a/src/user/service/permission.service.ts
+++ b/src/user/service/permission.service.ts
@@ -23,12 +23,12 @@ export class PermissionService {
     return user;
   }
 
-  /** 청소 시스템 접근 권한 확인 (교수/조교/반대표) — User 반환, 없으면 BusinessError throw */
-  async requireCleaningAccess(slackId: string): Promise<User> {
+  /** 교수/조교/반대표 권한 확인 — User 반환, 없으면 BusinessError throw */
+  async requireAdminOrClassRep(slackId: string): Promise<User> {
     const user = await this.userService.findBySlackIdWithClass(slackId);
     const allowed = [UserRole.PROFESSOR, UserRole.TA, UserRole.CLASS_REP];
     if (!user || user.status !== UserStatus.ACTIVE || !allowed.includes(user.role)) {
-      throw new BusinessError(UserErrorCode.ADMIN_REQUIRED);
+      throw new BusinessError(UserErrorCode.ADMIN_OR_CLASS_REP_REQUIRED);
     }
     return user;
   }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->

## 주요 변경 사항
<!-- 변경 항목마다 ### 제목으로 구분하고 하위 내용을 작성해주세요
### 변경한 기능 또는 파일
- 세부 내용
-->
### 청소 규칙 CRUD 기능 구현
- 청소 규칙 생성, 수정, 삭제 기능 구현
- 담당자 설정시 해당 반의 인원만 조회 가능하도록 static select로 변경
- 교수 권한의 경우 전인원 조회 가능하나 해당 반의 인원이 아닐시 할당하는 것은 불가
### 청소 관리 시스템 접근 권한 검증
- user entity의 role을 가져와 권한에 따라 기능 접근 범위를 상이하게 설정
### 슬랙 앱 버튼, 모달 및 액션 핸들러 구현
- 버튼 상호작용 및 db접근
- 슬랙 앱 홈탭에 청소 규칙 관리 섹션 추가
### 
## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [✅] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
<img width="511" height="586" alt="3학년 규칙 생성(학생)" src="https://github.com/user-attachments/assets/a9d7510d-0e62-4f7b-bc05-9b2072812d1b" />
<img width="526" height="686" alt="규칙 생성(교수)" src="https://github.com/user-attachments/assets/9513d979-f89d-421e-8d57-d47805482d27" />
<img width="516" height="255" alt="규칙 삭제 모달" src="https://github.com/user-attachments/assets/5f943fec-d841-4509-be14-e09e564ed76f" />
<img width="511" height="256" alt="규칙 수정 모달" src="https://github.com/user-attachments/assets/8539687a-838e-48f4-82e5-5b065b47a007" />
<img width="518" height="611" alt="규칙 수정" src="https://github.com/user-attachments/assets/688a6611-07be-4832-9795-c85b2e652f97" />
<img width="522" height="542" alt="규칙 수정2" src="https://github.com/user-attachments/assets/164fbc16-9b3e-4ae0-8398-643afc6a3aa8" />
<img width="504" height="166" alt="슬랙 홈 화면" src="https://github.com/user-attachments/assets/84f20550-380e-450e-bdb7-270038580295" />
