### PR TITLE
fix(logging): 앱 컨테이너 host.docker.internal 해석 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       NODE_ENV: ${NODE_ENV:-production}
       DB_HOST: db


### PR DESCRIPTION
## 개요

dev 서버에서 `LOKI_URL=http://host.docker.internal:3100` 설정 시 DNS 해석 실패 수정

## 주요 변경 사항

### docker-compose.yml
- 앱 컨테이너에 `extra_hosts: host.docker.internal:host-gateway` 추가
- Linux 환경에서 `host.docker.internal`이 호스트 머신 IP로 해석됨

## 관련 이슈

없음

## 테스트

- [x] dev 서버 배포 후 Loki connection error 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)