### PR TITLE
fix(ci): Secrets Manager 키 이름 대소문자 수정

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -64,7 +64,7 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-id ${{ steps.instance.outputs.id }} \
             --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["GRAFANA_PASSWORD=$(aws secretsmanager get-secret-value --secret-id ${{ secrets.SECRETS_ARN }} --region ap-northeast-2 --query SecretString --output text | python3 -c \"import sys,json; print(json.load(sys.stdin)[\\\"grafana_password\\\"])\") && printf \"GRAFANA_PASSWORD=%s\\nPROMETHEUS_CONFIG=./monitoring/prometheus/prometheus.prod.yml\\n\" \"$GRAFANA_PASSWORD\" > /home/ec2-user/gsc-slack-app/.env && echo done"]}' \
+            --parameters '{"commands":["GRAFANA_PASSWORD=$(aws secretsmanager get-secret-value --secret-id ${{ secrets.SECRETS_ARN }} --region ap-northeast-2 --query SecretString --output text | python3 -c \"import sys,json; print(json.load(sys.stdin)[\\\"GRAFANA_PASSWORD\\\"])\") && printf \"GRAFANA_PASSWORD=%s\\nPROMETHEUS_CONFIG=./monitoring/prometheus/prometheus.prod.yml\\n\" \"$GRAFANA_PASSWORD\" > /home/ec2-user/gsc-slack-app/.env && echo done"]}' \
             --query "Command.CommandId" \
             --output text)
           echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- `deploy-monitoring.yml`의 Write .env 단계에서 Secrets Manager JSON 키를 `grafana_password` (소문자)로 참조하던 것을 `GRAFANA_PASSWORD` (대문자)로 수정
- EC2 SSM 배포 시 `KeyError: 'grafana_password'`로 실패하던 문제 해결

## Test plan

- [ ] `deploy-monitoring.yml` workflow 수동 실행 후 전 단계 성공 확인
- [ ] EC2 `/home/ec2-user/gsc-slack-app/.env`에 `GRAFANA_PASSWORD` 정상 기록 확인
- [ ] `make monitoring` 스택 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)