### PR TITLE
feat(tools): get_current_time 툴 추가 및 Slack AI 개선

### DIFF
--- a/src/resource/service/study-room.service.ts
+++ b/src/resource/service/study-room.service.ts
@@ -59,6 +59,9 @@ export class StudyRoomService {
 
   // 스터디룸 예약 생성 (시간 충돌 확인 후 Google Calendar 이벤트 생성)
   async bookResource(dto: BookResourceDto): Promise<string> {
+    if (!dto.resourceId)
+      throw new BusinessError(ResourceErrorCode.STUDY_ROOM_NOT_FOUND);
+
     const resource = await this.resourceService.findById(dto.resourceId);
     if (!resource)
       throw new BusinessError(ResourceErrorCode.STUDY_ROOM_NOT_FOUND);

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -7,7 +7,7 @@ import { UserService } from '../user/service/user.service';
 
 const MODEL = 'claude-haiku-4-5-20251001';
 const HISTORY_TTL_MS = 60 * 60 * 1000; // 1시간
-const MAX_HISTORY_MESSAGES = 20; // 최근 10턴
+const MAX_HISTORY_MESSAGES = 50; // 최근 25턴
 
 const buildSystemPrompt = (userName: string | null) => {
   const now = new Date().toLocaleString('ko-KR', {

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -24,9 +24,8 @@ const buildSystemPrompt = (userName: string | null) => {
   return `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
 ${userName ? `현재 대화 중인 사용자의 이름은 "${userName}"입니다.` : ''}
 현재 날짜 및 시각: ${now}
-사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 귀엽고 간결하게 한국어로 안내하세요.
+사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 귀엽고 간결하게 안내하세요. 사용자가 사용하는 언어로 응답하세요.
 모든 날짜와 시간은 한국 표준시(KST, UTC+9) 기준으로 해석하고 표시하세요.
-날짜와 시간 표시 형식은 "2025년 5월 10일 오후 2시" 형식을 사용하세요.
 id, calendarId, eventId 등 내부 식별자는 절대 사용자에게 노출하지 마세요.
 예약을 찾을 수 없거나 수정·취소 권한이 없는 경우 "해당 예약에 대한 권한이 없습니다" 형식으로 안내하세요.
 예약 생성·수정·취소는 반드시 해당 툴을 실제로 호출해야 완료됩니다. 툴 호출 없이 완료되었다고 응답하지 마세요.`;
@@ -103,7 +102,9 @@ export class SlackAiService {
     text: string,
     onProgress?: (msg: string) => Promise<void>,
   ): Promise<string> {
-    const tools = this.toolsService.getDefinitions();
+    const tools = this.toolsService
+      .getDefinitions()
+      .filter((t) => t.name !== 'get_current_time'); // 프롬프트에 시간이 있으므로 툴 제외
     const user = await this.userService.findBySlackId(slackId);
     const systemPrompt = buildSystemPrompt(user?.name ?? null);
 

--- a/src/tools/time.tool.ts
+++ b/src/tools/time.tool.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import type Anthropic from '@anthropic-ai/sdk';
+
+@Injectable()
+export class TimeTool {
+  readonly definitions: Anthropic.Tool[] = [
+    {
+      name: 'get_current_time',
+      description:
+        '현재 날짜와 시간을 반환합니다. 예약 등 날짜/시간 관련 작업 전에 반드시 호출하세요.',
+      input_schema: { type: 'object' as const, properties: {}, required: [] },
+    },
+  ];
+
+  async execute(name: string): Promise<unknown> {
+    if (name !== 'get_current_time') return null;
+
+    const now = new Date();
+    return {
+      iso: now.toISOString(),
+      timezone: 'Asia/Seoul',
+      formatted: now.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' }),
+    };
+  }
+}

--- a/src/tools/tools.module.ts
+++ b/src/tools/tools.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { ResourceModule } from '../resource/resource.module';
 import { UserModule } from '../user/user.module';
 import { BookingTool } from './booking.tool';
+import { TimeTool } from './time.tool';
 import { ToolsService } from './tools.service';
 
 @Module({
   imports: [ResourceModule, UserModule],
-  providers: [BookingTool, ToolsService],
+  providers: [BookingTool, TimeTool, ToolsService],
   exports: [ToolsService],
 })
 export class ToolsModule {}

--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import type Anthropic from '@anthropic-ai/sdk';
 import { BookingTool } from './booking.tool';
+import { TimeTool } from './time.tool';
 import { BusinessError } from '../common/errors/base.error';
 
 @Injectable()
 export class ToolsService {
-  private readonly tools: BookingTool[];
+  private readonly tools: (BookingTool | TimeTool)[];
 
-  constructor(private readonly bookingTool: BookingTool) {
-    this.tools = [bookingTool];
+  constructor(bookingTool: BookingTool, timeTool: TimeTool) {
+    this.tools = [bookingTool, timeTool];
   }
 
   getDefinitions(): Anthropic.Tool[] {


### PR DESCRIPTION
## 개요

MCP 환경에서 날짜/시간 조회를 위한 툴 추가, 예약 서비스 방어 코드 보강, Slack AI 다국어 대응 및 히스토리 개선.

## 주요 변경 사항

### get_current_time 툴 추가
- MCP에서 시스템 프롬프트 없이 현재 날짜/시간 조회 가능
- Slack AI에서는 시스템 프롬프트에 날짜가 주입되므로 해당 툴 제외

### bookResource 방어 코드 추가
- resourceId가 undefined일 때 TypeORM이 WHERE 없이 전체 조회하는 문제 방지
- undefined 입력 시 즉시 STUDY_ROOM_NOT_FOUND 반환

### Slack AI 개선
- 응답 언어를 한국어 고정에서 사용자 언어 자동 감지로 변경
- 날짜 표시 형식 고정 지시 제거
- 대화 히스토리 최대 메시지 수 20 → 50으로 증가 (툴 호출이 많은 대화 컨텍스트 유실 방지)

## 관련 이슈

없음

## 테스트

- [x] MCP에서 get_current_time 툴 호출 확인
- [x] Slack AI 영어 메시지에 영어로 응답 확인
- [x] Slack AI 일본어 메시지에 일본어로 응답 확인