### PR TITLE
feat(metrics): Prometheus 메트릭 계측 및 모니터링 스택 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,6 @@ ANTHROPIC_API_KEY=
 ADMIN_SLACK_ID=
 
 # 모니터링 스택 (docker-compose.monitoring.yml)
-# 로컬: host.docker.internal:3000 / dev 서버: app:3000 / prod EC2: <ALB>:3000
+# 로컬/dev 서버: host.docker.internal:3000 / prod EC2: <ALB DNS>:3000
 APP_HOST=host.docker.internal:3000
 GRAFANA_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,8 @@ ANTHROPIC_API_KEY=
 
 # 관리자 슬랙 아이디
 ADMIN_SLACK_ID=
+
+# 모니터링 스택 (docker-compose.monitoring.yml)
+# 로컬: host.docker.internal:3000 / dev 서버: app:3000 / prod EC2: <ALB>:3000
+APP_HOST=host.docker.internal:3000
+GRAFANA_PASSWORD=

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,6 +27,10 @@ jobs:
         working-directory: ${{ vars.DEPLOY_DIR }}
         run: make dev
 
+      - name: Restart monitoring stack
+        working-directory: ${{ vars.DEPLOY_DIR }}
+        run: make monitoring
+
       - name: Verify app is running
         run: |
           sleep 10

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: db local local-d dev prod down-local down-dev down-prod down-db logs logs-app backup restore clean
+.PHONY: db local local-d dev prod down-local down-dev down-prod down-db monitoring down-monitoring logs logs-app backup restore clean
 
 # DB + Redis 실행 (로컬 개발용)
 db:
@@ -35,6 +35,16 @@ down-prod:
 # DB + Redis 종료 (로컬 개발용)
 down-db:
 	docker compose -f docker-compose.yml -f docker-compose.local.yml down
+
+# 모니터링 스택 실행 (Alloy, Prometheus, Grafana)
+# 로컬: APP_HOST 기본값 host.docker.internal:3000
+# dev 서버: APP_HOST=app:3000 make monitoring
+monitoring:
+	docker compose -f docker-compose.monitoring.yml up -d
+
+# 모니터링 스택 종료
+down-monitoring:
+	docker compose -f docker-compose.monitoring.yml down
 
 # 로그 확인
 logs:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,6 +1,6 @@
 services:
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.11.3
     container_name: gsc-prometheus
     restart: unless-stopped
     environment:
@@ -12,12 +12,14 @@ services:
       - |
         sed "s|PROMETHEUS_TARGET|${APP_HOST}|g" /etc/prometheus/prometheus.yml.tmpl > /tmp/prometheus.yml &&
         exec /bin/prometheus --config.file=/tmp/prometheus.yml --storage.tsdb.retention.time=30d
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml.tmpl:ro
       - prometheus_data:/prometheus
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:13.0.1
     container_name: gsc-grafana
     restart: unless-stopped
     ports:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,35 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: gsc-prometheus
+    restart: unless-stopped
+    environment:
+      APP_HOST: ${APP_HOST:-host.docker.internal:3000}
+    # sed로 PROMETHEUS_TARGET을 환경변수 APP_HOST로 치환 후 실행
+    entrypoint:
+      - sh
+      - -c
+      - |
+        sed "s|PROMETHEUS_TARGET|${APP_HOST}|g" /etc/prometheus/prometheus.yml.tmpl > /tmp/prometheus.yml &&
+        exec /bin/prometheus --config.file=/tmp/prometheus.yml --storage.tsdb.retention.time=30d
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml.tmpl:ro
+      - prometheus_data:/prometheus
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: gsc-grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD}
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    folder: GSC Slack App
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+# PROMETHEUS_TARGET은 docker-compose.monitoring.yml의 APP_HOST 환경변수로 치환됨
+# 로컬: host.docker.internal:3000 / dev 서버: app:3000 / prod: <ALB DNS>:3000
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'gsc-slack-app'
+    static_configs:
+      - targets: ['PROMETHEUS_TARGET']
+    metrics_path: /metrics

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "googleapis": "^170.1.0",
         "nestjs-slack-bolt": "^1.5.0",
         "pg": "^8.17.2",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
         "rrule": "^2.8.1",
         "rxjs": "^7.8.1",
