### PR TITLE
infra(monitoring): 프로덕션 모니터링 EC2 스택 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,9 +51,9 @@ ANTHROPIC_API_KEY=
 ADMIN_SLACK_ID=
 
 # 모니터링 스택 (docker-compose.monitoring.yml)
-# 로컬/dev 서버: host.docker.internal:3000 / prod EC2: <ALB DNS>:3000
-APP_HOST=host.docker.internal:3000
 GRAFANA_PASSWORD=
+# prod EC2에서는 prometheus.prod.yml 사용 (aws_sd_configs로 ECS 자동 탐색)
+# PROMETHEUS_CONFIG=./monitoring/prometheus/prometheus.prod.yml
 
 # Loki 로그 수집 (미설정 시 콘솔 출력만)
 # 로컬(npm): http://localhost:3100 / 로컬·dev(Docker): http://host.docker.internal:3100 / prod: http://<EC2 IP>:3100

--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -61,7 +61,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-id ${{ steps.instance.outputs.id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters "{\"commands\":[\"cat > /home/ec2-user/gsc-slack-app/.env <<'ENV'\nGRAFANA_PASSWORD=${{ secrets.GRAFANA_PASSWORD }}\nPROMETHEUS_CONFIG=./monitoring/prometheus/prometheus.prod.yml\nENV\necho 'done'\"]}" \
+            --parameters '{"commands":["GRAFANA_PASSWORD=$(aws secretsmanager get-secret-value --secret-id ${{ secrets.SECRETS_ARN }} --region ap-northeast-2 --query SecretString --output text | python3 -c \"import sys,json; print(json.load(sys.stdin)[\\\"grafana_password\\\"])\") && printf \"GRAFANA_PASSWORD=%s\\nPROMETHEUS_CONFIG=./monitoring/prometheus/prometheus.prod.yml\\n\" \"$GRAFANA_PASSWORD\" > /home/ec2-user/gsc-slack-app/.env && echo done"]}' \
             --query "Command.CommandId" \
             --output text)
           echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -1,0 +1,101 @@
+name: Deploy Monitoring Stack
+
+# workflow_call: docker-publish.yml의 운영 환경 배포(release) 완료 후 자동 호출
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      instance_id:
+        type: string
+        required: false
+
+jobs:
+  deploy:
+    name: Deploy to monitoring EC2
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Resolve instance ID
+        id: instance
+        run: |
+          INSTANCE_ID="${{ inputs.instance_id }}"
+          if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "null" ]; then
+            INSTANCE_ID=$(aws ec2 describe-instances \
+              --filters "Name=tag:Name,Values=bannote-prod-monitoring" "Name=instance-state-name,Values=running" \
+              --query "Reservations[0].Instances[0].InstanceId" \
+              --output text)
+          fi
+          echo "id=$INSTANCE_ID" >> $GITHUB_OUTPUT
+
+      - name: Pull latest code
+        id: pull
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-id ${{ steps.instance.outputs.id }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters '{"commands":["cd /home/ec2-user/gsc-slack-app && git pull origin main"]}' \
+            --query "Command.CommandId" \
+            --output text)
+          echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait and get pull result
+        run: |
+          aws ssm wait command-executed \
+            --command-id ${{ steps.pull.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }}
+          aws ssm get-command-invocation \
+            --command-id ${{ steps.pull.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }} \
+            --query "StandardOutputContent" \
+            --output text
+
+      - name: Write .env file
+        id: env
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-id ${{ steps.instance.outputs.id }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters "{\"commands\":[\"cat > /home/ec2-user/gsc-slack-app/.env <<'ENV'\nGRAFANA_PASSWORD=${{ secrets.GRAFANA_PASSWORD }}\nPROMETHEUS_CONFIG=./monitoring/prometheus/prometheus.prod.yml\nENV\necho 'done'\"]}" \
+            --query "Command.CommandId" \
+            --output text)
+          echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait and get env result
+        run: |
+          aws ssm wait command-executed \
+            --command-id ${{ steps.env.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }}
+          aws ssm get-command-invocation \
+            --command-id ${{ steps.env.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }} \
+            --query "StandardOutputContent" \
+            --output text
+
+      - name: Deploy monitoring stack
+        id: deploy
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-id ${{ steps.instance.outputs.id }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters '{"commands":["cd /home/ec2-user/gsc-slack-app && make monitoring"]}' \
+            --query "Command.CommandId" \
+            --output text)
+          echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait and get deploy result
+        run: |
+          aws ssm wait command-executed \
+            --command-id ${{ steps.deploy.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }}
+          aws ssm get-command-invocation \
+            --command-id ${{ steps.deploy.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }} \
+            --query "StandardOutputContent" \
+            --output text
+          echo "✅ Monitoring stack deployed"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - dev
   release:
