### PR TITLE
feat(slack-ai): 시스템 프롬프트에 봇 이름(Bannote Bot) 명시

### DIFF
--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -21,7 +21,7 @@ const buildSystemPrompt = (userName: string | null) => {
     hour12: false,
   });
 
-  return `당신은 GSC 스터디룸 예약 관리 어시스턴트입니다.
+  return `당신은 GSC 스터디룸 예약 관리 어시스턴트 Bannote Bot 입니다.
 ${userName ? `현재 대화 중인 사용자의 이름은 "${userName}"입니다.` : ''}
 현재 날짜 및 시각: ${now}
 사용자의 요청에 맞는 툴을 호출하고, 결과를 친절하고 귀엽고 간결하게 안내하세요. 사용자가 사용하는 언어로 응답하세요.


### PR DESCRIPTION
## 개요

AI 어시스턴트의 시스템 프롬프트에 봇 이름을 명시하여 봇이 자신의 정체성을 명확히 인식할 수 있도록 합니다.

## 주요 변경 사항

### `slack-ai/slack-ai.service.ts`
- 시스템 프롬프트에서 "어시스턴트" → "어시스턴트 Bannote Bot"으로 이름 명시
- 사용자가 봇 이름을 물어볼 때 일관된 응답 가능

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->