@@ -2597,6 +2598,15 @@
         "npm": ">=5.10.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -4312,6 +4322,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -9190,6 +9206,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10118,6 +10147,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "googleapis": "^170.1.0",
     "nestjs-slack-bolt": "^1.5.0",
     "pg": "^8.17.2",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rrule": "^2.8.1",
     "rxjs": "^7.8.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module, OnModuleInit } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { SlackModule } from 'nestjs-slack-bolt';
@@ -16,11 +17,15 @@ import { ScheduleModule } from './schedule/schedule.module';
 import { ChannelModule } from './channel/channel.module';
 import { ResourceModule } from './resource/resource.module';
 import { httpReceiver } from './slack-receiver';
-import { slackErrorMiddleware } from './common/slack-error.middleware';
+import { createSlackErrorMiddleware } from './common/slack-error.middleware';
+import { createSlackMetricsMiddleware } from './common/slack-metrics.middleware';
 import { CleaningModule } from './cleaning/cleaning.module';
 import { SlackAiModule } from './slack-ai/slack-ai.module';
 import { McpModule } from './mcp/mcp.module';
 import { AnnouncementModule } from './announcement/announcement.module';
+import { MetricsModule } from './common/metrics/metrics.module';
+import { MetricsInterceptor } from './common/interceptors/metrics.interceptor';
+import { AppMetrics } from './common/metrics/app.metrics';
 
 @Module({
   imports: [
@@ -77,14 +82,25 @@ import { AnnouncementModule } from './announcement/announcement.module';
     SlackAiModule,
     McpModule,
     AnnouncementModule,
+    MetricsModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: MetricsInterceptor,
+    },
+  ],
 })
 export class AppModule implements OnModuleInit {
-  constructor(private readonly slackService: SlackService) {}
+  constructor(
+    private readonly slackService: SlackService,
+    private readonly appMetrics: AppMetrics,
+  ) {}
 
   onModuleInit() {
-    this.slackService.app.use(slackErrorMiddleware);
+    this.slackService.app.use(createSlackMetricsMiddleware(this.appMetrics));
+    this.slackService.app.use(createSlackErrorMiddleware(this.appMetrics));
   }
 }

--- a/src/common/interceptors/metrics.interceptor.ts
+++ b/src/common/interceptors/metrics.interceptor.ts
@@ -1,0 +1,36 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import type { Request, Response } from 'express';
+import { AppMetrics } from '../metrics/app.metrics';
+
+@Injectable()
+export class MetricsInterceptor implements NestInterceptor {
+  constructor(private readonly appMetrics: AppMetrics) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') return next.handle();
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const res = context.switchToHttp().getResponse<Response>();
+    const method = req.method;
+    const path = req.route?.path ?? req.path;
+    const end = this.appMetrics.httpRequestDurationSeconds.startTimer({
+      method,
+      path,
+    });
+
+    return next.handle().pipe(
+      tap(() => {
+        const status = String(res.statusCode);
+        end({ status });
+        this.appMetrics.httpRequestsTotal.inc({ method, path, status });
+      }),
+    );
+  }
+}

