### PR TITLE
fix(monitoring): docker compose 플러그인 및 ECS IAM 권한 수정

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -55,7 +55,7 @@ jobs:
           RESULT=$(aws ssm get-command-invocation \
             --command-id ${{ steps.pull.outputs.command_id }} \
             --instance-id ${{ steps.instance.outputs.id }} --output json)
-          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent'] or r['StandardErrorContent'])"
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent']); print(r['StandardErrorContent'])"
           echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); exit(0 if r['Status']=='Success' else 1)"
 
       - name: Write .env file
@@ -77,7 +77,29 @@ jobs:
           RESULT=$(aws ssm get-command-invocation \
             --command-id ${{ steps.env.outputs.command_id }} \
             --instance-id ${{ steps.instance.outputs.id }} --output json)
-          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent'] or r['StandardErrorContent'])"
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent']); print(r['StandardErrorContent'])"
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); exit(0 if r['Status']=='Success' else 1)"
+
+      - name: Ensure docker compose plugin
+        id: setup
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-id ${{ steps.instance.outputs.id }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters '{"commands":["mkdir -p /usr/libexec/docker/cli-plugins && ln -sf /usr/local/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose && docker compose version"]}' \
+            --query "Command.CommandId" \
+            --output text)
+          echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait and get setup result
+        run: |
+          aws ssm wait command-executed \
+            --command-id ${{ steps.setup.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }} || true
+          RESULT=$(aws ssm get-command-invocation \
+            --command-id ${{ steps.setup.outputs.command_id }} \
+            --instance-id ${{ steps.instance.outputs.id }} --output json)
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent']); print(r['StandardErrorContent'])"
           echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); exit(0 if r['Status']=='Success' else 1)"
 
       - name: Deploy monitoring stack
@@ -99,5 +121,5 @@ jobs:
           RESULT=$(aws ssm get-command-invocation \
             --command-id ${{ steps.deploy.outputs.command_id }} \
             --instance-id ${{ steps.instance.outputs.id }} --output json)
-          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent'] or r['StandardErrorContent'])"
+          echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['StandardOutputContent']); print(r['StandardErrorContent'])"
           echo "$RESULT" | python3 -c "import sys,json; r=json.load(sys.stdin); exit(0 if r['Status']=='Success' else 1)"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -30,7 +30,10 @@ resource "aws_iam_role_policy" "monitoring_prometheus_sd" {
         Effect = "Allow"
         Action = [
           "ecs:ListClusters",
+          "ecs:ListServices",
           "ecs:ListTasks",
+          "ecs:DescribeClusters",
+          "ecs:DescribeServices",
           "ecs:DescribeTasks",
           "ecs:DescribeTaskDefinition",
           "ec2:DescribeInstances",
@@ -122,9 +125,11 @@ resource "aws_instance" "monitoring" {
     systemctl start docker
     usermod -aG docker ec2-user
 
-    # Docker Compose 설치
+    # Docker Compose 설치 (standalone + plugin 심링크)
     curl -L "https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     chmod +x /usr/local/bin/docker-compose
+    mkdir -p /usr/libexec/docker/cli-plugins
+    ln -sf /usr/local/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 
     # 리포지토리 clone
     git clone https://github.com/kyumin1227/gsc-slack-app.git /home/ec2-user/gsc-slack-app


### PR DESCRIPTION
## Summary

- EC2에 `docker compose` CLI 플러그인 심링크 미설정으로 배포 실패하던 문제 수정
- Prometheus `aws_sd_configs`가 ECS 서비스를 탐색하지 못하던 IAM 권한 부족 문제 수정

## Changes

- `deploy-monitoring.yml`: 배포 전 docker compose 플러그인 심링크 설정 단계 추가, SSM stdout/stderr 동시 출력
- `terraform/ec2.tf`: user_data에 docker compose 플러그인 심링크 추가, IAM 정책에 `ecs:ListServices`, `ecs:DescribeClusters`, `ecs:DescribeServices` 추가

## Test plan

- [ ] `deploy-monitoring.yml` workflow 실행 후 전 단계 성공 확인
- [ ] Prometheus targets에서 ECS 태스크 발견 확인 (`http://localhost:9090/targets`)
- [ ] Grafana에서 메트릭 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)