### PR TITLE
fix(ci): SSM git 소유권 오류 수정 및 에러 출력 개선

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -42,7 +42,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-id ${{ steps.instance.outputs.id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["cd /home/ec2-user/gsc-slack-app && git pull origin main"]}' \
+            --parameters '{"commands":["git config --global --add safe.directory /home/ec2-user/gsc-slack-app && cd /home/ec2-user/gsc-slack-app && git pull origin main"]}' \
             --query "Command.CommandId" \
             --output text)
           echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
@@ -51,12 +51,12 @@ jobs:
         run: |
           aws ssm wait command-executed \
             --command-id ${{ steps.pull.outputs.command_id }} \
-            --instance-id ${{ steps.instance.outputs.id }}
-          aws ssm get-command-invocation \
+            --instance-id ${{ steps.instance.outputs.id }} || true
+          RESULT=$(aws ssm get-command-invocation \
             --command-id ${{ steps.pull.outputs.command_id }} \
-            --instance-id ${{ steps.instance.outputs.id }} \
-            --query "StandardOutputContent" \
-            --output text
+            --instance-id ${{ steps.instance.outputs.id }} --output json)
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent'] or r['StandardErrorContent'])"
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); exit(0 if r['Status']=='Success' else 1)"
 
       - name: Write .env file
         id: env
@@ -73,12 +73,12 @@ jobs:
         run: |
           aws ssm wait command-executed \
             --command-id ${{ steps.env.outputs.command_id }} \
-            --instance-id ${{ steps.instance.outputs.id }}
-          aws ssm get-command-invocation \
+            --instance-id ${{ steps.instance.outputs.id }} || true
+          RESULT=$(aws ssm get-command-invocation \
             --command-id ${{ steps.env.outputs.command_id }} \
-            --instance-id ${{ steps.instance.outputs.id }} \
-            --query "StandardOutputContent" \
-            --output text
+            --instance-id ${{ steps.instance.outputs.id }} --output json)
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent'] or r['StandardErrorContent'])"
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); exit(0 if r['Status']=='Success' else 1)"
 
       - name: Deploy monitoring stack
         id: deploy
@@ -95,10 +95,9 @@ jobs:
         run: |
           aws ssm wait command-executed \
             --command-id ${{ steps.deploy.outputs.command_id }} \
-            --instance-id ${{ steps.instance.outputs.id }}
-          aws ssm get-command-invocation \
+            --instance-id ${{ steps.instance.outputs.id }} || true
+          RESULT=$(aws ssm get-command-invocation \
             --command-id ${{ steps.deploy.outputs.command_id }} \
-            --instance-id ${{ steps.instance.outputs.id }} \
-            --query "StandardOutputContent" \
-            --output text
-          echo "✅ Monitoring stack deployed"
+            --instance-id ${{ steps.instance.outputs.id }} --output json)
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent'] or r['StandardErrorContent'])"
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); exit(0 if r['Status']=='Success' else 1)"


### PR DESCRIPTION
## 개요

`deploy-monitoring.yml` 워크플로우에서 SSM git pull 실패 문제 수정.

## 주요 변경 사항

### deploy-monitoring.yml
- `safe.directory` 설정 추가: `user_data`에서 root로 clone 후 `chown ec2-user`했으나 SSM도 root로 실행되어 git이 소유권 불일치로 거부하는 문제 해결
- `wait || true` + 상태 체크 패턴으로 변경: 커맨드 실패 시에도 stdout/stderr 출력 후 종료 코드로 실패 처리 (기존에는 wait 실패 시 에러 내용이 보이지 않았음)

## 관련 이슈

#187 머지 후 deploy-monitoring 워크플로우 실행 중 발견

## 테스트

- [x] deploy-monitoring 워크플로우 git pull 성공 확인
- [x] 커맨드 실패 시 에러 내용이 CI 로그에 출력되는지 확인