### PR TITLE
feat(announcement): 봇을 통한 채널 공지 기능 추가

### DIFF
--- a/src/announcement/announcement.controller.ts
+++ b/src/announcement/announcement.controller.ts
@@ -95,6 +95,72 @@ export class AnnouncementController {
     });
   }
 
+  /** 공지 삭제 — action.value = announcement.id */
+  @Action('announcement:delete')
+  async handleDelete({
+    ack,
+    client,
+    body,
+    action,
+  }: SlackActionMiddlewareArgs<BlockAction<ButtonAction>> & AllMiddlewareArgs) {
+    await ack();
+
+    const userId = body.user.id;
+
+    try {
+      await this.permissionService.requireAdmin(userId);
+    } catch (e) {
+      if (e instanceof BusinessError) {
+        await client.chat.postEphemeral({
+          channel: userId,
+          user: userId,
+          text: e.message,
+        });
+        return;
+      }
+      throw e;
+    }
+
+    const id = Number(action.value);
+    const announcement = await this.announcementService.findOne(id);
+
+    if (!announcement) {
+      await client.chat.postEphemeral({
+        channel: userId,
+        user: userId,
+        text: '해당 공지를 찾을 수 없습니다.',
+      });
+      return;
+    }
+
+    try {
+      await client.chat.delete({
+        channel: announcement.channelId,
+        ts: announcement.messageTs,
+      });
+    } catch (error: unknown) {
+      const code = extractSlackErrorCode(error);
+      if (code !== 'message_not_found') {
+        this.logger.error(`채널 메시지 삭제 실패 — id: ${id}, error: ${code}`);
+        await client.chat.postEphemeral({
+          channel: userId,
+          user: userId,
+          text: `채널 메시지 삭제에 실패했습니다: ${code}`,
+        });
+        return;
+      }
+    }
+
+    await this.announcementService.softDelete(id);
+    this.logger.log(`공지 삭제 완료 — id: ${id}, by: ${userId}`);
+
+    const announcements = await this.announcementService.findRecent(10);
+    await client.views.update({
+      view_id: body.view?.id ?? '',
+      view: AnnouncementView.listModal(announcements),
+    });
+  }
+
   /** 수정 모달 열기 — action.value = announcement.id */
   @Action('announcement:edit:open-modal')
   async openEditModal({

--- a/src/announcement/announcement.controller.ts
+++ b/src/announcement/announcement.controller.ts
@@ -1,0 +1,330 @@
+import { Controller, Logger } from '@nestjs/common';
+import { Action, View } from 'nestjs-slack-bolt';
+import type {
+  AllMiddlewareArgs,
+  SlackActionMiddlewareArgs,
+  SlackViewMiddlewareArgs,
+  BlockAction,
+  ButtonAction,
+} from '@slack/bolt';
+import { AnnouncementService } from './announcement.service';
+import { AnnouncementView } from './view/announcement.view';
+import { PermissionService } from '../user/service/permission.service';
+import { BusinessError } from '../common/errors';
+
+@Controller()
+export class AnnouncementController {
+  private readonly logger = new Logger(AnnouncementController.name);
+
+  constructor(
+    private readonly announcementService: AnnouncementService,
+    private readonly permissionService: PermissionService,
+  ) {}
+
+  /** 공지 목록 모달 열기 */
+  @Action('announcement:list:open-modal')
+  async openListModal({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const userId = body.user.id;
+
+    try {
+      await this.permissionService.requireAdmin(userId);
+    } catch (e) {
+      if (e instanceof BusinessError) {
+        await client.chat.postEphemeral({
+          channel: userId,
+          user: userId,
+          text: e.message,
+        });
+        return;
+      }
+      throw e;
+    }
+
+    const announcements = await this.announcementService.findRecent(10);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: AnnouncementView.listModal(announcements),
+    });
+  }
+
+  /** 공지 작성 모달 열기 (Home 또는 목록 모달 내 버튼) */
+  @Action('announcement:create:open-modal')
+  async openCreateModal({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const userId = body.user.id;
+
+    try {
+      await this.permissionService.requireAdmin(userId);
+    } catch (e) {
+      if (e instanceof BusinessError) {
+        await client.chat.postEphemeral({
+          channel: userId,
+          user: userId,
+          text: e.message,
+        });
+        return;
+      }
+      throw e;
+    }
+
+    // 봇이 참여 중인 public/private 채널만 가져옴 (DM/MPIM 제외)
+    const result = await client.conversations.list({
+      types: 'public_channel,private_channel',
+      exclude_archived: true,
+      limit: 200,
+    });
+    const channels = (result.channels ?? []).filter((ch) => ch.is_member);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: AnnouncementView.createModal(channels),
+    });
+  }
+
+  /** 수정 모달 열기 — action.value = announcement.id */
+  @Action('announcement:edit:open-modal')
+  async openEditModal({
+    ack,
+    client,
+    body,
+    action,
+  }: SlackActionMiddlewareArgs<BlockAction<ButtonAction>> & AllMiddlewareArgs) {
+    await ack();
+
+    const userId = body.user.id;
+
+    try {
+      await this.permissionService.requireAdmin(userId);
+    } catch (e) {
+      if (e instanceof BusinessError) {
+        await client.chat.postEphemeral({
+          channel: userId,
+          user: userId,
+          text: e.message,
+        });
+        return;
+      }
+      throw e;
+    }
+
+    const id = Number(action.value);
+    const announcement = await this.announcementService.findOne(id);
+
+    if (!announcement) {
+      await client.chat.postEphemeral({
+        channel: userId,
+        user: userId,
+        text: '해당 공지를 찾을 수 없습니다.',
+      });
+      return;
+    }
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: AnnouncementView.editModal(announcement),
+    });
+  }
+
+  /** 공지 작성 제출 */
+  @View('announcement:modal:create')
+  async handleCreate({
+    ack,
+    body,
+    view,
+    client,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const userId = body.user.id;
+
+    // 제출 시점 권한 재확인
+    try {
+      await this.permissionService.requireAdmin(userId);
+    } catch (e) {
+      if (e instanceof BusinessError) {
+        await ack({
+          response_action: 'errors',
+          errors: { channel_block: e.message },
+        });
+        return;
+      }
+      throw e;
+    }
+
+    const values = view.state.values;
+    const channelId =
+      values.channel_block.channel_input.selected_option?.value ?? '';
+    const title = values.title_block.title_input.value ?? '';
+    // rich_text_input은 rich_text_value로 읽음 (Slack Block Kit 타입 미지원 → any 캐스팅)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const richTextBlock = (values.content_block?.content_input as any)?.rich_text_value ?? null;
+
+    if (!channelId) {
+      await ack({
+        response_action: 'errors',
+        errors: { channel_block: '채널을 선택해주세요.' },
+      });
+      return;
+    }
+    if (!richTextBlock) {
+      await ack({
+        response_action: 'errors',
+        errors: { content_block: '공지 내용을 입력해주세요.' },
+      });
+      return;
+    }
+
+    await ack();
+
+    const contentJson = JSON.stringify(richTextBlock);
+
+    try {
+      const message = AnnouncementView.announcementMessage(title, richTextBlock);
+      const result = await client.chat.postMessage({
+        channel: channelId,
+        text: message.text,
+        blocks: message.blocks,
+      });
+
+      const messageTs = result.ts ?? '';
+
+      await this.announcementService.create({
+        channelId,
+        messageTs,
+        title,
+        content: contentJson,
+        authorSlackId: userId,
+      });
+
+      this.logger.log(
+        `공지 발송 완료 — channel: ${channelId}, ts: ${messageTs}, by: ${userId}`,
+      );
+    } catch (error: unknown) {
+      this.logger.error('공지 발송 실패:', error);
+      await client.chat.postEphemeral({
+        channel: userId,
+        user: userId,
+        text: `공지 발송에 실패했습니다: ${extractSlackErrorMessage(error)}`,
+      });
+    }
+  }
+
+  /** 공지 수정 제출 — private_metadata = announcement.id */
+  @View('announcement:modal:edit')
+  async handleEdit({
+    ack,
+    body,
+    view,
+    client,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const userId = body.user.id;
+
+    // 제출 시점 권한 재확인
+    try {
+      await this.permissionService.requireAdmin(userId);
+    } catch (e) {
+      if (e instanceof BusinessError) {
+        await ack({
+          response_action: 'errors',
+          errors: { title_block: e.message },
+        });
+        return;
+      }
+      throw e;
+    }
+
+    const id = Number(view.private_metadata);
+    const values = view.state.values;
+    const title = values.title_block.title_input.value ?? '';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const richTextBlock = (values.content_block?.content_input as any)?.rich_text_value ?? null;
+
+    if (!richTextBlock) {
+      await ack({
+        response_action: 'errors',
+        errors: { content_block: '공지 내용을 입력해주세요.' },
+      });
+      return;
+    }
+
+    await ack();
+
+    const contentJson = JSON.stringify(richTextBlock);
+    const announcement = await this.announcementService.findOne(id);
+
+    if (!announcement) {
+      await client.chat.postEphemeral({
+        channel: userId,
+        user: userId,
+        text: '해당 공지를 찾을 수 없습니다.',
+      });
+      return;
+    }
+
+    try {
+      const message = AnnouncementView.announcementMessage(title, richTextBlock);
+      await client.chat.update({
+        channel: announcement.channelId,
+        ts: announcement.messageTs,
+        text: message.text,
+        blocks: message.blocks,
+      });
+
+      await this.announcementService.update(id, { title, content: contentJson });
+
+      this.logger.log(
+        `공지 수정 완료 — id: ${id}, channel: ${announcement.channelId}`,
+      );
+    } catch (error: unknown) {
+      const errorCode = extractSlackErrorCode(error);
+      this.logger.error(`공지 수정 실패 — id: ${id}, error: ${errorCode}`);
+
+      if (errorCode === 'message_not_found') {
+        await client.chat.postEphemeral({
+          channel: userId,
+          user: userId,
+          text: '채널에서 원본 메시지를 찾을 수 없습니다. 메시지가 삭제되었을 수 있습니다.',
+        });
+      } else {
+        await client.chat.postEphemeral({
+          channel: userId,
+          user: userId,
+          text: `공지 수정에 실패했습니다: ${extractSlackErrorMessage(error)}`,
+        });
+      }
+    }
+  }
+}
+
+/** Slack API 에러 코드 추출 헬퍼 */
+function extractSlackErrorCode(error: unknown): string {
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'data' in error &&
+    error.data !== null &&
+    typeof error.data === 'object' &&
+    'error' in error.data
+  ) {
+    return String(error.data.error);
+  }
+  return '';
+}
+
+/** 에러 메시지 추출 헬퍼 */
+function extractSlackErrorMessage(error: unknown): string {
+  const code = extractSlackErrorCode(error);
+  if (code) return code;
+  if (error instanceof Error) return error.message;
+  return '알 수 없는 오류';
+}

