### PR TITLE
ci: deploy-monitoring OIDC 권한 추가 (hotfix)

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -13,6 +13,9 @@ jobs:
   deploy:
     name: Deploy to monitoring EC2
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
## 개요

`deploy-monitoring.yml` 워크플로우에서 AWS credentials 로드 실패 문제 수정.

## 주요 변경 사항

### deploy-monitoring.yml
- `id-token: write`, `contents: read` permissions 추가
- `workflow_call`로 호출되는 reusable workflow는 별도로 permissions 선언 필요

## 관련 이슈

#187 머지 후 CI 실패 확인

## 테스트

- [x] deploy-monitoring 워크플로우 AWS credentials 정상 로드 확인