### PR TITLE
fix(ci): SSM 커맨드를 ec2-user 권한으로 실행하도록 변경

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -42,7 +42,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-id ${{ steps.instance.outputs.id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["git config --global --add safe.directory /home/ec2-user/gsc-slack-app && cd /home/ec2-user/gsc-slack-app && git pull origin main"]}' \
+            --parameters '{"commands":["sudo su - ec2-user -c \"cd /home/ec2-user/gsc-slack-app && git pull origin main\""]}' \
             --query "Command.CommandId" \
             --output text)
           echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
@@ -86,7 +86,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-id ${{ steps.instance.outputs.id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["cd /home/ec2-user/gsc-slack-app && make monitoring"]}' \
+            --parameters '{"commands":["sudo su - ec2-user -c \"cd /home/ec2-user/gsc-slack-app && make monitoring\""]}' \
             --query "Command.CommandId" \
             --output text)
           echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 개요

SSM으로 EC2에 커맨드 실행 시 root 권한으로 인한 git 실패 문제 수정.

## 주요 변경 사항

### deploy-monitoring.yml
- `git pull`, `make monitoring`을 `sudo su - ec2-user -c "..."` 로 실행
  - ec2-user 로그인 환경 전체 로드 (`$HOME`, PATH, docker 그룹 멤버십)
  - 소유권 불일치(`dubious ownership`) 및 `$HOME not set` 문제 근본 해결
- `.env` 쓰기는 root 유지 (Secrets Manager 조회 및 파일 쓰기 모두 root로 가능)

## 관련 이슈

PR #190 이후 추가 발견된 SSM 실행 환경 문제

## 테스트

- [x] deploy-monitoring 워크플로우 git pull 성공 확인
- [x] make monitoring (docker compose) 정상 실행 확인