--- a/src/announcement/announcement.controller.ts
+++ b/src/announcement/announcement.controller.ts
@@ -48,11 +48,12 @@ export class AnnouncementController {
       throw e;
     }
 
-    const announcements = await this.announcementService.findRecent(10);
+    const limit = AnnouncementView.PAGE_SIZE;
+    const { items, total } = await this.announcementService.findPage(0, limit);
 
     await client.views.open({
       trigger_id: body.trigger_id,
-      view: AnnouncementView.listModal(announcements),
+      view: AnnouncementView.listModal(items, 0, total),
     });
   }
 
@@ -154,10 +155,67 @@ export class AnnouncementController {
     await this.announcementService.softDelete(id);
     this.logger.log(`공지 삭제 완료 — id: ${id}, by: ${userId}`);
 
-    const announcements = await this.announcementService.findRecent(10);
+    const limit = AnnouncementView.PAGE_SIZE;
+    const offset = Number(body.view?.private_metadata ?? '0');
+    const { items, total } = await this.announcementService.findPage(offset, limit);
+    // 삭제 후 현재 페이지 항목이 없으면 이전 페이지로 이동
+    const adjustedOffset = items.length === 0 && offset > 0 ? offset - limit : offset;
+    const page =
+      adjustedOffset !== offset
+        ? await this.announcementService.findPage(adjustedOffset, limit)
+        : { items, total };
+
+    const viewId = body.view?.id;
+    if (!viewId) {
+      this.logger.error('삭제 후 목록 갱신 실패: view_id 없음');
+      return;
+    }
+
     await client.views.update({
-      view_id: body.view?.id ?? '',
-      view: AnnouncementView.listModal(announcements),
+      view_id: viewId,
+      hash: body.view?.hash,
+      view: AnnouncementView.listModal(page.items, adjustedOffset, page.total),
+    });
+  }
+
+  /** 이전 페이지 — action.value = 이동할 offset */
+  @Action('announcement:list:prev')
+  async handleListPrev(
+    args: SlackActionMiddlewareArgs<BlockAction<ButtonAction>> & AllMiddlewareArgs,
+  ) {
+    return this.handleListPage(args);
+  }
+
+  /** 다음 페이지 — action.value = 이동할 offset */
+  @Action('announcement:list:next')
+  async handleListNext(
+    args: SlackActionMiddlewareArgs<BlockAction<ButtonAction>> & AllMiddlewareArgs,
+  ) {
+    return this.handleListPage(args);
+  }
+
+  private async handleListPage({
+    ack,
+    client,
+    body,
+    action,
+  }: SlackActionMiddlewareArgs<BlockAction<ButtonAction>> & AllMiddlewareArgs) {
+    await ack();
+
+    const offset = Number(action.value);
+    const limit = AnnouncementView.PAGE_SIZE;
+    const { items, total } = await this.announcementService.findPage(offset, limit);
+
+    const viewId = body.view?.id;
+    if (!viewId) {
+      this.logger.error('페이지 이동 실패: view_id 없음');
+      return;
+    }
+
+    await client.views.update({
+      view_id: viewId,
+      hash: body.view?.hash,
+      view: AnnouncementView.listModal(items, offset, total),
     });
   }
 

