### PR TITLE
feat(mcp): MCP 서버 + Google OAuth 2.0 + PKCE 인증

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ DB_SYNCHRONIZE=true
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/google/callback
+MCP_GOOGLE_REDIRECT_URI=http://localhost:3000/mcp/auth/callback
+MCP_BASE_URL=http://localhost:3000
 
 # Google Service Account
 GOOGLE_SERVICE_ACCOUNT_EMAIL=example@example.iam.gserviceaccount.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.95.1",
         "@keyv/redis": "^5.1.6",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@nestjs/cache-manager": "^3.1.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -990,6 +991,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2135,6 +2148,68 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -3888,7 +3963,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3906,7 +3980,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3923,7 +3996,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv-keywords": {
@@ -5534,6 +5606,27 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5636,6 +5729,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5646,7 +5757,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -5686,7 +5796,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6448,6 +6557,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hookified": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
@@ -6614,6 +6732,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -7607,6 +7734,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7682,6 +7818,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8845,6 +8987,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -9188,7 +9339,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11425,6 +11575,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.1",
     "@keyv/redis": "^5.1.6",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Redirect } from '@nestjs/common';
+import { Controller, Get, Redirect, Req } from '@nestjs/common';
 import { AppService } from './app.service';
 import { Action, Message } from 'nestjs-slack-bolt';
 import type {
@@ -7,10 +7,15 @@ import type {
   BlockAction,
   AllMiddlewareArgs,
 } from '@slack/bolt';
+import type { Request } from 'express';
+import { McpService } from './mcp/mcp.service';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly mcpService: McpService,
+  ) {}
 
   @Get()
   @Redirect('health')
@@ -29,6 +34,18 @@ export class AppController {
         `호스트: ${info.hostname} (${info.ip})\n` +
         `시작: ${info.startedAt}`,
     );
+  }
+
+  @Get('.well-known/oauth-authorization-server')
+  getOAuthMeta(@Req() req: Request) {
+    const baseUrl = process.env.MCP_BASE_URL ?? `${req.protocol}://${req.get('host')}`;
+    return this.mcpService.getAuthorizationServerMetadata(baseUrl);
+  }
+
+  @Get('.well-known/oauth-protected-resource')
+  getProtectedResourceMeta(@Req() req: Request) {
+    const baseUrl = process.env.MCP_BASE_URL ?? `${req.protocol}://${req.get('host')}`;
+    return this.mcpService.getProtectedResourceMetadata(baseUrl);
   }
 
   // 외부 URL 버튼 공통 ack 핸들러 — action_id에 `:open-url`이 포함된 모든 버튼

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { httpReceiver } from './slack-receiver';
 import { slackErrorMiddleware } from './common/slack-error.middleware';
 import { CleaningModule } from './cleaning/cleaning.module';
 import { SlackAiModule } from './slack-ai/slack-ai.module';
+import { McpModule } from './mcp/mcp.module';
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { SlackAiModule } from './slack-ai/slack-ai.module';
     ResourceModule,
     CleaningModule,
     SlackAiModule,