--- a/src/common/metrics/app.metrics.ts
+++ b/src/common/metrics/app.metrics.ts
@@ -1,0 +1,107 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import {
+  Registry,
+  Counter,
+  Gauge,
+  Histogram,
+  collectDefaultMetrics,
+} from 'prom-client';
+
+@Injectable()
+export class AppMetrics implements OnModuleInit {
+  readonly registry = new Registry();
+
+  readonly aiMessagesTotal = new Counter({
+    name: 'ai_messages_total',
+    help: 'AI 메시지 처리 횟수',
+    registers: [this.registry],
+  });
+
+  readonly aiMessageDurationSeconds = new Histogram({
+    name: 'ai_message_duration_seconds',
+    help: 'AI 메시지 처리 시간 (초)',
+    buckets: [3, 5, 8, 10, 15, 20, 30],
+    registers: [this.registry],
+  });
+
+  readonly aiMessageRounds = new Histogram({
+    name: 'ai_message_rounds',
+    help: 'AI 메시지당 tool_use 라운드 수',
+    buckets: [1, 2, 3, 4, 5, 7, 10],
+    registers: [this.registry],
+  });
+
+  readonly aiProcessingCurrent = new Gauge({
+    name: 'ai_processing_current',
+    help: '현재 AI 메시지 처리 중인 수',
+    registers: [this.registry],
+  });
+
+  readonly slackActionsTotal = new Counter({
+    name: 'slack_actions_total',
+    help: 'Slack 액션/뷰 제출 횟수',
+    labelNames: ['action_id'] as const,
+    registers: [this.registry],
+  });
+
+  readonly toolExecutionsTotal = new Counter({
+    name: 'tool_executions_total',
+    help: '툴 실행 횟수',
+    labelNames: ['tool_name', 'success'] as const,
+    registers: [this.registry],
+  });
+
+  readonly businessErrorsTotal = new Counter({
+    name: 'business_errors_total',
+    help: '비즈니스 에러 발생 횟수',
+    labelNames: ['error_code'] as const,
+    registers: [this.registry],
+  });
+
+  readonly unexpectedErrorsTotal = new Counter({
+    name: 'unexpected_errors_total',
+    help: '예상치 못한 에러 발생 횟수',
+    registers: [this.registry],
+  });
+
+  readonly aiTokensTotal = new Counter({
+    name: 'ai_tokens_total',
+    help: 'Anthropic API 토큰 사용량',
+    labelNames: ['type'] as const,
+    registers: [this.registry],
+  });
+
+  readonly googleApiErrorsTotal = new Counter({
+    name: 'google_api_errors_total',
+    help: 'Google Calendar API 에러 횟수',
+    labelNames: ['operation'] as const,
+    registers: [this.registry],
+  });
+
+  readonly cronJobDurationSeconds = new Histogram({
+    name: 'cron_job_duration_seconds',
+    help: 'Cron 작업 실행 시간 (초)',
+    labelNames: ['job_name'] as const,
+    buckets: [0.1, 0.5, 1, 5, 10, 30, 60],
+    registers: [this.registry],
+  });
+
+  readonly httpRequestsTotal = new Counter({
+    name: 'http_requests_total',
+    help: 'HTTP 요청 횟수',
+    labelNames: ['method', 'path', 'status'] as const,
+    registers: [this.registry],
+  });
+
+  readonly httpRequestDurationSeconds = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP 요청 처리 시간 (초)',
+    labelNames: ['method', 'path', 'status'] as const,
+    buckets: [0.01, 0.05, 0.1, 0.5, 1, 5],
+    registers: [this.registry],
+  });
+
+  onModuleInit() {
+    collectDefaultMetrics({ register: this.registry });
+  }
+}

--- a/src/common/metrics/metrics.module.ts
+++ b/src/common/metrics/metrics.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { AppMetrics } from './app.metrics';
+
+@Global()
+@Module({
+  providers: [AppMetrics],
+  exports: [AppMetrics],
+})
+export class MetricsModule {}

--- a/src/common/slack-error.middleware.ts
+++ b/src/common/slack-error.middleware.ts
@@ -2,81 +2,86 @@ import type { AnyMiddlewareArgs } from '@slack/bolt';
 import { Logger } from '@nestjs/common';
 import { BusinessError } from './errors';
 import { ErrorView } from './error.view';
+import type { AppMetrics } from './metrics/app.metrics';
 
 const logger = new Logger('SlackErrorMiddleware');
 