--- a/src/announcement/announcement.controller.ts
+++ b/src/announcement/announcement.controller.ts
@@ -10,6 +10,7 @@ import type {
 import { AnnouncementService } from './announcement.service';
 import { AnnouncementView } from './view/announcement.view';
 import { PermissionService } from '../user/service/permission.service';
+import { UserService } from '../user/service/user.service';
 import { BusinessError } from '../common/errors';
 
 @Controller()
@@ -19,6 +20,7 @@ export class AnnouncementController {
   constructor(
     private readonly announcementService: AnnouncementService,
     private readonly permissionService: PermissionService,
+    private readonly userService: UserService,
   ) {}
 
   /** 공지 목록 모달 열기 */
@@ -198,12 +200,18 @@ export class AnnouncementController {
 
       const messageTs = result.ts ?? '';
 
+      const author = await this.userService.findBySlackId(userId);
+      if (!author) {
+        this.logger.error(`공지 작성자를 찾을 수 없음 — slackId: ${userId}`);
+        return;
+      }
+
       await this.announcementService.create({
         channelId,
         messageTs,
         title,
         content: contentJson,
-        authorSlackId: userId,
+        authorId: author.id,
       });
 
       this.logger.log(

--- a/src/announcement/announcement.entity.ts
+++ b/src/announcement/announcement.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../user/user.entity';
+
+@Entity()
+export class Announcement {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  /** Slack 채널 ID (C...) */
+  @Column()
+  channelId: string;
+
+  /** chat.postMessage response.ts — chat.update 키 */
+  @Column()
+  messageTs: string;
+
+  /** 공지 제목 */
+  @Column()
+  title: string;
+
+  /** 공지 내용 */
+  @Column('text')
+  content: string;
+
+  /** 작성자 (admin만 확인 가능) */
+  @ManyToOne(() => User, { eager: true })
+  author: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/announcement/announcement.entity.ts
+++ b/src/announcement/announcement.entity.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -38,4 +39,7 @@ export class Announcement {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
 }

--- a/src/announcement/announcement.module.ts
+++ b/src/announcement/announcement.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Announcement } from './announcement.entity';
+import { AnnouncementService } from './announcement.service';
+import { AnnouncementController } from './announcement.controller';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Announcement]), UserModule],
+  controllers: [AnnouncementController],
+  providers: [AnnouncementService],
+  exports: [AnnouncementService],
+})
+export class AnnouncementModule {}