-    types: [ published ]
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -54,6 +54,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    outputs:
+      monitoring_instance_id: ${{ steps.tf_output.outputs.instance_id }}
 
     steps:
       - name: Checkout repository
@@ -84,6 +86,11 @@ jobs:
             -var="ecs_task_role_arn=${{ secrets.ECS_TASK_ROLE_ARN }}" \
             -var="acm_certificate_arn=${{ secrets.ACM_CERTIFICATE_ARN }}"
 
+      - name: Get monitoring instance ID
+        id: tf_output
+        working-directory: terraform
+        run: echo "instance_id=$(terraform output -raw monitoring_instance_id)" >> $GITHUB_OUTPUT
+
       - name: Force new ECS deployment
         run: |
           TASK_DEF_ARN=$(aws ecs describe-task-definition \
@@ -108,3 +115,11 @@ jobs:
             --cluster bannote-prod-cluster \
             --services bannote-prod-service \
             --region ap-northeast-2
+
+  deploy-monitoring-stack:
+    name: Deploy monitoring stack
+    needs: deploy-prod
+    uses: ./.github/workflows/deploy-monitoring.yml
+    with:
+      instance_id: ${{ needs.deploy-prod.outputs.monitoring_instance_id }}
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,7 @@ down-prod:
 down-db:
 	docker compose -f docker-compose.yml -f docker-compose.local.yml down
 
-# 모니터링 스택 실행 (Alloy, Prometheus, Grafana)
-# 로컬: APP_HOST 기본값 host.docker.internal:3000
-# dev 서버: APP_HOST=app:3000 make monitoring
+# 모니터링 스택 실행 (Prometheus, Loki, Grafana)
 monitoring:
 	docker compose -f docker-compose.monitoring.yml up -d
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -3,19 +3,13 @@ services:
     image: prom/prometheus:v3.11.3
     container_name: gsc-prometheus
     restart: unless-stopped
-    environment:
-      APP_HOST: ${APP_HOST:-host.docker.internal:3000}
-    # sed로 PROMETHEUS_TARGET을 환경변수 APP_HOST로 치환 후 실행
-    entrypoint:
-      - sh
-      - -c
-      - |
-        sed "s|PROMETHEUS_TARGET|${APP_HOST}|g" /etc/prometheus/prometheus.yml.tmpl > /tmp/prometheus.yml &&
-        exec /bin/prometheus --config.file=/tmp/prometheus.yml --storage.tsdb.retention.time=30d
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=30d'
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml.tmpl:ro
+      - ${PROMETHEUS_CONFIG:-./monitoring/prometheus/prometheus.yml}:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
 
   loki:

--- a/monitoring/prometheus/prometheus.prod.yml
+++ b/monitoring/prometheus/prometheus.prod.yml
@@ -1,0 +1,19 @@
+# prod 전용 — aws_sd_configs로 ECS Fargate 태스크 자동 탐색
+# EC2 IAM 역할에 ecs:ListClusters, ecs:ListTasks, ecs:DescribeTasks, ecs:DescribeTaskDefinition 권한 필요
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'gsc-slack-app'
+    aws_sd_configs:
+      - region: ap-northeast-2
+        role: ecs
+    relabel_configs:
+      - source_labels: [__meta_ecs_task_definition_family]
+        action: keep
+        regex: bannote-prod-task
+      - source_labels: [__address__]
+        regex: '(.*)'
+        replacement: '$1:3000'
+        target_label: __address__
+    metrics_path: /metrics

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,10 +1,9 @@
-# PROMETHEUS_TARGET은 docker-compose.monitoring.yml의 APP_HOST 환경변수로 치환됨
-# 로컬: host.docker.internal:3000 / dev 서버: app:3000 / prod: <ALB DNS>:3000
+# 로컬/dev 서버 공용 — prod는 prometheus.prod.yml 사용
 global:
   scrape_interval: 15s
 
 scrape_configs:
   - job_name: 'gsc-slack-app'
     static_configs:
-      - targets: ['PROMETHEUS_TARGET']
+      - targets: ['host.docker.internal:3000']
     metrics_path: /metrics

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -56,3 +56,46 @@ resource "aws_lb_listener" "https" {
     target_group_arn = aws_lb_target_group.app.arn
   }
 }
