### PR TITLE
feat(tools): check_room_availability roomName → roomId 변경

### DIFF
--- a/src/resource/service/study-room.service.ts
+++ b/src/resource/service/study-room.service.ts
@@ -171,16 +171,17 @@ export class StudyRoomService {
   async getRoomAvailability(
     startTime: Date,
     endTime: Date,
-    roomName?: string,
+    roomId?: number,
   ): Promise<RoomAvailability[]> {
     const allRooms = await this.resourceService.findAllByType(
       ResourceType.STUDY_ROOM,
     );
-    const rooms = roomName
-      ? allRooms.filter(
-          (r) => r.name === roomName || (r.aliases ?? []).includes(roomName),
-        )
-      : allRooms;
+    let rooms = allRooms;
+    if (roomId !== undefined) {
+      rooms = allRooms.filter((r) => r.id === roomId);
+      if (rooms.length === 0)
+        throw new BusinessError(ResourceErrorCode.STUDY_ROOM_NOT_FOUND);
+    }
 
     return Promise.all(
       rooms.map(async (room) => {

--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -45,24 +45,24 @@ export class BookingTool {
     {
       name: 'check_room_availability',
       description:
-        '지정한 시간 범위 내 스터디룸별 예약 현황을 조회합니다. 빈 방과 예약된 방, 예약 시간대를 반환합니다. roomName을 사용할 경우 반드시 이 툴보다 먼저 get_study_rooms를 호출해 정확한 이름을 확인하세요.',
+        '지정한 시간 범위 내 스터디룸별 예약 현황을 조회합니다. 빈 방과 예약된 방, 예약 시간대를 반환합니다. roomId를 사용할 경우 반드시 이 툴보다 먼저 get_study_rooms를 호출해 정확한 ID를 확인하세요.',
       input_schema: {
         type: 'object' as const,
         properties: {
           startDatetime: {
             type: 'string',
             description:
-              '조회 시작 일시 (ISO 8601, 예: 2025-05-10T09:00:00+09:00)',
+              '조회 시작 일시 (ISO 8601, 예: 2025-05-10T00:00:00+09:00)',
           },
           endDatetime: {
             type: 'string',
             description:
-              '조회 종료 일시 (ISO 8601, 예: 2025-05-10T22:00:00+09:00)',
+              '조회 종료 일시 (ISO 8601, 예: 2025-05-10T23:59:00+09:00)',
           },
-          roomName: {
-            type: 'string',
+          roomId: {
+            type: 'number',
             description:
-              '특정 방만 조회할 경우 방 이름 또는 alias. 반드시 get_study_rooms로 정확한 이름을 확인 후 입력. 생략 시 전체 방 조회.',
+              '특정 방만 조회할 경우 get_study_rooms에서 반환된 방 ID. 생략 시 전체 방 조회.',
           },
         },
         required: ['startDatetime', 'endDatetime'],
@@ -231,15 +231,15 @@ export class BookingTool {
     }
 
     if (name === 'check_room_availability') {
-      const { startDatetime, endDatetime, roomName } = input as {
+      const { startDatetime, endDatetime, roomId } = input as {
         startDatetime: string;
         endDatetime: string;
-        roomName?: string;
+        roomId?: number;
       };
       const availability = await this.studyRoomService.getRoomAvailability(
         new Date(startDatetime),
         new Date(endDatetime),
-        roomName,
+        roomId,
       );
       return availability.map((r) => ({
         roomName: r.roomName,


### PR DESCRIPTION
## 개요

`check_room_availability` 툴의 특정 방 조회 파라미터를 `roomName(string)` → `roomId(number)`로 변경합니다. 이름/alias 문자열 매칭 대신 ID 기반으로 조회해 더 정확한 결과를 보장합니다.

## 주요 변경 사항

### `src/tools/booking.tool.ts`
- `roomName?: string` → `roomId?: number` 파라미터 변경
- 툴 description 업데이트: roomId 사용 전 `get_study_rooms` 호출 안내
- 조회 시간 예시를 `T09:00:00` / `T22:00:00` → `T00:00:00` / `T23:59:00` (24시간 기준)으로 수정

### `src/resource/service/study-room.service.ts`
- `getRoomAvailability` 시그니처: `roomName?: string` → `roomId?: number`
- 이름/alias 기반 필터 → ID 기반 필터로 변경
- roomId를 전달했으나 해당 방이 없을 경우 `STUDY_ROOM_NOT_FOUND` 에러 반환

## 관련 이슈

없음

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] 로컬에서 mcp 연결 후 동작 확인