--- a/src/announcement/announcement.service.ts
+++ b/src/announcement/announcement.service.ts
@@ -39,7 +39,7 @@ export class AnnouncementService {
       messageTs: dto.messageTs,
       title: dto.title,
       content: dto.content,
-      author: { slackId: dto.authorSlackId } as unknown as User,
+      author: { id: dto.authorId } as unknown as User,
     });
     return this.announcementRepository.save(announcement);
   }

--- a/src/announcement/announcement.service.ts
+++ b/src/announcement/announcement.service.ts
@@ -51,4 +51,9 @@ export class AnnouncementService {
       content: dto.content,
     });
   }
+
+  /** 공지 소프트 삭제 */
+  async softDelete(id: number): Promise<void> {
+    await this.announcementRepository.softDelete(id);
+  }
 }

--- a/src/announcement/announcement.service.ts
+++ b/src/announcement/announcement.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Announcement } from './announcement.entity';
+import { User } from '../user/user.entity';
+import {
+  CreateAnnouncementDto,
+  UpdateAnnouncementDto,
+} from './dto/create-announcement.dto';
+
+@Injectable()
+export class AnnouncementService {
+  constructor(
+    @InjectRepository(Announcement)
+    private readonly announcementRepository: Repository<Announcement>,
+  ) {}
+
+  /** 최근 공지 최대 n개 조회 (author 포함) */
+  async findRecent(limit = 10): Promise<Announcement[]> {
+    return this.announcementRepository.find({
+      order: { createdAt: 'DESC' },
+      take: limit,
+      relations: { author: true },
+    });
+  }
+
+  /** 단일 공지 조회 */
+  async findOne(id: number): Promise<Announcement | null> {
+    return this.announcementRepository.findOne({
+      where: { id },
+      relations: { author: true },
+    });
+  }
+
+  /** 공지 생성 */
+  async create(dto: CreateAnnouncementDto): Promise<Announcement> {
+    const announcement = this.announcementRepository.create({
+      channelId: dto.channelId,
+      messageTs: dto.messageTs,
+      title: dto.title,
+      content: dto.content,
+      author: { slackId: dto.authorSlackId } as unknown as User,
+    });
+    return this.announcementRepository.save(announcement);
+  }
+
+  /** 공지 수정 (제목·내용만) */
+  async update(id: number, dto: UpdateAnnouncementDto): Promise<void> {
+    await this.announcementRepository.update(id, {
+      title: dto.title,
+      content: dto.content,
+    });
+  }
+}

