### PR TITLE
infra(monitoring): 모니터링 EC2 인스턴스 타입 t3.small로 업그레이드

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -56,27 +56,11 @@ resource "aws_iam_instance_profile" "monitoring_ec2" {
   role = aws_iam_role.monitoring_ec2.name
 }
 
-# EC2 보안 그룹 — SSH, Grafana(3001), Loki(3100) 허용
+# EC2 보안 그룹 — inline ingress 없이 별도 rule로 관리 (inline + rule 혼용 시 충돌)
 resource "aws_security_group" "monitoring" {
   name        = "${local.name_prefix}-monitoring-sg"
   description = "Monitoring EC2 security group"
   vpc_id      = aws_vpc.main.id
-
-  ingress {
-    description = "SSH"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    description     = "Grafana from ALB"
-    from_port       = 3001
-    to_port         = 3001
-    protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
-  }
 
   egress {
     from_port   = 0

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -168,6 +168,27 @@ resource "aws_security_group" "cache" {
   }
 }
 
+# monitoring SG ingress rules
+resource "aws_security_group_rule" "monitoring_ssh_ingress" {
+  type              = "ingress"
+  description       = "SSH"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.monitoring.id
+}
+
+resource "aws_security_group_rule" "monitoring_grafana_ingress" {
+  type                     = "ingress"
+  description              = "Grafana from ALB"
+  from_port                = 3001
+  to_port                  = 3001
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.alb.id
+  security_group_id        = aws_security_group.monitoring.id
+}
+
 # 순환 참조 방지: monitoring ↔ ecs SG cross-reference는 별도 rule로 분리
 resource "aws_security_group_rule" "monitoring_loki_from_ecs" {
   type                     = "ingress"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -18,6 +18,6 @@ cache_node_type = "cache.t4g.micro"
 
 # Monitoring EC2
 grafana_domain           = "grafana.gsc-lab.io"
-monitoring_instance_type = "t3.micro"
+monitoring_instance_type = "t3.small"
 monitoring_key_name      = "monitoring-key"
 


### PR DESCRIPTION
## 개요

모니터링 EC2(t3.micro, 1GB)에서 Prometheus + Loki + Grafana 운영 시 가용 메모리 18MB로 OOM 발생. t3.small(2GB)로 업그레이드합니다.

## 주요 변경 사항

### terraform/prod.tfvars

- `monitoring_instance_type`: `t3.micro` → `t3.small`

## 관련 이슈

없음

## 테스트

- [ ] `terraform apply` 후 인스턴스 타입 변경 확인
- [ ] 컨테이너 정상 유지 확인