### PR TITLE
infra(ecs): MCP 관련 환경변수 추가

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -60,6 +60,8 @@ resource "aws_ecs_task_definition" "app" {
         { name = "REDIS_PORT", value = tostring(aws_elasticache_cluster.main.cache_nodes[0].port) },
         { name = "GOOGLE_WEBHOOK_URL", value = "https://${var.app_domain}" },
         { name = "ADMIN_SLACK_ID", value = var.admin_slack_id },
+        { name = "MCP_GOOGLE_REDIRECT_URI", value = "https://${var.app_domain}/mcp/auth/callback" },
+        { name = "MCP_BASE_URL", value = "https://${var.app_domain}" },
       ]
 
       logConfiguration = {


### PR DESCRIPTION
## 개요

MCP 서버 기능 추가로 새로 생긴 환경변수 2개를 ECS Fargate 태스크 정의에 반영합니다.

## 주요 변경 사항

### terraform/ecs.tf
- `MCP_GOOGLE_REDIRECT_URI` — MCP OAuth 콜백 URL (`https://{app_domain}/mcp/auth/callback`)
- `MCP_BASE_URL` — MCP 서버 기본 URL (`https://{app_domain}`)

두 변수 모두 기존 `app_domain` 변수로 조합되므로 `variables.tf` 변경 없이 적용됩니다.

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] `terraform plan`으로 변경 사항 확인 후 적용

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->