+
+# Grafana 타겟 그룹 — EC2 인스턴스 타입
+resource "aws_lb_target_group" "grafana" {
+  name        = "${local.name_prefix}-grafana-tg"
+  port        = 3001
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "instance"
+
+  health_check {
+    path                = "/api/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-grafana-tg"
+  }
+}
+
+resource "aws_lb_target_group_attachment" "grafana" {
+  target_group_arn = aws_lb_target_group.grafana.arn
+  target_id        = aws_instance.monitoring.id
+  port             = 3001
+}
+
+# grafana.gsc-lab.io → EC2:3001
+resource "aws_lb_listener_rule" "grafana" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.grafana.arn
+  }
+
+  condition {
+    host_header {
+      values = [var.grafana_domain]
+    }
+  }
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -18,25 +18,33 @@ resource "aws_iam_role_policy_attachment" "monitoring_ssm" {
 }
 
 # Prometheus aws_sd_configs가 ECS 태스크를 탐색하기 위한 권한
+# + Grafana 비밀번호를 Secrets Manager에서 읽기 위한 권한
 resource "aws_iam_role_policy" "monitoring_prometheus_sd" {
   name = "${local.name_prefix}-prometheus-sd-policy"
   role = aws_iam_role.monitoring_ec2.id
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Action = [
-        "ecs:ListClusters",
-        "ecs:ListTasks",
-        "ecs:DescribeTasks",
-        "ecs:DescribeTaskDefinition",
-        "ec2:DescribeInstances",
-        "ec2:DescribeAvailabilityZones",
-        "ec2:DescribeNetworkInterfaces"
-      ]
-      Resource = "*"
-    }]
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecs:ListClusters",
+          "ecs:ListTasks",
+          "ecs:DescribeTasks",
+          "ecs:DescribeTaskDefinition",
+          "ec2:DescribeInstances",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeNetworkInterfaces"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = var.secrets_arn
+      }
+    ]
   })
 }
 

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -75,14 +75,6 @@ resource "aws_security_group" "monitoring" {
     security_groups = [aws_security_group.alb.id]
   }
 