+    McpModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/google/oauth/google-oauth.service.ts
+++ b/src/google/oauth/google-oauth.service.ts
@@ -20,9 +20,11 @@ export interface OAuthState {
 
 @Injectable()
 export class GoogleOAuthService {
-  getGoogleAuthUrl(state: string): string {
+  getGoogleAuthUrl(
+    state: string,
+    redirectUri: string = process.env.GOOGLE_REDIRECT_URI ?? '',
+  ): string {
     const clientId = process.env.GOOGLE_CLIENT_ID;
-    const redirectUri = process.env.GOOGLE_REDIRECT_URI;
     const scopes = [
       'email',
       'profile',
@@ -33,7 +35,10 @@ export class GoogleOAuthService {
     return `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scope}&state=${state}&access_type=offline&prompt=consent`;
   }
 
-  async exchangeCodeForTokens(code: string): Promise<GoogleTokens> {
+  async exchangeCodeForTokens(
+    code: string,
+    redirectUri: string = process.env.GOOGLE_REDIRECT_URI ?? '',
+  ): Promise<GoogleTokens> {
     const response = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -41,7 +46,7 @@ export class GoogleOAuthService {
         code,
         client_id: process.env.GOOGLE_CLIENT_ID ?? '',
         client_secret: process.env.GOOGLE_CLIENT_SECRET ?? '',
-        redirect_uri: process.env.GOOGLE_REDIRECT_URI ?? '',
+        redirect_uri: redirectUri,
         grant_type: 'authorization_code',
       }),
     });

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -1,0 +1,26 @@
+import { All, Controller, Logger, Req, Res } from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { McpService } from './mcp.service';
+
+@Controller('mcp')
+export class McpController {
+  private readonly logger = new Logger(McpController.name);
+
+  constructor(private readonly mcpService: McpService) {}
+
+  @All()
+  async handleMcp(@Req() req: Request, @Res() res: Response): Promise<void> {
+    const slackId = await this.mcpService.resolveSlackId(
+      req.headers.authorization,
+    );
+
+    if (!slackId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    this.logger.log(`[MCP] ${req.method} slackId=${slackId}`);
+
+    await this.mcpService.handleRequest(req, res, req.body as unknown, slackId);
+  }
+}

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -1,4 +1,15 @@
-import { All, Controller, Logger, Req, Res } from '@nestjs/common';
+import {
+  All,
+  Body,
+  Controller,
+  Get,
+  Logger,
+  Post,
+  Query,
+  Redirect,
+  Req,
+  Res,
+} from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { McpService } from './mcp.service';
 
@@ -8,6 +19,78 @@ export class McpController {
 
   constructor(private readonly mcpService: McpService) {}
 
+  // ─── OAuth 2.0 Authorization Endpoint ────────────────────────────────────
+
+  @Get('auth/authorize')
+  @Redirect()
+  async authorize(
+    @Query('code_challenge') codeChallenge: string,
+    @Query('code_challenge_method') codeChallengeMethod: string,
+    @Query('redirect_uri') clientRedirectUri: string,
+    @Query('state') clientState: string,
+  ) {
+    const url = await this.mcpService.startAuthorize({
+      codeChallenge,
+      codeChallengeMethod,
+      clientRedirectUri,
+      clientState,
+    });
+    return { url };
+  }
+
+  // ─── Google OAuth Callback ────────────────────────────────────────────────
+
+  @Get('auth/callback')
+  @Redirect()
+  async googleCallback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Res() res: Response,
+  ) {
+    const result = await this.mcpService.handleGoogleCallback(code, state);
+
+    if (!result) {
+      res.status(403).send(
+        '<p>가입된 유저를 찾을 수 없거나 인증 세션이 만료되었습니다. 다시 시도해 주세요.</p>',
+      );
+      return;
+    }
+
+    return { url: result.clientRedirectUri };
+  }
+
+  // ─── Dynamic Client Registration (RFC 7591) ──────────────────────────────
+
+  @Post('auth/register')
+  registerClient(@Body() body: Record<string, unknown>, @Res() res: Response) {
+    const client = this.mcpService.registerClient(body);
+    res.status(201).json(client);
+  }
+
+  // ─── OAuth 2.0 Token Endpoint ─────────────────────────────────────────────
+
+  @Post('auth/token')
+  async token(
+    @Body('code') code: string,
+    @Body('code_verifier') codeVerifier: string,
+    @Res() res: Response,
+  ) {
+    const accessToken = await this.mcpService.issueToken(code, codeVerifier);
+
+    if (!accessToken) {
+      res.status(400).json({ error: 'invalid_grant' });
+      return;
+    }
+
+    res.json({
+      access_token: accessToken,
+      token_type: 'bearer',
+      expires_in: 7 * 24 * 60 * 60, // 7일 (초)
+    });
+  }
+
+  // ─── MCP Protocol Handler ─────────────────────────────────────────────────
+
   @All()
   async handleMcp(@Req() req: Request, @Res() res: Response): Promise<void> {
     const slackId = await this.mcpService.resolveSlackId(
@@ -15,12 +98,14 @@ export class McpController {
     );
 
     if (!slackId) {
-      res.status(401).json({ error: 'Unauthorized' });
+      const baseUrl = process.env.MCP_BASE_URL ?? `${req.protocol}://${req.get('host')}`;
+      res.status(401)
+        .set('WWW-Authenticate', `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`)
+        .json({ error: 'Unauthorized' });
       return;
     }
 
     this.logger.log(`[MCP] ${req.method} slackId=${slackId}`);
-
     await this.mcpService.handleRequest(req, res, req.body as unknown, slackId);
   }
 }

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -70,22 +70,25 @@ export class McpController {
   // ─── OAuth 2.0 Token Endpoint ─────────────────────────────────────────────
 
   @Post('auth/token')
-  async token(
-    @Body('code') code: string,
-    @Body('code_verifier') codeVerifier: string,
-    @Res() res: Response,
-  ) {
-    const accessToken = await this.mcpService.issueToken(code, codeVerifier);
+  async token(@Body() body: Record<string, string>, @Res() res: Response) {
+    let result: { accessToken: string; refreshToken: string } | null;
 
-    if (!accessToken) {
+    if (body.grant_type === 'refresh_token') {
+      result = await this.mcpService.refreshToken(body.refresh_token);
+    } else {
+      result = await this.mcpService.issueToken(body.code, body.code_verifier);
+    }
+
+    if (!result) {
       res.status(400).json({ error: 'invalid_grant' });
       return;
     }
 
     res.json({
-      access_token: accessToken,
+      access_token: result.accessToken,
+      refresh_token: result.refreshToken,
       token_type: 'bearer',
-      expires_in: 7 * 24 * 60 * 60, // 7일 (초)
+      expires_in: 60 * 60, // 1시간 (초)
     });
   }
 

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -3,10 +3,12 @@ import { McpController } from './mcp.controller';
 import { McpService } from './mcp.service';
 import { ToolsModule } from '../tools/tools.module';
 import { UserModule } from '../user/user.module';
+import { GoogleModule } from '../google/google.module';
 
 @Module({
-  imports: [ToolsModule, UserModule],
+  imports: [ToolsModule, UserModule, GoogleModule],
   controllers: [McpController],
   providers: [McpService],
+  exports: [McpService],
 })
 export class McpModule {}

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { McpController } from './mcp.controller';
+import { McpService } from './mcp.service';
+import { ToolsModule } from '../tools/tools.module';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [ToolsModule, UserModule],
+  controllers: [McpController],
+  providers: [McpService],
+})
+export class McpModule {}

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
 import { randomUUID } from 'node:crypto';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -7,23 +8,158 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { ToolsService } from '../tools/tools.service';
 import { UserService } from '../user/service/user.service';
+import { GoogleOAuthService } from '../google/oauth/google-oauth.service';
 
 interface McpSession {
   server: Server;
   transport: StreamableHTTPServerTransport;
 }
 
+interface PkceSession {
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  clientRedirectUri: string;
+  clientState: string;
+}
+
+interface AuthCode {
+  slackId: string;
+  codeChallenge: string;
+}
+
+const MCP_SESSION_TTL = 7 * 24 * 60 * 60 * 1000; // 7일
+const PKCE_TTL = 10 * 60 * 1000; // 10분
+const AUTH_CODE_TTL = 5 * 60 * 1000; // 5분
+
 @Injectable()
 export class McpService {
-  // sessionId → { server, transport }
   private readonly sessions = new Map<string, McpSession>();
 
   constructor(
     private readonly toolsService: ToolsService,
     private readonly userService: UserService,
+    private readonly googleOAuthService: GoogleOAuthService,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
   ) {}
+
+  // ─── OAuth 2.0 메타데이터 ────────────────────────────────────────────────
+
+  getAuthorizationServerMetadata(baseUrl: string) {
+    return {
+      issuer: baseUrl,
+      authorization_endpoint: `${baseUrl}/mcp/auth/authorize`,
+      token_endpoint: `${baseUrl}/mcp/auth/token`,
+      registration_endpoint: `${baseUrl}/mcp/auth/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code'],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['none'],
+    };
+  }
+
+  registerClient(
+    clientMetadata: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const clientId = randomUUID();
+    return {
+      client_id: clientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      ...clientMetadata,
+    };
+  }
+
+  getProtectedResourceMetadata(baseUrl: string) {
+    return {
+      resource: `${baseUrl}/mcp`,
+      authorization_servers: [baseUrl],
+    };
+  }
+
+  // ─── OAuth 2.0 Authorization Endpoint ───────────────────────────────────
+
+  async startAuthorize(params: {
+    codeChallenge: string;
+    codeChallengeMethod: string;
+    clientRedirectUri: string;
+    clientState: string;
+  }): Promise<string> {
+    const ourState = randomUUID();
+    await this.cache.set(
+      `mcp:pkce:${ourState}`,
+      params satisfies PkceSession,
+      PKCE_TTL,
+    );
+
+    const redirectUri = process.env.MCP_GOOGLE_REDIRECT_URI ?? '';
+    return this.googleOAuthService.getGoogleAuthUrl(ourState, redirectUri);
+  }
+
+  // ─── Google OAuth Callback ───────────────────────────────────────────────
+
+  async handleGoogleCallback(
+    code: string,
+    ourState: string,
+  ): Promise<{ clientRedirectUri: string; clientState: string } | null> {
+    const pkce = await this.cache.get<PkceSession>(`mcp:pkce:${ourState}`);
+    if (!pkce) return null;
+
+    await this.cache.del(`mcp:pkce:${ourState}`);
+
+    const redirectUri = process.env.MCP_GOOGLE_REDIRECT_URI ?? '';
+    const { accessToken } = await this.googleOAuthService.exchangeCodeForTokens(
+      code,
+      redirectUri,
+    );
+    const { email } =
+      await this.googleOAuthService.getGoogleUserInfo(accessToken);
+
+    const user = await this.userService.findByEmail(email);
+    if (!user) return null;
+
+    const authCode = randomUUID();
+    await this.cache.set(
+      `mcp:authcode:${authCode}`,
+      {
+        slackId: user.slackId,
+        codeChallenge: pkce.codeChallenge,
+      } satisfies AuthCode,
+      AUTH_CODE_TTL,
+    );
+
+    return {
+      clientRedirectUri: `${pkce.clientRedirectUri}?code=${authCode}&state=${encodeURIComponent(pkce.clientState)}`,
+      clientState: pkce.clientState,
+    };
+  }
+
+  // ─── OAuth 2.0 Token Endpoint ────────────────────────────────────────────
+
+  async issueToken(code: string, codeVerifier: string): Promise<string | null> {
+    const authCode = await this.cache.get<AuthCode>(`mcp:authcode:${code}`);
+    if (!authCode) return null;
+
+    await this.cache.del(`mcp:authcode:${code}`);
+
+    // PKCE S256 검증
+    const computed = createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+    if (computed !== authCode.codeChallenge) return null;
+
+    const token = randomUUID();
+    await this.cache.set(
+      `mcp:session:${token}`,
+      authCode.slackId,
+      MCP_SESSION_TTL,
+    );
+    return token;
+  }
+
+  // ─── MCP 요청 처리 ───────────────────────────────────────────────────────
 
   private buildServer(slackId: string): Server {
     const server = new Server(
@@ -61,14 +197,12 @@ export class McpService {
   ): Promise<void> {
     const sessionId = (req.headers['mcp-session-id'] as string) ?? undefined;
 
-    // 기존 세션 재사용
     if (sessionId && this.sessions.has(sessionId)) {
       const session = this.sessions.get(sessionId)!;
       await session.transport.handleRequest(req, res, body);
       return;
     }
 
-    // initialize 요청인지 확인 (새 세션 생성 가능)
     const isInit =
       body !== null &&
       typeof body === 'object' &&
@@ -83,7 +217,6 @@ export class McpService {
       return;
     }
 
-    // 새 세션 생성
     const newSessionId = randomUUID();
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => newSessionId,
@@ -91,10 +224,7 @@ export class McpService {
     const server = this.buildServer(slackId);
 
     this.sessions.set(newSessionId, { server, transport });
-
-    transport.onclose = () => {
-      this.sessions.delete(newSessionId);
-    };
+    transport.onclose = () => this.sessions.delete(newSessionId);
 
     await server.connect(transport);
     await transport.handleRequest(req, res, body);
@@ -105,9 +235,7 @@ export class McpService {
     const token = authHeader.slice(7).trim();
     if (!token) return null;
 
-    // POC: Bearer 토큰 = slackId 직접 사용
-    // TODO: Google OAuth 세션 토큰으로 교체
-    const user = await this.userService.findBySlackId(token);
-    return user ? token : null;
+    const slackId = await this.cache.get<string>(`mcp:session:${token}`);
+    return slackId ?? null;
   }
 }

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -31,7 +31,8 @@ interface AuthCode {
   codeChallenge: string;
 }
 
-const MCP_SESSION_TTL = 7 * 24 * 60 * 60 * 1000; // 7일
+const ACCESS_TOKEN_TTL = 60 * 60 * 1000; // 1시간
+const REFRESH_TOKEN_TTL = 365 * 24 * 60 * 60 * 1000; // 365일
 const PKCE_TTL = 10 * 60 * 1000; // 10분
 const AUTH_CODE_TTL = 5 * 60 * 1000; // 5분
 
@@ -55,7 +56,7 @@ export class McpService {
       token_endpoint: `${baseUrl}/mcp/auth/token`,
       registration_endpoint: `${baseUrl}/mcp/auth/register`,
       response_types_supported: ['code'],
-      grant_types_supported: ['authorization_code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
       code_challenge_methods_supported: ['S256'],
       token_endpoint_auth_methods_supported: ['none'],
     };
@@ -138,25 +139,43 @@ export class McpService {
 
   // ─── OAuth 2.0 Token Endpoint ────────────────────────────────────────────
 
-  async issueToken(code: string, codeVerifier: string): Promise<string | null> {
+  async issueToken(
+    code: string,
+    codeVerifier: string,
+  ): Promise<{ accessToken: string; refreshToken: string } | null> {
     const authCode = await this.cache.get<AuthCode>(`mcp:authcode:${code}`);
     if (!authCode) return null;
 
     await this.cache.del(`mcp:authcode:${code}`);
 
-    // PKCE S256 검증
     const computed = createHash('sha256')
       .update(codeVerifier)
       .digest('base64url');
     if (computed !== authCode.codeChallenge) return null;
 
-    const token = randomUUID();
-    await this.cache.set(
-      `mcp:session:${token}`,
-      authCode.slackId,
-      MCP_SESSION_TTL,
-    );
-    return token;
+    return this.mintTokenPair(authCode.slackId);
+  }
+
+  async refreshToken(
+    refreshToken: string,
+  ): Promise<{ accessToken: string; refreshToken: string } | null> {
+    const slackId = await this.cache.get<string>(`mcp:refresh:${refreshToken}`);
+    if (!slackId) return null;
+
+    await this.cache.del(`mcp:refresh:${refreshToken}`);
+    return this.mintTokenPair(slackId);
+  }
+
+  private async mintTokenPair(
+    slackId: string,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const accessToken = randomUUID();
+    const refreshToken = randomUUID();
+    await Promise.all([
+      this.cache.set(`mcp:session:${accessToken}`, slackId, ACCESS_TOKEN_TTL),
+      this.cache.set(`mcp:refresh:${refreshToken}`, slackId, REFRESH_TOKEN_TTL),
+    ]);
+    return { accessToken, refreshToken };
   }
 
   // ─── MCP 요청 처리 ───────────────────────────────────────────────────────

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { ToolsService } from '../tools/tools.service';
+import { UserService } from '../user/service/user.service';
+
+interface McpSession {
+  server: Server;
+  transport: StreamableHTTPServerTransport;
+}
+
+@Injectable()
+export class McpService {
+  // sessionId → { server, transport }
+  private readonly sessions = new Map<string, McpSession>();
+
+  constructor(
+    private readonly toolsService: ToolsService,
+    private readonly userService: UserService,
+  ) {}
+
+  private buildServer(slackId: string): Server {
+    const server = new Server(
+      { name: 'gsc-slack-app', version: '1.0.0' },
+      { capabilities: { tools: {} } },
+    );
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.toolsService.getDefinitions().map((t) => ({
+        name: t.name,
+        description: t.description ?? '',
+        inputSchema: t.input_schema,
+      })),
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async (req) => {
+      const result = await this.toolsService.execute(
+        req.params.name,
+        req.params.arguments ?? {},
+        slackId,
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    });
+
+    return server;
+  }
+
+  async handleRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    body: unknown,
+    slackId: string,
+  ): Promise<void> {
+    const sessionId = (req.headers['mcp-session-id'] as string) ?? undefined;
+
+    // 기존 세션 재사용
+    if (sessionId && this.sessions.has(sessionId)) {
+      const session = this.sessions.get(sessionId)!;
+      await session.transport.handleRequest(req, res, body);
+      return;
+    }
+
+    // initialize 요청인지 확인 (새 세션 생성 가능)
+    const isInit =
+      body !== null &&
+      typeof body === 'object' &&
+      'method' in body &&
+      (body as Record<string, unknown>).method === 'initialize';
+
+    if (!isInit) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({ error: 'No active session. Send initialize first.' }),
+      );
+      return;
+    }
+
+    // 새 세션 생성
+    const newSessionId = randomUUID();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => newSessionId,
+    });
+    const server = this.buildServer(slackId);
+
+    this.sessions.set(newSessionId, { server, transport });
+
+    transport.onclose = () => {
+      this.sessions.delete(newSessionId);
+    };
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+  }
+
+  async resolveSlackId(authHeader: string | undefined): Promise<string | null> {
+    if (!authHeader?.startsWith('Bearer ')) return null;
+    const token = authHeader.slice(7).trim();
+    if (!token) return null;
+
+    // POC: Bearer 토큰 = slackId 직접 사용
+    // TODO: Google OAuth 세션 토큰으로 교체
+    const user = await this.userService.findBySlackId(token);
+    return user ? token : null;
+  }
+}


### PR DESCRIPTION
## 개요

`@modelcontextprotocol/sdk` 기반 MCP 서버를 구현하고, Google OAuth 2.0 + PKCE 인증으로 슬랙 유저를 식별합니다. Claude Desktop 커스텀 커넥터에 URL만 입력하면 구글 로그인 후 바로 사용 가능합니다.

## 주요 변경 사항

### MCP 서버 (`src/mcp/`)
- Streamable HTTP transport 기반 MCP 서버 구현
- Bearer 토큰 검증 후 슬랙 유저 컨텍스트로 툴 실행

### Google OAuth 2.0 + PKCE 인증
- `GET /mcp/auth/authorize` — PKCE 세션 저장 후 구글 로그인 리다이렉트
- `GET /mcp/auth/callback` — 구글 콜백 처리, 슬랙 유저 매핑, auth code 발급
- `POST /mcp/auth/token` — authorization_code / refresh_token grant 처리
- `POST /mcp/auth/register` — Dynamic Client Registration (RFC 7591)

### OAuth 디스커버리 엔드포인트
- `GET /.well-known/oauth-authorization-server`
- `GET /.well-known/oauth-protected-resource`

### 토큰 관리
- Access token: 1시간, Refresh token: 365일 (rotation 적용)
- Redis로 PKCE 세션(10분), auth code(5분), 토큰 관리

## 관련 이슈

없음

## 테스트

- [x] 커스텀 커넥터에 URL 입력 시 구글 로그인 화면 진입 확인
- [x] 로그인 후 MCP 연결 성공 확인
- [x] access token 만료 시 자동 갱신 확인 (401 → refresh_token → 200)
- [x] 미가입 구글 계정 로그인 시 403 확인