--- a/src/announcement/announcement.service.ts
+++ b/src/announcement/announcement.service.ts
@@ -15,13 +15,18 @@ export class AnnouncementService {
     private readonly announcementRepository: Repository<Announcement>,
   ) {}
 
-  /** 최근 공지 최대 n개 조회 (author 포함) */
-  async findRecent(limit = 10): Promise<Announcement[]> {
-    return this.announcementRepository.find({
+  /** 페이지 단위 공지 조회 (author 포함) */
+  async findPage(
+    offset: number,
+    limit: number,
+  ): Promise<{ items: Announcement[]; total: number }> {
+    const [items, total] = await this.announcementRepository.findAndCount({
       order: { createdAt: 'DESC' },
+      skip: offset,
       take: limit,
       relations: { author: true },
     });
+    return { items, total };
   }
 
   /** 단일 공지 조회 */

--- a/src/announcement/dto/create-announcement.dto.ts
+++ b/src/announcement/dto/create-announcement.dto.ts
@@ -1,0 +1,12 @@
+export interface CreateAnnouncementDto {
+  channelId: string;
+  messageTs: string;
+  title: string;
+  content: string;
+  authorSlackId: string;
+}
+
+export interface UpdateAnnouncementDto {
+  title: string;
+  content: string;
+}

--- a/src/announcement/dto/create-announcement.dto.ts
+++ b/src/announcement/dto/create-announcement.dto.ts
@@ -3,7 +3,7 @@ export interface CreateAnnouncementDto {
   messageTs: string;
   title: string;
   content: string;
-  authorSlackId: string;
+  authorId: number;
 }
 
 export interface UpdateAnnouncementDto {

--- a/src/announcement/view/announcement.view.ts
+++ b/src/announcement/view/announcement.view.ts
@@ -3,17 +3,26 @@ import type { Channel } from '@slack/web-api/dist/types/response/ConversationsLi
 import type { Announcement } from '../announcement.entity';
 
 export class AnnouncementView {
+  static readonly PAGE_SIZE = 10;
+
   /** 공지 목록 모달 */
-  static listModal(announcements: Announcement[]): View {
+  static listModal(
+    announcements: Announcement[],
+    offset: number,
+    total: number,
+  ): View {
+    const limit = AnnouncementView.PAGE_SIZE;
+    const currentPage = Math.floor(offset / limit) + 1;
+    const totalPages = Math.max(1, Math.ceil(total / limit));
+    const hasPrev = offset > 0;
+    const hasNext = offset + limit < total;
+
     const announcementBlocks: KnownBlock[] =
       announcements.length === 0
         ? [
             {
               type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: '아직 등록된 공지가 없습니다.',
-              },
+              text: { type: 'mrkdwn', text: '아직 등록된 공지가 없습니다.' },
             },
           ]
         : announcements.flatMap<KnownBlock>((a) => [
@@ -46,7 +55,10 @@ export class AnnouncementView {
                   value: String(a.id),
                   confirm: {
                     title: { type: 'plain_text', text: '공지 삭제' },
-                    text: { type: 'mrkdwn', text: '정말 삭제하시겠습니까?\n채널의 원본 메시지도 함께 삭제됩니다.' },
+                    text: {
+                      type: 'mrkdwn',
+                      text: '정말 삭제하시겠습니까?\n채널의 원본 메시지도 함께 삭제됩니다.',
+                    },
                     confirm: { type: 'plain_text', text: '삭제' },
                     deny: { type: 'plain_text', text: '취소' },
                     style: 'danger',
@@ -56,12 +68,53 @@ export class AnnouncementView {
             },
           ]);
 
+    const paginationElements: {
+      type: 'button';
+      text: { type: 'plain_text'; text: string };
+      action_id: string;
+      value: string;
+    }[] = [];
+    if (hasPrev) {
+      paginationElements.push({
+        type: 'button' as const,
+        text: { type: 'plain_text' as const, text: '◀ 이전' },
+        action_id: 'announcement:list:prev',
+        value: String(offset - limit),
+      });
+    }
+    if (hasNext) {
+      paginationElements.push({
+        type: 'button' as const,
+        text: { type: 'plain_text' as const, text: '다음 ▶' },
+        action_id: 'announcement:list:next',
+        value: String(offset + limit),
+      });
+    }
+
     return {
       type: 'modal',
       callback_id: 'announcement:modal:list',
+      private_metadata: String(offset),
       title: { type: 'plain_text', text: '공지 목록' },
       close: { type: 'plain_text', text: '닫기' },
-      blocks: [...announcementBlocks],
+      blocks: [
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `${currentPage} / ${totalPages} 페이지 (총 ${total}건)`,
+            },
+          ],
+        } as KnownBlock,
+        ...announcementBlocks,
+        ...(hasPrev || hasNext
+          ? [
+              { type: 'divider' } as KnownBlock,
+              { type: 'actions', elements: paginationElements } as KnownBlock,
+            ]
+          : []),
+      ],
     };
   }
 

--- a/src/announcement/view/announcement.view.ts
+++ b/src/announcement/view/announcement.view.ts
@@ -25,7 +25,7 @@ export class AnnouncementView {
                 text: [
                   `*${a.title}*`,
                   `채널: <#${a.channelId}>`,
-                  `작성자: ${a.author?.name ?? '알 수 없음'}  |  ${formatDate(a.createdAt)}`,
+                  `작성자: ${a.author?.slackId ? `<@${a.author.slackId}>` : (a.author?.name ?? '알 수 없음')}  |  ${formatDate(a.createdAt)}`,
                 ].join('\n'),
               },
               accessory: {

--- a/src/announcement/view/announcement.view.ts
+++ b/src/announcement/view/announcement.view.ts
@@ -1,0 +1,214 @@
+import type { View, KnownBlock } from '@slack/types';
+import type { Channel } from '@slack/web-api/dist/types/response/ConversationsListResponse';
+import type { Announcement } from '../announcement.entity';
+
+export class AnnouncementView {
+  /** 공지 목록 모달 */
+  static listModal(announcements: Announcement[]): View {
+    const announcementBlocks: KnownBlock[] =
+      announcements.length === 0
+        ? [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: '아직 등록된 공지가 없습니다.',
+              },
+            },
+          ]
+        : announcements.flatMap<KnownBlock>((a) => [
+            { type: 'divider' },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: [
+                  `*${a.title}*`,
+                  `채널: <#${a.channelId}>`,
+                  `작성자: ${a.author?.name ?? '알 수 없음'}  |  ${formatDate(a.createdAt)}`,
+                ].join('\n'),
+              },
+              accessory: {
+                type: 'button',
+                text: { type: 'plain_text', text: '수정' },
+                action_id: 'announcement:edit:open-modal',
+                value: String(a.id),
+              },
+            },
+          ]);
+
+    return {
+      type: 'modal',
+      callback_id: 'announcement:modal:list',
+      title: { type: 'plain_text', text: '공지 목록' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks: [...announcementBlocks],
+    };
+  }
+
+  /** 공지 작성 모달 — channels: 봇이 참여 중인 채널 목록 */
+  static createModal(channels: Channel[]): View {
+    const options = channels.map((ch) => ({
+      text: { type: 'plain_text' as const, text: `# ${ch.name ?? ch.id}` },
+      value: ch.id ?? '',
+    }));
+
+    return {
+      type: 'modal',
+      callback_id: 'announcement:modal:create',
+      title: { type: 'plain_text', text: '공지 작성' },
+      submit: { type: 'plain_text', text: '발송' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'input',
+          block_id: 'channel_block',
+          label: { type: 'plain_text', text: '채널 선택' },
+          element: {
+            type: 'static_select',
+            action_id: 'channel_input',
+            placeholder: { type: 'plain_text', text: '채널을 선택하세요' },
+            options,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'title_block',
+          label: { type: 'plain_text', text: '공지 제목' },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'title_input',
+            placeholder: { type: 'plain_text', text: '공지 제목을 입력하세요' },
+            max_length: 100,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'content_block',
+          label: { type: 'plain_text', text: '공지 내용' },
+          hint: {
+            type: 'plain_text',
+            text: '@멘션, 굵게(Ctrl+B), 기울임(Ctrl+I), 코드블록 등을 사용할 수 있어요.',
+          },
+          element: {
+            type: 'rich_text_input',
+            action_id: 'content_input',
+          } as unknown as import('@slack/types').RichTextInput,
+        },
+      ],
+    };
+  }
+
+  /** 공지 수정 모달 */
+  static editModal(announcement: Announcement): View {
+    return {
+      type: 'modal',
+      callback_id: 'announcement:modal:edit',
+      private_metadata: String(announcement.id),
+      title: { type: 'plain_text', text: '공지 수정' },
+      submit: { type: 'plain_text', text: '수정' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `채널: <#${announcement.channelId}>`,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'title_block',
+          label: { type: 'plain_text', text: '공지 제목' },
+          element: {
+            type: 'plain_text_input',
+            action_id: 'title_input',
+            initial_value: announcement.title,
+            max_length: 100,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'content_block',
+          label: { type: 'plain_text', text: '공지 내용' },
+          hint: {
+            type: 'plain_text',
+            text: '@멘션, 굵게(Ctrl+B), 기울임(Ctrl+I), 코드블록 등을 사용할 수 있어요.',
+          },
+          element: {
+            type: 'rich_text_input',
+            action_id: 'content_input',
+            initial_value: parseContentJson(announcement.content),
+          } as unknown as import('@slack/types').RichTextInput,
+        },
+      ],
+    };
+  }
+
+  /** 채널에 발송되는 공지 메시지 블록 */
+  static announcementMessage(
+    title: string,
+    richTextBlock: KnownBlock,
+  ): { text: string; blocks: KnownBlock[] } {
+    return {
+      text: `[공지] ${title}`,
+      blocks: [
+        {
+          type: 'header',
+          text: { type: 'plain_text', text: `📢 ${title}`, emoji: true },
+        },
+        { type: 'divider' },
+        richTextBlock,
+      ],
+    };
+  }
+
+  /** Home 탭 공지 관리 섹션 (admin 전용) */
+  static homeSection(): KnownBlock[] {
+    return [
+      { type: 'divider' },
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: '📢 공지 관리', emoji: true },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: '봇을 통해 채널에 공식 공지를 발송하거나 기존 공지를 수정할 수 있어요.',
+          },
+        ],
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '공지 목록 보기' },
+            action_id: 'announcement:list:open-modal',
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '공지 작성' },
+            style: 'primary',
+            action_id: 'announcement:create:open-modal',
+          },
+        ],
+      },
+    ];
+  }
+}
+
+/** DB에 저장된 rich_text JSON을 파싱. 파싱 실패 시 빈 rich_text 블록 반환 */
+function parseContentJson(json: string): object {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return { type: 'rich_text', elements: [] };
+  }
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/src/announcement/view/announcement.view.ts
+++ b/src/announcement/view/announcement.view.ts
@@ -28,12 +28,31 @@ export class AnnouncementView {
                   `작성자: ${a.author?.slackId ? `<@${a.author.slackId}>` : (a.author?.name ?? '알 수 없음')}  |  ${formatDate(a.createdAt)}`,
                 ].join('\n'),
               },
