### PR TITLE
fix(monitoring): Prometheus 메트릭 수집 문제 수정

### DIFF
--- a/monitoring/prometheus/prometheus.prod.yml
+++ b/monitoring/prometheus/prometheus.prod.yml
@@ -9,10 +9,10 @@ scrape_configs:
       - region: ap-northeast-2
         role: ecs
     relabel_configs:
-      - source_labels: [__meta_ecs_task_definition_family]
+      - source_labels: [__meta_ecs_task_definition]
         action: keep
-        regex: bannote-prod-task
-      - source_labels: [__address__]
+        regex: '.*task-definition/bannote-prod-task:.*'
+      - source_labels: [__meta_ecs_ip_address]
         regex: '(.*)'
         replacement: '$1:3000'
         target_label: __address__

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -104,18 +104,11 @@ resource "aws_security_group" "alb" {
   }
 }
 
-# ECS 보안 그룹 — ALB에서 컨테이너 포트, 모니터링 EC2에서 /metrics 스크랩 허용
+# ECS 보안 그룹 — inline ingress 없이 별도 rule로 관리 (inline + rule 혼용 시 충돌)
 resource "aws_security_group" "ecs" {
   name        = "${local.name_prefix}-ecs-sg"
   description = "ECS tasks security group"
   vpc_id      = aws_vpc.main.id
-
-  ingress {
-    from_port       = var.container_port
-    to_port         = var.container_port
-    protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
-  }
 
   egress {
     from_port   = 0
@@ -127,6 +120,16 @@ resource "aws_security_group" "ecs" {
   tags = {
     Name = "${local.name_prefix}-ecs-sg"
   }
+}
+
+resource "aws_security_group_rule" "ecs_alb_ingress" {
+  type                     = "ingress"
+  description              = "App port from ALB"
+  from_port                = var.container_port
+  to_port                  = var.container_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.alb.id
+  security_group_id        = aws_security_group.ecs.id
 }
 
 # RDS 보안 그룹 — ECS에서 5432 포트만 허용


### PR DESCRIPTION
## 개요

Prometheus가 ECS 태스크를 발견해도 메트릭 수집이 안 되던 두 가지 문제를 수정합니다.

## 주요 변경 사항

### terraform/network.tf — ECS 보안 그룹 rule 분리

- `aws_security_group.ecs`의 inline ingress를 `aws_security_group_rule.ecs_alb_ingress`로 분리
- inline rule과 `aws_security_group_rule` 혼용 시 terraform apply 때 충돌로 monitoring → ECS 3000 포트 규칙이 삭제되는 버그 수정

### monitoring/prometheus/prometheus.prod.yml — relabel 수정

- `__meta_ecs_task_definition_family` → `__meta_ecs_task_definition` (실제 레이블에 family 필드 없음)
- `__address__` → `__meta_ecs_ip_address` 로 변경하여 포트 3000 교체 정상화

## 관련 이슈

없음

## 테스트

- [x] terraform plan에서 ECS SG 규칙 삭제 없이 정상 적용 확인
- [x] Prometheus targets에서 ECS 태스크 `health: up` 확인
- [x] Grafana에서 메트릭 수신 확인