-  ingress {
-    description     = "Loki from ECS"
-    from_port       = 3100
-    to_port         = 3100
-    protocol        = "tcp"
-    security_groups = [aws_security_group.ecs.id]
-  }
-
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -17,6 +17,29 @@ resource "aws_iam_role_policy_attachment" "monitoring_ssm" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+# Prometheus aws_sd_configs가 ECS 태스크를 탐색하기 위한 권한
+resource "aws_iam_role_policy" "monitoring_prometheus_sd" {
+  name = "${local.name_prefix}-prometheus-sd-policy"
+  role = aws_iam_role.monitoring_ec2.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ecs:ListClusters",
+        "ecs:ListTasks",
+        "ecs:DescribeTasks",
+        "ecs:DescribeTaskDefinition",
+        "ec2:DescribeInstances",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeNetworkInterfaces"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
 resource "aws_iam_instance_profile" "monitoring_ec2" {
   name = "${local.name_prefix}-monitoring-ec2-profile"
   role = aws_iam_role.monitoring_ec2.name

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -100,7 +100,7 @@ resource "aws_instance" "monitoring" {
     usermod -aG docker ec2-user
 
     # Docker Compose 설치
-    curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    curl -L "https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     chmod +x /usr/local/bin/docker-compose
 
     # 리포지토리 clone
@@ -110,5 +110,9 @@ resource "aws_instance" "monitoring" {
 
   tags = {
     Name = "${local.name_prefix}-monitoring"
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,114 @@
+# SSM 사용을 위한 EC2 IAM 역할
+resource "aws_iam_role" "monitoring_ec2" {
+  name = "${local.name_prefix}-monitoring-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "monitoring_ssm" {
+  role       = aws_iam_role.monitoring_ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "monitoring_ec2" {
+  name = "${local.name_prefix}-monitoring-ec2-profile"
+  role = aws_iam_role.monitoring_ec2.name
+}
+
+# EC2 보안 그룹 — SSH, Grafana(3001), Loki(3100) 허용
+resource "aws_security_group" "monitoring" {
+  name        = "${local.name_prefix}-monitoring-sg"
+  description = "Monitoring EC2 security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description     = "Grafana from ALB"
+    from_port       = 3001
+    to_port         = 3001
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description     = "Loki from ECS"
+    from_port       = 3100
+    to_port         = 3100
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-monitoring-sg"
+  }
+}
+
+# 최신 Amazon Linux 2023 AMI (SSM Agent 기본 포함)
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "monitoring" {
+  ami                         = data.aws_ami.amazon_linux.id
+  instance_type               = var.monitoring_instance_type
+  subnet_id                   = aws_subnet.public[0].id
+  vpc_security_group_ids      = [aws_security_group.monitoring.id]
+  iam_instance_profile        = aws_iam_instance_profile.monitoring_ec2.name
+  key_name                    = var.monitoring_key_name
+  associate_public_ip_address = true
+
+  user_data = <<-EOF
+    #!/bin/bash
+    dnf update -y
+    dnf install -y docker git
+
+    # Docker 설정
+    systemctl enable docker
+    systemctl start docker
+    usermod -aG docker ec2-user
+
+    # Docker Compose 설치
+    curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+
+    # 리포지토리 clone
+    git clone https://github.com/kyumin1227/gsc-slack-app.git /home/ec2-user/gsc-slack-app
+    chown -R ec2-user:ec2-user /home/ec2-user/gsc-slack-app
+  EOF
+
+  tags = {
+    Name = "${local.name_prefix}-monitoring"
+  }
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -62,6 +62,7 @@ resource "aws_ecs_task_definition" "app" {
         { name = "ADMIN_SLACK_ID", value = var.admin_slack_id },
         { name = "MCP_GOOGLE_REDIRECT_URI", value = "https://${var.app_domain}/mcp/auth/callback" },
         { name = "MCP_BASE_URL", value = "https://${var.app_domain}" },
+        { name = "LOKI_URL", value = "http://${aws_instance.monitoring.private_ip}:3100" },
       ]
 
       logConfiguration = {

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -104,7 +104,7 @@ resource "aws_security_group" "alb" {
   }
 }
 
-# ECS 보안 그룹 — ALB에서 컨테이너 포트만 허용
+# ECS 보안 그룹 — ALB에서 컨테이너 포트, 모니터링 EC2에서 /metrics 스크랩 허용
 resource "aws_security_group" "ecs" {
   name        = "${local.name_prefix}-ecs-sg"
   description = "ECS tasks security group"
@@ -115,6 +115,14 @@ resource "aws_security_group" "ecs" {
     to_port         = var.container_port
     protocol        = "tcp"
     security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description     = "Prometheus scrape from monitoring EC2"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.monitoring.id]
   }
 
   egress {

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -117,14 +117,6 @@ resource "aws_security_group" "ecs" {
     security_groups = [aws_security_group.alb.id]
   }
 
-  ingress {
-    description     = "Prometheus scrape from monitoring EC2"
-    from_port       = var.container_port
-    to_port         = var.container_port
-    protocol        = "tcp"
-    security_groups = [aws_security_group.monitoring.id]
-  }
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -171,4 +163,25 @@ resource "aws_security_group" "cache" {
   tags = {
     Name = "${local.name_prefix}-cache-sg"
   }
+}
+
+# 순환 참조 방지: monitoring ↔ ecs SG cross-reference는 별도 rule로 분리
+resource "aws_security_group_rule" "monitoring_loki_from_ecs" {
+  type                     = "ingress"
+  description              = "Loki from ECS"
+  from_port                = 3100
+  to_port                  = 3100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs.id
+  security_group_id        = aws_security_group.monitoring.id
+}
+
+resource "aws_security_group_rule" "ecs_prometheus_from_monitoring" {
+  type                     = "ingress"
+  description              = "Prometheus scrape from monitoring EC2"
+  from_port                = var.container_port
+  to_port                  = var.container_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+  security_group_id        = aws_security_group.ecs.id
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,3 +12,18 @@ output "ecs_service_name" {
   description = "ECS service name"
   value       = aws_ecs_service.app.name
 }
+
+output "monitoring_instance_id" {
+  description = "Monitoring EC2 instance ID (for MONITORING_INSTANCE_ID GitHub secret)"
+  value       = aws_instance.monitoring.id
+}
+
+output "monitoring_public_ip" {
+  description = "Monitoring EC2 public IP (for SSH)"
+  value       = aws_instance.monitoring.public_ip
+}
+
+output "monitoring_private_ip" {
+  description = "Monitoring EC2 private IP (used for LOKI_URL)"
+  value       = aws_instance.monitoring.private_ip
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -16,3 +16,8 @@ db_instance_class = "db.t4g.micro"
 # ElastiCache
 cache_node_type = "cache.t4g.micro"
 
+# Monitoring EC2
+grafana_domain           = "grafana.gsc-lab.io"
+monitoring_instance_type = "t3.micro"
+monitoring_key_name      = "monitoring-key"
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -95,3 +95,21 @@ variable "secrets_arn" {
   description = "Secrets Manager secret ARN containing app environment variables"
   type        = string
 }
+
+# Monitoring EC2
+variable "monitoring_instance_type" {
+  description = "EC2 instance type for monitoring stack"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "monitoring_key_name" {
+  description = "EC2 key pair name for monitoring instance"
+  type        = string
+  default     = "monitoring-key"
+}
+
+variable "grafana_domain" {
+  description = "Grafana subdomain (e.g. grafana.gsc-lab.io)"
+  type        = string
+}


### PR DESCRIPTION
## 개요

EC2 인스턴스에 Prometheus + Loki + Grafana 모니터링 스택을 구성하고, prod 배포 시 GitHub Actions에서 자동으로 배포되도록 파이프라인을 연결한다.

## 주요 변경 사항

### Terraform — EC2 인스턴스 및 네트워크
- `ec2.tf`: 모니터링 EC2 인스턴스, IAM 역할 (SSM + ECS/EC2 Describe + Secrets Manager 권한), 보안 그룹
  - `prevent_destroy` 적용 (Docker 볼륨 데이터 보호)
  - docker-compose `v2.36.0` 버전 고정
- `alb.tf`: Grafana 타겟 그룹 + ALB 리스너 룰 (`grafana.gsc-lab.io` → EC2:3001)
- `network.tf`: ECS 보안 그룹에 모니터링 EC2 → 컨테이너 포트 ingress 추가 (Prometheus 스크랩용)
- `ecs.tf`: `LOKI_URL` 환경변수 추가 (EC2 private IP)
- `variables.tf` / `outputs.tf` / `prod.tfvars`: 관련 변수·출력 추가

### Prometheus 환경별 config 분리
- `prometheus.prod.yml` 추가: `aws_sd_configs`로 ECS Fargate 태스크 자동 탐색 (`bannote-prod-task`)
- `prometheus.yml` 단순화: `host.docker.internal:3000` 고정 (로컬/dev 공용), sed 템플릿 제거
- `docker-compose.monitoring.yml`: `PROMETHEUS_CONFIG` 환경변수로 config 파일 선택

### GitHub Actions 배포 파이프라인
- `deploy-monitoring.yml` 추가: SSM으로 EC2에 모니터링 스택 배포
  - EC2가 직접 Secrets Manager에서 `grafana_password` 키를 읽어 `.env` 작성
  - `workflow_call` (terraform output으로 instance_id 자동 전달) / `workflow_dispatch` 지원
- `docker-publish.yml`: prod 배포 완료 후 `deploy-monitoring` 자동 호출

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 -->

## 테스트

- [ ] `terraform plan` 에러 없음 확인
- [ ] `terraform apply` 후 EC2 인스턴스 생성 및 SSM 연결 확인
- [ ] `make monitoring` 실행 후 `grafana.gsc-lab.io` 접근 확인
- [ ] Prometheus `/targets`에서 ECS Fargate 태스크 탐색 확인
- [ ] Loki 로그 수신 확인 (`{service="gsc-slack-app"}`)

## 수동 작업 필요

- [x] 기존 Secrets Manager 시크릿에 `grafana_password` 키 추가
- [x] Route53에서 `grafana.gsc-lab.io` CNAME → ALB DNS 등록