-              accessory: {
-                type: 'button',
-                text: { type: 'plain_text', text: '수정' },
-                action_id: 'announcement:edit:open-modal',
-                value: String(a.id),
-              },
+            },
+            {
+              type: 'actions',
+              elements: [
+                {
+                  type: 'button',
+                  text: { type: 'plain_text', text: '수정' },
+                  action_id: 'announcement:edit:open-modal',
+                  value: String(a.id),
+                },
+                {
+                  type: 'button',
+                  text: { type: 'plain_text', text: '삭제' },
+                  action_id: 'announcement:delete',
+                  style: 'danger',
+                  value: String(a.id),
+                  confirm: {
+                    title: { type: 'plain_text', text: '공지 삭제' },
+                    text: { type: 'mrkdwn', text: '정말 삭제하시겠습니까?\n채널의 원본 메시지도 함께 삭제됩니다.' },
+                    confirm: { type: 'plain_text', text: '삭제' },
+                    deny: { type: 'plain_text', text: '취소' },
+                    style: 'danger',
+                  },
+                },
+              ],
             },
           ]);
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { slackErrorMiddleware } from './common/slack-error.middleware';
 import { CleaningModule } from './cleaning/cleaning.module';
 import { SlackAiModule } from './slack-ai/slack-ai.module';
 import { McpModule } from './mcp/mcp.module';