-export const slackErrorMiddleware = async (
-  // next is present at runtime but not in the AnyMiddlewareArgs union type
+export const createSlackErrorMiddleware =
+  (appMetrics: AppMetrics) =>
+  async (
+    // next is present at runtime but not in the AnyMiddlewareArgs union type
+    args: AnyMiddlewareArgs & { next: () => Promise<void> },
+  ) => {
+    const { next } = args;
+    try {
+      await next();
+    } catch (err) {
+      if (err instanceof BusinessError) {
+        appMetrics.businessErrorsTotal.inc({ error_code: err.code });
+        logger.warn(`[BusinessError] ${err.code}: ${err.message}`);
+      } else {
+        appMetrics.unexpectedErrorsTotal.inc();
+        logger.error('[SlackError]', err);
+      }
 
-  args: AnyMiddlewareArgs & { next: () => Promise<void> },
-) => {
-  const { next } = args;
-  try {
-    await next();
-  } catch (err) {
-    const body = (args as any).body;
+      const body = (args as any).body;
+      const client = (args as any).client;
 
-    const client = (args as any).client;
+      if (!client) return;
 
-    if (err instanceof BusinessError) {
-      logger.warn(`[BusinessError] ${err.code}: ${err.message}`);
-    } else {
-      logger.error('[SlackError]', err);
+      const triggerId: string | undefined = body?.trigger_id;
+      logger.debug(
+        `[ErrorModal] triggerId=${triggerId}, userId=${body && 'user' in body ? body.user?.id : body?.user_id}`,
+      );
+      const userId: string | undefined =
+        body && 'user' in body && body.user
+          ? (body.user as { id?: string }).id
+          : body?.user_id;
+      const blocks = ErrorView.fromError(err);
+      // text는 알림 fallback용 — blocks와 함께 쓸 때 Slack이 text만 렌더링하지 않도록 분리
+      const text =
+        err instanceof Error ? `❌ ${err.message}` : '❌ 오류가 발생했습니다.';
+
+      const errorView = {
+        type: 'modal' as const,
+        title: { type: 'plain_text' as const, text: '오류' },
+        close: { type: 'plain_text' as const, text: '닫기' },
+        blocks,
+      };
+
+      const viewId: string | undefined = body?.view?.id;
+
+      // 모달이 열려 있으면 현재 뷰를 에러 모달로 교체 (ack 후 trigger_id 만료 케이스 포함)
+      if (viewId) {
+        const updated = await client.views
+          .update({ view_id: viewId, view: errorView })
+          .then(() => true)
+          .catch(() => false);
+        if (updated) return;
+      }
+
+      // viewId 없거나 update 실패 → trigger_id로 push/open 시도
+      if (triggerId) {
+        const isInsideModal = body?.view?.type === 'modal';
+        const openOrPush = isInsideModal
+          ? client.views.push
+          : client.views.open;
+        const opened = await openOrPush({
+          trigger_id: triggerId,
+          view: errorView,
+        })
+          .then(() => true)
+          .catch((e: unknown) => {
+            logger.warn('[ErrorModal] views failed, fallback to DM', e);
+            return false;
+          });
+        if (opened) return;
+      }
+
+      if (userId) {
+        await client.chat
+          .postMessage({ channel: userId, text, blocks })
+          .catch(() => {});
+      }
     }
-
-    if (!client) return;
-
-    const triggerId: string | undefined = body?.trigger_id;
-    logger.debug(
-      `[ErrorModal] triggerId=${triggerId}, userId=${body && 'user' in body ? body.user?.id : body?.user_id}`,
-    );
-    const userId: string | undefined =
-      body && 'user' in body && body.user
-        ? (body.user as { id?: string }).id
-        : body?.user_id;
-    const blocks = ErrorView.fromError(err);
-    // text는 알림 fallback용 — blocks와 함께 쓸 때 Slack이 text만 렌더링하지 않도록 분리
-    const text =
-      err instanceof Error ? `❌ ${err.message}` : '❌ 오류가 발생했습니다.';
-
-    const errorView = {
-      type: 'modal' as const,
-      title: { type: 'plain_text' as const, text: '오류' },
-      close: { type: 'plain_text' as const, text: '닫기' },
-      blocks,
-    };
-
-    const viewId: string | undefined = body?.view?.id;
-
-    // 모달이 열려 있으면 현재 뷰를 에러 모달로 교체 (ack 후 trigger_id 만료 케이스 포함)
-    if (viewId) {
-      const updated = await client.views
-        .update({ view_id: viewId, view: errorView })
-        .then(() => true)
-        .catch(() => false);
-      if (updated) return;
-    }
-
-    // viewId 없거나 update 실패 → trigger_id로 push/open 시도
-    if (triggerId) {
-      const isInsideModal = body?.view?.type === 'modal';
-      const openOrPush = isInsideModal ? client.views.push : client.views.open;
-      const opened = await openOrPush({
-        trigger_id: triggerId,
-        view: errorView,
-      })
-        .then(() => true)
-        .catch((e: unknown) => {
-          logger.warn('[ErrorModal] views failed, fallback to DM', e);
-          return false;
-        });
-      if (opened) return;
-    }
-
-    if (userId) {
-      await client.chat
-        .postMessage({ channel: userId, text, blocks })
-        .catch(() => {});
-    }
-  }
-};
+  };

--- a/src/common/slack-metrics.middleware.ts
+++ b/src/common/slack-metrics.middleware.ts
@@ -1,0 +1,20 @@
+import type { AnyMiddlewareArgs } from '@slack/bolt';
+import type { AppMetrics } from './metrics/app.metrics';
+
+export const createSlackMetricsMiddleware =
+  (appMetrics: AppMetrics) =>
+  async (args: AnyMiddlewareArgs & { next: () => Promise<void> }) => {
+    const { next } = args;
+    const b = (args as any).body;
+
+    if (b?.type === 'block_actions') {
+      for (const action of b.actions ?? []) {
+        if (action.action_id)
+          appMetrics.slackActionsTotal.inc({ action_id: action.action_id });
+      }
+    } else if (b?.type === 'view_submission' && b?.view?.callback_id) {
+      appMetrics.slackActionsTotal.inc({ action_id: b.view.callback_id });
+    }
+
+    await next();
+  };

--- a/src/google/calendar/events.service.ts
+++ b/src/google/calendar/events.service.ts
@@ -1,9 +1,25 @@
 import { Injectable } from '@nestjs/common';
 import { calendar_v3 } from 'googleapis';
 import { GoogleCalendarBaseService } from './base.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 
 @Injectable()
 export class GoogleEventsService extends GoogleCalendarBaseService {
+  constructor(private readonly appMetrics: AppMetrics) {
+    super();
+  }
+
+  private async callApi<T>(
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await fn();
+    } catch (error) {
+      this.appMetrics.googleApiErrorsTotal.inc({ operation });
+      throw error;
+    }
+  }
   // ========== 서비스 계정 기반 이벤트 ==========
 
   async createEventAsServiceAccount(
@@ -18,18 +34,20 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     },
   ): Promise<string> {
     const calendar = this.getCalendarClient();
-    const response = await calendar.events.insert({
-      calendarId,
-      sendUpdates: 'none',
-      requestBody: {
-        summary: params.summary,
-        description: params.description,
-        location: params.location,
-        start: { dateTime: params.startDateTime, timeZone: 'Asia/Seoul' },
-        end: { dateTime: params.endDateTime, timeZone: 'Asia/Seoul' },
-        extendedProperties: { private: { groupId: params.groupId } },
-      },
-    });
+    const response = await this.callApi('createEvent', () =>
+      calendar.events.insert({
+        calendarId,
+        sendUpdates: 'none',
+        requestBody: {
+          summary: params.summary,
+          description: params.description,
+          location: params.location,
+          start: { dateTime: params.startDateTime, timeZone: 'Asia/Seoul' },
+          end: { dateTime: params.endDateTime, timeZone: 'Asia/Seoul' },
+          extendedProperties: { private: { groupId: params.groupId } },
+        },
+      }),
+    );
 
     if (!response.data.id) throw new Error('Failed to create calendar event');
     return response.data.id;
@@ -64,7 +82,9 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     eventId: string,
   ): Promise<void> {
     const calendar = this.getCalendarClient();
-    await calendar.events.delete({ calendarId, eventId, sendUpdates: 'none' });
+    await this.callApi('deleteEvent', () =>
+      calendar.events.delete({ calendarId, eventId, sendUpdates: 'none' }),
+    );
   }
 
   async updateEventAsServiceAccount(
@@ -87,12 +107,14 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
       body.start = { dateTime: params.startDateTime, timeZone: 'Asia/Seoul' };
     if (params.endDateTime)
       body.end = { dateTime: params.endDateTime, timeZone: 'Asia/Seoul' };
-    await calendar.events.patch({
-      calendarId,
-      eventId,
-      sendUpdates: 'none',
-      requestBody: body,
-    });
+    await this.callApi('updateEvent', () =>
+      calendar.events.patch({
+        calendarId,
+        eventId,
+        sendUpdates: 'none',
+        requestBody: body,
+      }),
+    );
   }
 
   async patchEventPrivateExtendedProperty(

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { httpReceiver } from './slack-receiver';
 import { ScheduleCronService } from './schedule/service/schedule-cron.service';
+import { AppMetrics } from './common/metrics/app.metrics';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -9,6 +10,12 @@ async function bootstrap() {
   if (httpReceiver) {
     app.use(httpReceiver.router);
   }
+
+  const appMetrics = app.get(AppMetrics);
+  app.getHttpAdapter().get('/metrics', async (_req, res) => {
+    res.set('Content-Type', appMetrics.registry.contentType);
+    res.end(await appMetrics.registry.metrics());
+  });
 
   await app.listen(process.env.PORT ?? 3000);
 

--- a/src/schedule/service/schedule-cron.service.ts
+++ b/src/schedule/service/schedule-cron.service.ts
@@ -8,6 +8,7 @@ import { ScheduleWatchService } from './schedule-watch.service';
 import { ResourceMirrorService } from '../../resource/resource-mirror.service';
 import { ResourceService } from '../../resource/service/resource.service';
 import { GoogleEventsService } from '../../google/calendar/events.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 
 const CRON_SUPPRESS_KEY = 'suppress:cron:sync';
 
@@ -21,6 +22,7 @@ export class ScheduleCronService {
     private readonly resourceMirrorService: ResourceMirrorService,
     private readonly resourceService: ResourceService,
     private readonly googleEventsService: GoogleEventsService,
+    private readonly appMetrics: AppMetrics,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
   ) {}
 
@@ -35,14 +37,24 @@ export class ScheduleCronService {
   // Google Calendar Watch 최대 만료 7일, 주 1회 갱신으로 충분
   @Cron('0 0 * * 1')
   async renewWatches(): Promise<void> {
-    this.logger.log('Starting weekly watch renewal...');
-    await this.scheduleWatchService.renewAllActiveWatches();
-    this.logger.log('Weekly watch renewal completed');
+    const end = this.appMetrics.cronJobDurationSeconds.startTimer({
+      job_name: 'renewWatches',
+    });
+    try {
+      this.logger.log('Starting weekly watch renewal...');
+      await this.scheduleWatchService.renewAllActiveWatches();
+      this.logger.log('Weekly watch renewal completed');
+    } finally {
+      end();
+    }
   }
 
   // 매일 새벽 3시 — 오늘부터 30일 이내 이벤트 미러링 동기화
   @Cron('0 3 * * *', { timeZone: 'Asia/Seoul' })
   async syncMirrors(): Promise<void> {
+    const endCron = this.appMetrics.cronJobDurationSeconds.startTimer({
+      job_name: 'syncMirrors',
+    });
     try {
       this.logger.log('Starting daily mirror sync...');
       await this.cache.set(CRON_SUPPRESS_KEY, 1, 60 * 60 * 1000); // 1시간 failsafe TTL
@@ -144,6 +156,7 @@ export class ScheduleCronService {
         `Daily mirror sync completed: ${synced} synced, ${removed} removed, ${failed} failed`,
       );
     } finally {
+      endCron();
       // 동기화 직후 발생하는 지연 웹훅들을 무시하기 위해 suppress 상태를 3분간 유지
       await this.cache.set(CRON_SUPPRESS_KEY, 1, 3 * 60 * 1000);
     }

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -4,6 +4,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { ToolsService } from '../tools/tools.service';
 import { UserService } from '../user/service/user.service';
+import { AppMetrics } from '../common/metrics/app.metrics';
 
 const MODEL = 'claude-haiku-4-5-20251001';
 const HISTORY_TTL_MS = 60 * 60 * 1000; // 1시간
@@ -41,6 +42,7 @@ export class SlackAiService {
   constructor(
     private readonly toolsService: ToolsService,
     private readonly userService: UserService,
+    private readonly appMetrics: AppMetrics,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
   ) {}
 
@@ -102,6 +104,22 @@ export class SlackAiService {
     text: string,
     onProgress?: (msg: string) => Promise<void>,
   ): Promise<string> {
+    this.appMetrics.aiMessagesTotal.inc();
+    this.appMetrics.aiProcessingCurrent.inc();
+    const endTimer = this.appMetrics.aiMessageDurationSeconds.startTimer();
+    try {
+      return await this._handleMessage(slackId, text, onProgress);
+    } finally {
+      endTimer();
+      this.appMetrics.aiProcessingCurrent.dec();
+    }
+  }
+
+  private async _handleMessage(
+    slackId: string,
+    text: string,
+    onProgress?: (msg: string) => Promise<void>,
+  ): Promise<string> {
     const tools = this.toolsService
       .getDefinitions()
       .filter((t) => t.name !== 'get_current_time'); // 프롬프트에 시간이 있으므로 툴 제외
@@ -124,12 +142,22 @@ export class SlackAiService {
         messages,
       });
 
+      this.appMetrics.aiTokensTotal.inc(
+        { type: 'input' },
+        response.usage.input_tokens,
+      );
+      this.appMetrics.aiTokensTotal.inc(
+        { type: 'output' },
+        response.usage.output_tokens,
+      );
+
       if (response.stop_reason !== 'tool_use') {
         const replyText = this.extractText(response.content);
         await this.saveHistory(slackId, [
           ...messages,
           { role: 'assistant', content: replyText },
         ]);
+        this.appMetrics.aiMessageRounds.observe(round + 1);
         this.logger.log(
           `[handleMessage] 완료 (${round + 1}라운드) length=${replyText.length}`,
         );

--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -3,12 +3,17 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { BookingTool } from './booking.tool';
 import { TimeTool } from './time.tool';
 import { BusinessError } from '../common/errors/base.error';
+import { AppMetrics } from '../common/metrics/app.metrics';
 
 @Injectable()
 export class ToolsService {
   private readonly tools: (BookingTool | TimeTool)[];
 
-  constructor(bookingTool: BookingTool, timeTool: TimeTool) {
+  constructor(
+    bookingTool: BookingTool,
+    timeTool: TimeTool,
+    private readonly appMetrics: AppMetrics,
+  ) {
     this.tools = [bookingTool, timeTool];
   }
 
@@ -24,10 +29,24 @@ export class ToolsService {
     try {
       for (const tool of this.tools) {
         const result = await tool.execute(name, input, slackId);
-        if (result !== null) return result;
+        if (result !== null) {
+          this.appMetrics.toolExecutionsTotal.inc({
+            tool_name: name,
+            success: 'true',
+          });
+          return result;
+        }
       }
+      this.appMetrics.toolExecutionsTotal.inc({
+        tool_name: name,
+        success: 'false',
+      });
       return { error: `알 수 없는 툴: ${name}` };
     } catch (e) {
+      this.appMetrics.toolExecutionsTotal.inc({
+        tool_name: name,
+        success: 'false',
+      });
       if (e instanceof BusinessError)
         return { success: false, error: e.message };
       throw e;


### PR DESCRIPTION
## 개요

prom-client로 NestJS 앱에 커스텀 메트릭을 추가하고, Prometheus + Grafana 모니터링 스택을 구성했습니다.

## 주요 변경 사항

### AppMetrics 모듈 및 /metrics 엔드포인트
- 커스텀 `Registry` 기반 `AppMetrics` 글로벌 모듈 추가 (hot-reload 충돌 방지)
- `GET /metrics` 엔드포인트 노출 (Prometheus 스크랩용)
- Node.js 기본 메트릭 자동 수집 (`collectDefaultMetrics`)

### 서비스 계측
- **HTTP 인터셉터**: 요청 수 / 지연시간 (`method`, `path`, `status`)
- **Slack 미들웨어**: 액션 ID별 이벤트 카운트
- **AI 서비스**: 처리 횟수, 처리 시간, 라운드 수, 동시 처리 수, 토큰 사용량 (input/output)
- **Tools 서비스**: 툴별 실행 횟수 / 성공여부
- **Cron 서비스**: 작업별 실행 시간
- **Google Calendar**: API 호출 에러 카운트
- **에러 미들웨어**: 비즈니스 에러 / 예상치 못한 에러 카운트

### 모니터링 인프라 (docker-compose.monitoring.yml)
- Prometheus: `APP_HOST` 환경변수로 스크랩 타겟 동적 주입 (sed 치환)
- Grafana: Prometheus 데이터소스 자동 프로비저닝, 포트 3001
- `make monitoring` / `make down-monitoring` 타겟 추가
- 로컬/dev 서버/prod 공통 사용 가능

## 관련 이슈

없음

## 테스트

- [x] 로컬에서 `npm run start:dev` 실행 후 `GET /metrics` 응답 확인
- [x] `make monitoring` 후 Grafana(`localhost:3001`)에서 Prometheus 데이터소스 연결 확인
- [x] AI 대화, 예약 후 커스텀 메트릭 수집 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)