### PR TITLE
fix(mcp): 세션 만료 시 404 반환으로 클라이언트 자동 재연결 유도

### DIFF
--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -108,7 +108,6 @@ export class McpController {
       return;
     }
 
-    this.logger.log(`[MCP] ${req.method} slackId=${slackId}`);
     await this.mcpService.handleRequest(req, res, req.body as unknown, slackId);
   }
 }

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { randomUUID } from 'node:crypto';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -178,6 +178,8 @@ export class McpService {
     return { accessToken, refreshToken };
   }
 
+  private readonly logger = new Logger(McpService.name);
+
   // ─── MCP 요청 처리 ───────────────────────────────────────────────────────
 
   private buildServer(slackId: string): Server {
@@ -195,14 +197,33 @@ export class McpService {
     }));
 
     server.setRequestHandler(CallToolRequestSchema, async (req) => {
-      const result = await this.toolsService.execute(
-        req.params.name,
-        req.params.arguments ?? {},
-        slackId,
-      );
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-      };
+      const tool = req.params.name;
+      try {
+        const result = await this.toolsService.execute(
+          tool,
+          req.params.arguments ?? {},
+          slackId,
+        );
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+        };
+      } catch (e) {
+        this.logger.error(
+          `Tool execution failed — tool=${tool} slackId=${slackId} error=${e instanceof Error ? e.message : String(e)}`,
+        );
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: e instanceof Error ? e.message : String(e),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
     });
 
     return server;
@@ -219,6 +240,14 @@ export class McpService {
     if (sessionId && this.sessions.has(sessionId)) {
       const session = this.sessions.get(sessionId)!;
       await session.transport.handleRequest(req, res, body);
+      return;
+    }
+
+    // 세션 ID가 있지만 서버에 없는 경우 (재시작 등) → 404로 클라이언트 재연결 유도
+    if (sessionId) {
+      this.logger.warn(`Session not found (expired or server restarted) — sessionId=${sessionId} slackId=${slackId}`);
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Session not found. Please reinitialize.' }));
       return;
     }
 
@@ -243,7 +272,11 @@ export class McpService {
     const server = this.buildServer(slackId);
 
     this.sessions.set(newSessionId, { server, transport });
-    transport.onclose = () => this.sessions.delete(newSessionId);
+    this.logger.log(`Session created — sessionId=${newSessionId} slackId=${slackId}`);
+    transport.onclose = () => {
+      this.sessions.delete(newSessionId);
+      this.logger.log(`Session closed — sessionId=${newSessionId} slackId=${slackId}`);
+    };
 
     await server.connect(transport);
     await transport.handleRequest(req, res, body);


### PR DESCRIPTION
## 개요

서버 재시작 후 MCP 클라이언트(Claude Desktop 등)가 자동으로 재연결되지 않는 문제를 수정합니다.

## 문제

서버 재시작 시 인메모리 세션이 초기화되어, 기존 세션 ID로 요청이 오면 400을 반환했습니다. 클라이언트는 400을 영구 에러로 인식하고 재연결을 포기했습니다.

## 변경 사항

### `src/mcp/mcp.service.ts`
- 알 수 없는 세션 ID 요청 시 400 → **404** 반환 (MCP 스펙 준수)
  - 클라이언트는 404를 받으면 새 `initialize`를 전송해 자동 재연결
- 툴 실행 오류 시 `ERROR` 로그 추가
- 세션 생성/종료 시 `LOG` 로그 추가

### `src/mcp/mcp.controller.ts`
- 매 요청마다 찍히던 불필요한 로그 제거

## 테스트

- [x] 로컬에서 서버 재시작 후 Claude Desktop 자동 재연결 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->