+import { AnnouncementModule } from './announcement/announcement.module';
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { McpModule } from './mcp/mcp.module';
     CleaningModule,
     SlackAiModule,
     McpModule,
+    AnnouncementModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/migrations/1776900000000-AddAnnouncementTable.ts
+++ b/src/migrations/1776900000000-AddAnnouncementTable.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAnnouncementTable1776900000000 implements MigrationInterface {
+  name = 'AddAnnouncementTable1776900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "announcement" (
+        "id" SERIAL NOT NULL,
+        "channelId" character varying NOT NULL,
+        "messageTs" character varying NOT NULL,
+        "title" character varying NOT NULL,
+        "content" text NOT NULL,
+        "authorId" integer,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_announcement" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "announcement"
+        ADD CONSTRAINT "FK_announcement_author"
+        FOREIGN KEY ("authorId") REFERENCES "user"("id")
+        ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "announcement" DROP CONSTRAINT "FK_announcement_author"`,
+    );
+    await queryRunner.query(`DROP TABLE "announcement"`);
+  }
+}

--- a/src/migrations/1776900000001-AddAnnouncementSoftDelete.ts
+++ b/src/migrations/1776900000001-AddAnnouncementSoftDelete.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAnnouncementSoftDelete1776900000001
+  implements MigrationInterface
+{
+  name = 'AddAnnouncementSoftDelete1776900000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "announcement" ADD "deletedAt" TIMESTAMP`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "announcement" DROP COLUMN "deletedAt"`,
+    );
+  }
+}

--- a/src/slack-home/slack-home.view.ts
+++ b/src/slack-home/slack-home.view.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import type { View } from '@slack/types';
 import type { User } from '../user/user.entity';
 import { UserRole } from '../user/user.entity';
+import { AnnouncementView } from '../announcement/view/announcement.view';
 
 const APP_VERSION: string = JSON.parse(
   readFileSync(join(__dirname, '../../package.json'), 'utf-8'),
@@ -512,6 +513,7 @@ export class HomeView {
             },
           ],
         },
+        ...AnnouncementView.homeSection(),
         { type: 'divider' },
         {
           type: 'actions',


### PR DESCRIPTION
## 개요

Admin 이상 권한 사용자가 Slack 봇을 통해 특정 채널에 공지를 작성·수정·삭제할 수 있는 기능을 추가합니다. Home 탭에 공지 관리 섹션이 노출되며, 목록은 10개씩 페이지네이션으로 제공됩니다.

## 주요 변경 사항

### announcement 모듈 신규 추가
- `Announcement` 엔티티 — channelId, messageTs, title, content(rich_text JSON), author(FK), soft delete
- `AnnouncementService` — 페이지 조회(`findPage`), 단일 조회, 생성, 수정, 소프트 삭제
- `AnnouncementController` — 공지 목록/작성/수정/삭제 Slack 액션·뷰 핸들러
- DB 마이그레이션 — `announcement` 테이블 생성, `deletedAt` 컬럼 추가

### 공지 작성
- 채널 선택 + 제목 + rich_text 내용 입력 후 발송
- `chat.postMessage`로 채널에 메시지 전송, `messageTs` DB 저장

### 공지 수정
- 기존 공지 제목·내용 수정, `chat.update`로 원본 메시지 동기화

### 공지 삭제 (소프트 삭제)
- `chat.delete`로 채널 원본 메시지 삭제 후 DB `deletedAt` 설정
- 삭제 후 현재 페이지가 비면 이전 페이지로 자동 이동

### 목록 페이지네이션
- 10개씩 표시, 상단 context 블록에 현재/전체 페이지 표시
- 이전(`list:prev`) / 다음(`list:next`) 버튼으로 이동, action_id 분리로 Slack 중복 오류 방지

### 기타
- 작성자를 목록에서 `<@slackId>` 멘션으로 표시
- Home 탭 admin 유저에게 공지 관리 섹션 노출
- 권한 확인은 액션 진입 시점과 제출 시점 두 번 수행

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] admin 권한 유저 — Home 탭 공지 관리 섹션 노출 확인
- [x] 비admin 유저 — 버튼 클릭 시 권한 오류 메시지 수신 확인
- [x] 공지 작성 → 채널 메시지 발송 및 DB 저장 확인
- [x] 공지 수정 → 채널 원본 메시지 업데이트 확인
- [x] 공지 삭제 → 채널 메시지 삭제 및 `deletedAt` 설정 확인
- [x] 목록 11건 이상 시 페이지네이션 이전/다음 버튼 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->