### PR TITLE
fix(tools): datetime 파라미터에 +09:00 오프셋 필수 명시

### DIFF
--- a/src/tools/booking.tool.ts
+++ b/src/tools/booking.tool.ts
@@ -52,12 +52,12 @@ export class BookingTool {
           startDatetime: {
             type: 'string',
             description:
-              '조회 시작 일시 (ISO 8601, 예: 2025-05-10T00:00:00+09:00)',
+              '조회 시작 일시 (ISO 8601, 반드시 +09:00 오프셋 포함, 예: 2025-05-10T00:00:00+09:00)',
           },
           endDatetime: {
             type: 'string',
             description:
-              '조회 종료 일시 (ISO 8601, 예: 2025-05-10T23:59:00+09:00)',
+              '조회 종료 일시 (ISO 8601, 반드시 +09:00 오프셋 포함, 예: 2025-05-10T23:59:00+09:00)',
           },
           roomId: {
             type: 'number',
@@ -86,12 +86,12 @@ export class BookingTool {
           startDatetime: {
             type: 'string',
             description:
-              '예약 시작 일시 (ISO 8601, 반드시 15분 단위, 예: 2025-05-10T14:00:00+09:00, 2025-05-10T14:15:00+09:00)',
+              '예약 시작 일시 (ISO 8601, 반드시 15분 단위 & +09:00 오프셋 포함, 예: 2025-05-10T14:00:00+09:00, 2025-05-10T14:15:00+09:00)',
           },
           endDatetime: {
             type: 'string',
             description:
-              '예약 종료 일시 (ISO 8601, 반드시 15분 단위, 예: 2025-05-10T16:00:00+09:00, 2025-05-10T15:45:00+09:00)',
+              '예약 종료 일시 (ISO 8601, 반드시 15분 단위 & +09:00 오프셋 포함, 예: 2025-05-10T16:00:00+09:00, 2025-05-10T15:45:00+09:00)',
           },
           attendeeSlackIds: {
             type: 'array',
@@ -149,11 +149,11 @@ export class BookingTool {
           },
           startDatetime: {
             type: 'string',
-            description: '수정할 시작 일시 (ISO 8601, 15분 단위)',
+            description: '수정할 시작 일시 (ISO 8601, 반드시 15분 단위 & +09:00 오프셋 포함, 예: 2025-05-10T14:00:00+09:00, 2025-05-10T14:15:00+09:00)',
           },
           endDatetime: {
             type: 'string',
-            description: '수정할 종료 일시 (ISO 8601, 15분 단위)',
+            description: '수정할 종료 일시 (ISO 8601, 반드시 15분 단위 & +09:00 오프셋 포함, 예: 2025-05-10T16:00:00+09:00, 2025-05-10T15:45:00+09:00)',
           },
           attendeeSlackIds: {
             type: 'array',


### PR DESCRIPTION
## 개요

예약/수정/조회 툴의 datetime 파라미터 description에 `+09:00` 오프셋를 반드시 포함하도록 명시합니다. Claude가 오프셋 없이 datetime을 전달하면 서버가 UTC로 해석해 실제 예약 시간이 9시간 밀리는 문제를 방지합니다.

## 주요 변경 사항

### `src/tools/booking.tool.ts`
- `check_room_availability` — `startDatetime`, `endDatetime` description에 `반드시 +09:00 오프셋 포함` 조건 추가
- `book_room` — `startDatetime`, `endDatetime` description에 `반드시 +09:00 오프셋 포함` 조건 추가
- `modify_booking` — `startDatetime`, `endDatetime` description에 `반드시 +09:00 오프셋 포함` 조건 및 예시 추가

## 관련 이슈

없음

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인