### PR TITLE
Feat/청소 배정 및 일정 관리 기능 구현

### DIFF
--- a/src/cleaning/controller/cleaning-schedule.controller.ts
+++ b/src/cleaning/controller/cleaning-schedule.controller.ts
@@ -1,0 +1,491 @@
+import { Controller } from '@nestjs/common';
+import { Action, View } from 'nestjs-slack-bolt';
+import type {
+  AllMiddlewareArgs,
+  SlackActionMiddlewareArgs,
+  SlackViewMiddlewareArgs,
+  BlockAction,
+} from '@slack/bolt';
+import { CleaningRuleService } from '../service/cleaning-rule.service';
+import { CleaningScheduleService } from '../service/cleaning-schedule.service';
+import { CleaningScheduleView } from '../view/cleaning-schedule.view';
+import { PermissionService } from '../../user/service/permission.service';
+import { formatClassLabel } from '../../common/class-label.util';
+import { StudentClassStatus } from '../../student-class/student-class.entity';
+import { UserRole } from '../../user/user.entity';
+import { BusinessError, CleaningErrorCode } from '../../common/errors';
+import { CleaningAssignmentStatus } from '../entity/cleaning-assignment.entity';
+import { CleaningScheduleStatus } from '../entity/cleaning-schedule.entity';
+
+@Controller()
+export class CleaningScheduleController {
+  constructor(
+    private readonly cleaningRuleService: CleaningRuleService,
+    private readonly cleaningScheduleService: CleaningScheduleService,
+    private readonly permissionService: PermissionService,
+  ) {}
+
+  // 규칙별 일정 관리 진입 목록을 연다.
+  @Action('cleaning:schedule:open-manage')
+  async openScheduleManage({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireAdminOrClassRep(
+      body.user.id,
+    );
+    const classId =
+      user.role === UserRole.CLASS_REP ? user.studentClassId : undefined;
+    const rules = await this.cleaningRuleService.findAllWithDetails(classId);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: CleaningScheduleView.scheduleManageListModal(rules),
+    });
+  }
+
+  @Action('cleaning:schedule:open-upcoming')
+  async openUpcomingSchedules(
+    args: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs,
+  ) {
+    return this.openScheduleDetail(args, 'upcoming');
+  }
+
+  @Action('cleaning:schedule:open-past')
+  async openPastSchedules(
+    args: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs,
+  ) {
+    return this.openScheduleDetail(args, 'past');
+  }
+
+  // 예정/지난 일정 상세 목록 렌더링을 공통 처리한다.
+  private async openScheduleDetail(
+    {
+      ack,
+      client,
+      body,
+    }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs,
+    filter: 'upcoming' | 'past',
+  ) {
+    await ack();
+
+    const user = await this.permissionService.requireAdminOrClassRep(
+      body.user.id,
+    );
+    const action = body.actions[0] as { value: string };
+    const ruleId = parseInt(action.value, 10);
+
+    const rule = await this.cleaningRuleService.findOneWithDetails(ruleId);
+    if (!rule) return;
+    if (
+      user.role === UserRole.CLASS_REP &&
+      rule.studentClassId !== user.studentClassId
+    )
+      // 반대표는 자기 반 규칙의 일정만 조회/관리할 수 있다.
+      return;
+
+    const schedules =
+      await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+    const label = formatClassLabel({
+      admissionYear: rule.studentClass.admissionYear,
+      section: rule.studentClass.section,
+      graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+    });
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningScheduleView.scheduleDetailModal(
+        schedules,
+        label,
+        ruleId,
+        filter,
+      ),
+    });
+  }
+
+  @Action('cleaning:schedule:open-edit')
+  async openScheduleEdit({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    await this.permissionService.requireAdminOrClassRep(body.user.id);
+    const action = body.actions[0] as { value: string };
+    const scheduleId = parseInt(action.value, 10);
+    const { ruleId, filter } = JSON.parse(
+      body.view?.private_metadata ?? '{}',
+    ) as { ruleId: number; filter: 'upcoming' | 'past' };
+
+    const schedule =
+      await this.cleaningScheduleService.findOneScheduleWithAssignees(
+        scheduleId,
+      );
+    if (!schedule) return;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningScheduleView.scheduleEditModal(schedule, ruleId, filter),
+    });
+  }
+
+  @Action('cleaning:schedule:open-delete')
+  async openScheduleDelete({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    await this.permissionService.requireAdminOrClassRep(body.user.id);
+    const action = body.actions[0] as { value: string };
+    const scheduleId = parseInt(action.value, 10);
+    const { ruleId, filter } = JSON.parse(
+      body.view?.private_metadata ?? '{}',
+    ) as { ruleId: number; filter: 'upcoming' | 'past' };
+
+    const schedule =
+      await this.cleaningScheduleService.findOneScheduleWithAssignees(
+        scheduleId,
+      );
+    if (!schedule) return;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningScheduleView.scheduleDeleteConfirmModal(
+        scheduleId,
+        ruleId,
+        filter,
+        schedule.cleaningDate,
+      ),
+    });
+  }
+
+  // 일정 삭제 후 기존 배정자에게 삭제 알림을 보낸다.
+  @View('cleaning:modal:schedule-delete')
+  async handleScheduleDelete({
+    ack,
+    view,
+    body,
+    client,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const { scheduleId, ruleId, filter } = JSON.parse(
+      view.private_metadata,
+    ) as { scheduleId: number; ruleId: number; filter: 'upcoming' | 'past' };
+
+    const [scheduleBefore, rule] = await Promise.all([
+      this.cleaningScheduleService.findOneScheduleWithAssignees(scheduleId),
+      ruleId
+        ? this.cleaningRuleService.findOneWithDetails(ruleId)
+        : Promise.resolve(null),
+    ]);
+
+    try {
+      await this.cleaningScheduleService.deleteSchedule(scheduleId);
+    } catch (e) {
+      if (
+        e instanceof BusinessError &&
+        e.code === CleaningErrorCode.SCHEDULE_HAS_ACTIVE_TRADES
+      ) {
+        await ack({
+          response_action: 'update',
+          view: CleaningScheduleView.scheduleDeleteConfirmModal(
+            scheduleId,
+            ruleId,
+            filter,
+            scheduleBefore?.cleaningDate ?? '',
+            e.message,
+          ),
+        } as any);
+        return;
+      }
+      throw e;
+    }
+
+    await ack();
+
+    if (scheduleBefore) {
+      const resourceName = rule?.ruleResource?.resource?.name ?? '미지정';
+      const slackIds = scheduleBefore.assignees
+        .filter((a) => a.status === CleaningAssignmentStatus.ASSIGNED)
+        .map((a) => a.userSlackId);
+      await Promise.allSettled(
+        slackIds.map((id) =>
+          client.chat.postMessage({
+            channel: id,
+            text: `🗑️ *${scheduleBefore.cleaningDate}* (${dayLabel(scheduleBefore.cleaningDate)}) | ${resourceName}\n청소 일정이 삭제되었습니다.`,
+          }),
+        ),
+      );
+    }
+
+    if (rule && body.view?.previous_view_id) {
+      const schedules =
+        await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+      const label = formatClassLabel({
+        admissionYear: rule.studentClass.admissionYear,
+        section: rule.studentClass.section,
+        graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+      });
+      await client.views.update({
+        view_id: body.view.previous_view_id,
+        view: CleaningScheduleView.scheduleDetailModal(
+          schedules,
+          label,
+          ruleId,
+          filter,
+        ),
+      });
+    }
+  }
+
+  // 선택 일정에 규칙 담당자 전원을 배정하고 신규 배정자에게 알린다.
+  @Action('cleaning:schedule:assign-all')
+  async assignAllToSchedule({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    await this.permissionService.requireAdminOrClassRep(body.user.id);
+    const action = body.actions[0] as { value: string };
+    const scheduleId = parseInt(action.value, 10);
+    const { ruleId, filter } = JSON.parse(
+      body.view?.private_metadata ?? '{}',
+    ) as { ruleId: number; filter: 'upcoming' | 'past' };
+
+    const [scheduleBefore, rule] = await Promise.all([
+      this.cleaningScheduleService.findOneScheduleWithAssignees(scheduleId),
+      ruleId
+        ? this.cleaningRuleService.findOneWithDetails(ruleId)
+        : Promise.resolve(null),
+    ]);
+    await this.cleaningScheduleService.assignAllToSchedule(scheduleId);
+    const scheduleAfter =
+      await this.cleaningScheduleService.findOneScheduleWithAssignees(
+        scheduleId,
+      );
+
+    if (scheduleAfter) {
+      const resourceName = rule?.ruleResource?.resource?.name ?? '미지정';
+      const beforeIds = new Set(
+        (scheduleBefore?.assignees ?? [])
+          .filter((a) => a.status === CleaningAssignmentStatus.ASSIGNED)
+          .map((a) => a.userSlackId),
+      );
+      const newlyAssigned = scheduleAfter.assignees
+        .filter(
+          (a) =>
+            a.status === CleaningAssignmentStatus.ASSIGNED &&
+            !beforeIds.has(a.userSlackId),
+        )
+        .map((a) => a.userSlackId);
+      await Promise.allSettled(
+        newlyAssigned.map((id) =>
+          client.chat.postMessage({
+            channel: id,
+            text: `🧹 *${scheduleAfter.cleaningDate}* (${dayLabel(scheduleAfter.cleaningDate)}) | ${resourceName}\n청소 일정에 배정되었습니다.`,
+          }),
+        ),
+      );
+    }
+
+    if (rule && body.view?.id) {
+      const schedules =
+        await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+      const label = formatClassLabel({
+        admissionYear: rule.studentClass.admissionYear,
+        section: rule.studentClass.section,
+        graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+      });
+      await client.views.update({
+        view_id: body.view.id,
+        view: CleaningScheduleView.scheduleDetailModal(
+          schedules,
+          label,
+          ruleId,
+          filter,
+        ),
+      });
+    }
+  }
+
+  @Action('cleaning:schedule:open-assignment-status')
+  async openAssignmentStatus({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    await this.permissionService.requireAdminOrClassRep(body.user.id);
+    const action = body.actions[0] as { value: string };
+    const scheduleId = parseInt(action.value, 10);
+
+    const schedule =
+      await this.cleaningScheduleService.findOneScheduleWithAssignees(
+        scheduleId,
+      );
+    if (!schedule) return;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningScheduleView.assignmentStatusModal(schedule),
+    });
+  }
+
+  // 모달에서 선택한 배정 상태만 모아 일괄 저장한다.
+  @View('cleaning:modal:assignment-status')
+  async handleAssignmentStatus({
+    ack,
+    view,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    await ack();
+
+    const updates = Object.entries(view.state.values)
+      .filter(([blockId]) => blockId.startsWith('assignment_'))
+      .flatMap(([blockId, field]) => {
+        const value = field.status_select.selected_option?.value;
+        if (!value) return [];
+        return [{ id: parseInt(blockId.replace('assignment_', ''), 10), status: value as CleaningAssignmentStatus }];
+      });
+
+    await this.cleaningScheduleService.updateAssignmentStatuses(updates);
+
+    logger.info(
+      `Assignment statuses updated: ${updates.map((u) => `${u.id}→${u.status}`).join(', ')}`,
+    );
+  }
+
+  // 일정 날짜/상태/필요 인원 변경 후 대상자에게 변경 내용을 알린다.
+  @View('cleaning:modal:schedule-edit')
+  async handleScheduleEdit({
+    ack,
+    client,
+    view,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const { scheduleId, ruleId, filter } = JSON.parse(
+      view.private_metadata,
+    ) as { scheduleId: number; ruleId: number; filter: 'upcoming' | 'past' };
+    const values = view.state.values;
+
+    const cleaningDate =
+      values.cleaning_date_block.cleaning_date_input.selected_date ?? undefined;
+
+    const status = values.status_block.status_select.selected_option
+      ?.value as CleaningScheduleStatus;
+
+    const [scheduleBefore, rule] = await Promise.all([
+      this.cleaningScheduleService.findOneScheduleWithAssignees(scheduleId),
+      this.cleaningRuleService.findOneWithDetails(ruleId),
+    ]);
+
+    let needPeoples: number;
+    if (filter === 'upcoming') {
+      // 예정 일정만 필요 인원을 수정할 수 있고, 지난 일정은 당시 값을 유지한다.
+      const raw = values.need_peoples_block?.need_peoples_input?.value;
+      const parsed = parseInt(raw ?? '', 10);
+      if (isNaN(parsed) || parsed < 1) {
+        await ack({
+          response_action: 'errors',
+          errors: { need_peoples_block: '1 이상의 숫자를 입력해주세요.' },
+        });
+        return;
+      }
+      needPeoples = parsed;
+    } else {
+      needPeoples = scheduleBefore?.needPeoples ?? 1;
+    }
+
+    try {
+      await this.cleaningScheduleService.updateSchedule(scheduleId, {
+        cleaningDate,
+        needPeoples,
+        status,
+      });
+    } catch (e) {
+      if (
+        e instanceof BusinessError &&
+        e.code === CleaningErrorCode.DUPLICATE_SCHEDULE_DATE
+      ) {
+        await ack({
+          response_action: 'errors',
+          errors: { cleaning_date_block: e.message },
+        });
+        return;
+      }
+      throw e;
+    }
+
+    if (scheduleBefore) {
+      const resourceName = rule?.ruleResource?.resource?.name ?? '미지정';
+      const assignedSlackIds = scheduleBefore.assignees
+        .filter((a) => a.status === CleaningAssignmentStatus.ASSIGNED)
+        .map((a) => a.userSlackId);
+
+      let notifyText: string | null = null;
+      const dateInfo = `*${scheduleBefore.cleaningDate}* (${dayLabel(scheduleBefore.cleaningDate)}) | ${resourceName}`;
+      if (status === CleaningScheduleStatus.CANCELED) {
+        notifyText = `❌ ${dateInfo}\n청소 일정이 취소되었습니다.`;
+      } else if (
+        status === CleaningScheduleStatus.SCHEDULED &&
+        scheduleBefore.status === CleaningScheduleStatus.CANCELED
+      ) {
+        notifyText = `✅ ${dateInfo}\n청소 일정이 복원되었습니다.`;
+      } else if (cleaningDate && cleaningDate !== scheduleBefore.cleaningDate) {
+        notifyText = `📅 ${resourceName} | 청소 일정 날짜가 변경되었습니다.\n*${scheduleBefore.cleaningDate}* (${dayLabel(scheduleBefore.cleaningDate)}) → *${cleaningDate}* (${dayLabel(cleaningDate)})`;
+      }
+
+      // 실제 사용자에게 영향이 있는 변경만 DM으로 알린다.
+      if (notifyText) {
+        await Promise.allSettled(
+          assignedSlackIds.map((id) =>
+            client.chat.postMessage({ channel: id, text: notifyText! }),
+          ),
+        );
+      }
+    }
+
+    const schedules =
+      await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+
+    if (rule && view.previous_view_id) {
+      const label = formatClassLabel({
+        admissionYear: rule.studentClass.admissionYear,
+        section: rule.studentClass.section,
+        graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+      });
+      await client.views.update({
+        view_id: view.previous_view_id,
+        view: CleaningScheduleView.scheduleDetailModal(
+          schedules,
+          label,
+          ruleId,
+          filter,
+        ),
+      });
+    }
+
+    await ack();
+
+    logger.info(
+      `Schedule ${scheduleId} updated: needPeoples=${needPeoples}, status=${status}`,
+    );
+  }
+}
+
+function dayLabel(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return (
+    ['일', '월', '화', '수', '목', '금', '토'][
+      new Date(y, m - 1, d).getDay()
+    ] + '요일'
+  );
+}

--- a/src/cleaning/service/cleaning-schedule.service.ts
+++ b/src/cleaning/service/cleaning-schedule.service.ts
@@ -1,0 +1,633 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, LessThan, Not, Repository } from 'typeorm';
+import { Cron } from '@nestjs/schedule';
+import {
+  CleaningSchedule,
+  CleaningScheduleStatus,
+} from '../entity/cleaning-schedule.entity';
+import {
+  CleaningAssignment,
+  CleaningAssignmentStatus,
+} from '../entity/cleaning-assignment.entity';
+import { CleaningRule } from '../entity/cleaning-rule.entity';
+import { CleaningRuleUser } from '../entity/cleaning-rule-user.entity';
+import { CleaningTrade, CleaningTradeStatus } from '../entity/cleaning-trade.entity';
+import { BusinessError, CleaningErrorCode } from '../../common/errors';
+
+export interface ScheduleWithAssignees {
+  id: number;
+  cleaningDate: string;
+  needPeoples: number;
+  status: CleaningScheduleStatus;
+  assignees: {
+    assignmentId: number;
+    userName: string;
+    userSlackId: string;
+    status: CleaningAssignmentStatus;
+  }[];
+}
+
+@Injectable()
+export class CleaningScheduleService {
+  private readonly logger = new Logger(CleaningScheduleService.name);
+
+  constructor(
+    @InjectRepository(CleaningSchedule)
+    private readonly scheduleRepo: Repository<CleaningSchedule>,
+    @InjectRepository(CleaningAssignment)
+    private readonly assignmentRepo: Repository<CleaningAssignment>,
+    @InjectRepository(CleaningRule)
+    private readonly ruleRepo: Repository<CleaningRule>,
+    @InjectRepository(CleaningRuleUser)
+    private readonly ruleUserRepo: Repository<CleaningRuleUser>,
+    @InjectRepository(CleaningTrade)
+    private readonly tradeRepo: Repository<CleaningTrade>,
+  ) {}
+
+  // 기간 지정 시 해당 범위의 요일만, 미지정 시 마지막 일정 이후 전원 1사이클만 생성한다.
+  async generateSchedules(
+    ruleId: number,
+    startDateStr?: string,
+    endDateStr?: string,
+  ): Promise<{ count: number; scheduleIds: number[] }> {
+    const rule = await this.ruleRepo.findOne({ where: { id: ruleId } });
+    if (!rule) return { count: 0, scheduleIds: [] };
+
+    const ruleUsers = await this.ruleUserRepo.find({ where: { ruleId } });
+    if (ruleUsers.length === 0) return { count: 0, scheduleIds: [] };
+
+    const existing = await this.scheduleRepo.find({
+      where: { ruleId },
+      order: { cleaningDate: 'DESC' },
+    });
+    // 같은 규칙/날짜 unique 제약을 피하기 위해 이미 생성된 날짜는 제외한다.
+    const existingDates = new Set(existing.map((s) => toDateStr(s.cleaningDate)));
+
+    // 배정 횟수가 적은 사람부터 배정해 장기적으로 담당 횟수를 맞춘다.
+    const assignmentCounts = await this.getAssignmentCounts(
+      ruleUsers.map((u) => u.userId),
+      ruleId,
+    );
+    // 동률 그룹만 랜덤 셔플해 공정성은 유지하면서 같은 조합 반복을 줄인다.
+    const usersByCnt = ruleUsers.map((ru) => ({
+      userId: ru.userId,
+      count: assignmentCounts.get(ru.userId) ?? 0,
+    }));
+    usersByCnt.sort((a, b) => a.count - b.count);
+
+    let si = 0;
+    while (si < usersByCnt.length) {
+      let ei = si;
+      while (ei < usersByCnt.length && usersByCnt[ei].count === usersByCnt[si].count) ei++;
+      for (let k = ei - 1; k > si; k--) {
+        const r = si + Math.floor(Math.random() * (k - si + 1));
+        [usersByCnt[k], usersByCnt[r]] = [usersByCnt[r], usersByCnt[k]];
+      }
+      si = ei;
+    }
+
+    const sortedUserIds = usersByCnt.map((u) => u.userId);
+
+    let cleaningDates: string[];
+
+    if (startDateStr || endDateStr) {
+      // 관리자가 기간을 지정하면 해당 기간 안의 청소 요일만 골라 생성한다.
+      const start = startDateStr ? parseLocalDate(startDateStr) : localToday();
+      const end = endDateStr ? parseLocalDate(endDateStr) : null;
+      cleaningDates = getDatesInRange(start, end, rule.daysOfWeek);
+    } else {
+      // 마지막 일정 이후부터 전원 1사이클 생성
+      const lastSchedule = existing[0];
+      const startFrom = lastSchedule
+        ? nextDayAfter(parseLocalDate(toDateStr(lastSchedule.cleaningDate)), rule.daysOfWeek)
+        : localToday();
+      const totalSchedules = Math.ceil(sortedUserIds.length / rule.needPeoples);
+      cleaningDates = getNDates(startFrom, rule.daysOfWeek, totalSchedules);
+    }
+
+    const newDates = cleaningDates.filter((d) => !existingDates.has(d));
+    if (newDates.length === 0) return { count: 0, scheduleIds: [] };
+
+    const scheduleIds: number[] = [];
+    let userIndex = 0;
+    const cycleSchedules = Math.ceil(sortedUserIds.length / rule.needPeoples);
+    let schedulesInCycle = 0;
+
+    for (const date of newDates) {
+      // 모든 담당자가 한 번씩 배정된 뒤에는 다음 사이클 조합을 다시 섞는다.
+      if (schedulesInCycle > 0 && schedulesInCycle % cycleSchedules === 0) {
+        for (let k = sortedUserIds.length - 1; k > 0; k--) {
+          const r = Math.floor(Math.random() * (k + 1));
+          [sortedUserIds[k], sortedUserIds[r]] = [sortedUserIds[r], sortedUserIds[k]];
+        }
+        userIndex = 0;
+      }
+
+      const schedule = await this.scheduleRepo.save(
+        this.scheduleRepo.create({
+          ruleId,
+          cleaningDate: date,
+          needPeoples: rule.needPeoples,
+          status: CleaningScheduleStatus.SCHEDULED,
+        }),
+      );
+      scheduleIds.push(schedule.id);
+
+      // needPeoples 단위로 순회하며 한 일정에 필요한 인원을 채운다.
+      const assignees = Array.from(
+        { length: rule.needPeoples },
+        (_, i) => sortedUserIds[(userIndex + i) % sortedUserIds.length],
+      );
+      userIndex = (userIndex + rule.needPeoples) % sortedUserIds.length;
+      schedulesInCycle++;
+
+      await this.assignmentRepo.save(
+        assignees.map((userId) =>
+          this.assignmentRepo.create({
+            scheduleId: schedule.id,
+            userId,
+            status: CleaningAssignmentStatus.ASSIGNED,
+          }),
+        ),
+      );
+    }
+
+    return { count: scheduleIds.length, scheduleIds };
+  }
+
+  async findSchedulesByRule(ruleId: number): Promise<ScheduleWithAssignees[]> {
+    const schedules = await this.scheduleRepo.find({
+      where: { ruleId },
+      order: { cleaningDate: 'ASC' },
+    });
+    return this.attachAssignees(schedules);
+  }
+
+  async findSchedulesByIds(
+    ids: number[],
+  ): Promise<ScheduleWithAssignees[]> {
+    if (ids.length === 0) return [];
+    const schedules = await this.scheduleRepo.find({ where: { id: In(ids) } });
+    return this.attachAssignees(schedules);
+  }
+
+  async findOneScheduleWithAssignees(
+    scheduleId: number,
+  ): Promise<ScheduleWithAssignees | null> {
+    const schedule = await this.scheduleRepo.findOne({
+      where: { id: scheduleId },
+    });
+    if (!schedule) return null;
+    const [result] = await this.attachAssignees([schedule]);
+    return result ?? null;
+  }
+
+  // 일정 수정 시 상태와 필요 인원 변경에 맞춰 연결된 배정 상태도 함께 보정한다.
+  async updateSchedule(
+    scheduleId: number,
+    dto: {
+      cleaningDate?: string;
+      needPeoples: number;
+      status: CleaningScheduleStatus;
+    },
+  ): Promise<void> {
+    const schedule = await this.scheduleRepo.findOne({
+      where: { id: scheduleId },
+    });
+    if (!schedule) return;
+
+    if (dto.cleaningDate && dto.cleaningDate !== schedule.cleaningDate) {
+      // 같은 규칙 안에서는 같은 날짜의 청소 일정이 하나만 존재해야 한다.
+      const conflict = await this.scheduleRepo.findOne({
+        where: {
+          ruleId: schedule.ruleId,
+          cleaningDate: dto.cleaningDate,
+          id: Not(scheduleId),
+        },
+      });
+      if (conflict) {
+        throw new BusinessError(CleaningErrorCode.DUPLICATE_SCHEDULE_DATE);
+      }
+    }
+
+    const wasCanceled = schedule.status === CleaningScheduleStatus.CANCELED;
+    const nowCanceled = dto.status === CleaningScheduleStatus.CANCELED;
+
+    await this.scheduleRepo.update(scheduleId, {
+      ...(dto.cleaningDate ? { cleaningDate: dto.cleaningDate } : {}),
+      needPeoples: dto.needPeoples,
+      status: dto.status,
+    });
+
+    if (!wasCanceled && nowCanceled) {
+      // 취소: ASSIGNED 배정 → CANCELED, PENDING 교환 → CANCELED
+      const assignments = await this.assignmentRepo.find({
+        where: { scheduleId, status: CleaningAssignmentStatus.ASSIGNED },
+        select: ['id'],
+      });
+      if (assignments.length > 0) {
+        const ids = assignments.map((a) => a.id);
+        await this.assignmentRepo.update(ids, {
+          status: CleaningAssignmentStatus.CANCELED,
+        });
+        await this.cancelPendingTradesForAssignments(ids);
+      }
+    } else if (wasCanceled && dto.status === CleaningScheduleStatus.SCHEDULED) {
+      // 복원: CANCELED 배정 → ASSIGNED
+      await this.assignmentRepo.update(
+        { scheduleId, status: CleaningAssignmentStatus.CANCELED },
+        { status: CleaningAssignmentStatus.ASSIGNED },
+      );
+    }
+
+    if (!nowCanceled && dto.needPeoples < schedule.needPeoples) {
+      // 필요 인원이 줄면 뒤쪽 배정부터 취소해 현재 일정의 active 인원을 맞춘다.
+      const active = await this.assignmentRepo.find({
+        where: { scheduleId, status: CleaningAssignmentStatus.ASSIGNED },
+        order: { id: 'DESC' },
+      });
+      const excess = active.slice(dto.needPeoples);
+      if (excess.length > 0) {
+        const ids = excess.map((a) => a.id);
+        await this.assignmentRepo.update(ids, {
+          status: CleaningAssignmentStatus.CANCELED,
+        });
+        await this.cancelPendingTradesForAssignments(ids);
+      }
+    }
+
+    if (!nowCanceled && dto.needPeoples > schedule.needPeoples) {
+      // 필요 인원이 늘면 규칙 담당자 중 아직 이 일정에 없는 사람을 추가 배정한다.
+      const currentAssigned = await this.assignmentRepo.find({
+        where: { scheduleId, status: CleaningAssignmentStatus.ASSIGNED },
+      });
+      const deficit = dto.needPeoples - currentAssigned.length;
+
+      if (deficit > 0) {
+        const assignedUserIds = new Set(currentAssigned.map((a) => a.userId));
+        const ruleUsers = await this.ruleUserRepo.find({
+          where: { ruleId: schedule.ruleId },
+        });
+        const canceled = await this.assignmentRepo.find({
+          where: { scheduleId, status: CleaningAssignmentStatus.CANCELED },
+        });
+        const canceledByUser = new Map(canceled.map((a) => [a.userId, a.id]));
+        const candidates = ruleUsers.filter((ru) => !assignedUserIds.has(ru.userId));
+
+        let added = 0;
+        for (const ru of candidates) {
+          if (added >= deficit) break;
+          if (canceledByUser.has(ru.userId)) {
+            await this.assignmentRepo.update(canceledByUser.get(ru.userId)!, {
+              status: CleaningAssignmentStatus.ASSIGNED,
+            });
+          } else {
+            await this.assignmentRepo.save(
+              this.assignmentRepo.create({
+                scheduleId,
+                userId: ru.userId,
+                status: CleaningAssignmentStatus.ASSIGNED,
+              }),
+            );
+          }
+          added++;
+        }
+      }
+    }
+  }
+
+  async updateAssignmentStatuses(
+    updates: { id: number; status: CleaningAssignmentStatus }[],
+  ): Promise<void> {
+    await Promise.all(
+      updates.map(({ id, status }) => this.assignmentRepo.update(id, { status })),
+    );
+  }
+
+  // 규칙의 담당자를 이 일정에 전원 배정하고 필요 인원도 담당자 수에 맞춘다.
+  async assignAllToSchedule(scheduleId: number): Promise<void> {
+    const schedule = await this.scheduleRepo.findOne({
+      where: { id: scheduleId },
+    });
+    if (!schedule || schedule.status === CleaningScheduleStatus.CANCELED) {
+      throw new BusinessError(CleaningErrorCode.ASSIGNMENT_NOT_FOUND);
+    }
+
+    const ruleUsers = await this.ruleUserRepo.find({
+      where: { ruleId: schedule.ruleId },
+    });
+
+    const existing = await this.assignmentRepo.find({ where: { scheduleId } });
+    const existingUserIds = new Set(existing.map((a) => a.userId));
+    // unique(scheduleId, userId) 때문에 취소 이력이 있으면 insert 대신 상태만 복원한다.
+    const canceledByUser = new Map(
+      existing
+        .filter((a) => a.status === CleaningAssignmentStatus.CANCELED)
+        .map((a) => [a.userId, a.id]),
+    );
+
+    for (const ru of ruleUsers) {
+      if (canceledByUser.has(ru.userId)) {
+        // CANCELED → ASSIGNED (unique 제약 때문에 INSERT 불가)
+        await this.assignmentRepo.update(canceledByUser.get(ru.userId)!, {
+          status: CleaningAssignmentStatus.ASSIGNED,
+        });
+      } else if (!existingUserIds.has(ru.userId)) {
+        await this.assignmentRepo.save(
+          this.assignmentRepo.create({
+            scheduleId,
+            userId: ru.userId,
+            status: CleaningAssignmentStatus.ASSIGNED,
+          }),
+        );
+      }
+    }
+
+    await this.scheduleRepo.update(scheduleId, { needPeoples: ruleUsers.length });
+  }
+
+  // 대기 중인 교환 요청이 있으면 삭제를 막아 배정 교환 흐름이 꼬이지 않게 한다.
+  async deleteSchedule(scheduleId: number): Promise<void> {
+    const assignments = await this.assignmentRepo.find({
+      where: { scheduleId },
+      select: ['id'],
+    });
+
+    if (assignments.length > 0) {
+      const assignmentIds = assignments.map((a) => a.id);
+
+      const pendingCount = await this.tradeRepo
+        .createQueryBuilder('t')
+        .where('t.status = :status', { status: CleaningTradeStatus.PENDING })
+        .andWhere(
+          '(t.requesterAssignmentId IN (:...ids) OR t.targetAssignmentId IN (:...ids))',
+          { ids: assignmentIds },
+        )
+        .getCount();
+
+      if (pendingCount > 0) {
+        throw new BusinessError(CleaningErrorCode.SCHEDULE_HAS_ACTIVE_TRADES);
+      }
+
+      await this.tradeRepo
+        .createQueryBuilder()
+        .delete()
+        .from(CleaningTrade)
+        .where(
+          '(requesterAssignmentId IN (:...ids) OR targetAssignmentId IN (:...ids))',
+          { ids: assignmentIds },
+        )
+        .execute();
+    }
+
+    await this.assignmentRepo.delete({ scheduleId });
+    await this.scheduleRepo.delete(scheduleId);
+  }
+
+  // 비활성화된 유저를 규칙에서 제거하고 예정된 배정은 남은 담당자로 대체한다.
+  async handleUserDeactivation(userId: number): Promise<void> {
+    const ruleUserRows = await this.ruleUserRepo.find({ where: { userId } });
+    if (ruleUserRows.length === 0) return;
+
+    const ruleIds = ruleUserRows.map((ru) => ru.ruleId);
+    await this.ruleUserRepo.delete({ userId });
+
+    const today = localTodayStr();
+
+    for (const ruleId of ruleIds) {
+      const remainingUsers = await this.ruleUserRepo.find({ where: { ruleId } });
+      if (remainingUsers.length === 0) continue;
+
+      const remainingUserIds = remainingUsers.map((ru) => ru.userId);
+
+      const futureAssignments = await this.assignmentRepo
+        .createQueryBuilder('a')
+        .innerJoin('a.schedule', 's')
+        .where('a.userId = :userId', { userId })
+        .andWhere('s.ruleId = :ruleId', { ruleId })
+        .andWhere('s.status = :sStatus', { sStatus: CleaningScheduleStatus.SCHEDULED })
+        .andWhere('s.cleaningDate >= :today', { today })
+        .andWhere('a.status = :aStatus', { aStatus: CleaningAssignmentStatus.ASSIGNED })
+        .select(['a.id AS id', 'a.scheduleId AS "scheduleId"'])
+        .getRawMany<{ id: number; scheduleId: number }>();
+
+      if (futureAssignments.length === 0) continue;
+
+      // 기존 배정은 취소 처리하고, 관련 교환 요청도 더 이상 유효하지 않으므로 취소한다.
+      const assignmentIds = futureAssignments.map((a) => a.id);
+      await this.assignmentRepo.update(assignmentIds, {
+        status: CleaningAssignmentStatus.CANCELED,
+      });
+      await this.cancelPendingTradesForAssignments(assignmentIds);
+
+      const counts = await this.getAssignmentCounts(remainingUserIds, ruleId);
+
+      for (const fa of futureAssignments) {
+        // 같은 일정에 이미 배정된 사람을 제외하고 가장 적게 배정된 담당자를 대체자로 고른다.
+        const alreadyAssigned = await this.assignmentRepo.find({
+          where: { scheduleId: fa.scheduleId, status: CleaningAssignmentStatus.ASSIGNED },
+          select: ['userId'],
+        });
+        const assignedSet = new Set(alreadyAssigned.map((a) => a.userId));
+
+        const canceledRecords = await this.assignmentRepo.find({
+          where: { scheduleId: fa.scheduleId, status: CleaningAssignmentStatus.CANCELED },
+          select: ['id', 'userId'],
+        });
+        const canceledByUser = new Map(canceledRecords.map((a) => [a.userId, a.id]));
+
+        const candidates = remainingUserIds.filter((uid) => !assignedSet.has(uid));
+        if (candidates.length === 0) continue;
+
+        const replacement = candidates.reduce((best, uid) =>
+          (counts.get(uid) ?? 0) < (counts.get(best) ?? 0) ? uid : best,
+        );
+
+        if (canceledByUser.has(replacement)) {
+          await this.assignmentRepo.update(canceledByUser.get(replacement)!, {
+            status: CleaningAssignmentStatus.ASSIGNED,
+          });
+        } else {
+          await this.assignmentRepo.save(
+            this.assignmentRepo.create({
+              scheduleId: fa.scheduleId,
+              userId: replacement,
+              status: CleaningAssignmentStatus.ASSIGNED,
+            }),
+          );
+        }
+
+        counts.set(replacement, (counts.get(replacement) ?? 0) + 1);
+      }
+    }
+  }
+
+  // 지난 예정 일정을 매일 완료 처리하고 남아 있는 배정도 완료로 맞춘다.
+  @Cron('0 0 * * *')
+  async completePastSchedules(): Promise<void> {
+    const today = localTodayStr();
+    const toComplete = await this.scheduleRepo.find({
+      where: { status: CleaningScheduleStatus.SCHEDULED, cleaningDate: LessThan(today) },
+      select: ['id'],
+    });
+    if (toComplete.length > 0) {
+      const ids = toComplete.map((s) => s.id);
+      await this.scheduleRepo.update(ids, { status: CleaningScheduleStatus.COMPLETED });
+      await this.assignmentRepo.update(
+        { scheduleId: In(ids), status: CleaningAssignmentStatus.ASSIGNED },
+        { status: CleaningAssignmentStatus.COMPLETED },
+      );
+    }
+    this.logger.log(`completePastSchedules: ${toComplete.length} schedules completed`);
+  }
+
+  private async cancelPendingTradesForAssignments(
+    assignmentIds: number[],
+  ): Promise<void> {
+    if (assignmentIds.length === 0) return;
+    await this.tradeRepo
+      .createQueryBuilder()
+      .update(CleaningTrade)
+      .set({ status: CleaningTradeStatus.CANCELED })
+      .where('status = :status', { status: CleaningTradeStatus.PENDING })
+      .andWhere(
+        '(requesterAssignmentId IN (:...ids) OR targetAssignmentId IN (:...ids))',
+        { ids: assignmentIds },
+      )
+      .execute();
+  }
+
+  private async attachAssignees(
+    schedules: CleaningSchedule[],
+  ): Promise<ScheduleWithAssignees[]> {
+    if (schedules.length === 0) return [];
+
+    const scheduleIds = schedules.map((s) => s.id);
+    const assignments = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .innerJoin('a.user', 'u')
+      .select([
+        'a.id AS "assignmentId"',
+        'a.scheduleId AS "scheduleId"',
+        'a.status AS "status"',
+        'u.name AS "userName"',
+        'u.slackId AS "userSlackId"',
+      ])
+      .where('a.scheduleId IN (:...ids)', { ids: scheduleIds })
+      .getRawMany<{
+        assignmentId: number;
+        scheduleId: number;
+        status: CleaningAssignmentStatus;
+        userName: string;
+        userSlackId: string;
+      }>();
+
+    const bySchedule = new Map<number, typeof assignments>();
+    for (const a of assignments) {
+      if (!bySchedule.has(a.scheduleId)) bySchedule.set(a.scheduleId, []);
+      bySchedule.get(a.scheduleId)!.push(a);
+    }
+
+    return schedules.map((s) => ({
+      id: s.id,
+      cleaningDate: toDateStr(s.cleaningDate),
+      needPeoples: s.needPeoples,
+      status: s.status,
+      assignees: (bySchedule.get(s.id) ?? []).map((a) => ({
+        assignmentId: a.assignmentId,
+        userName: a.userName,
+        userSlackId: a.userSlackId,
+        status: a.status,
+      })),
+    }));
+  }
+
+  private async getAssignmentCounts(
+    userIds: number[],
+    ruleId: number,
+  ): Promise<Map<number, number>> {
+    if (userIds.length === 0) return new Map();
+
+    const rows = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .innerJoin('a.schedule', 's')
+      .select('a.userId', 'userId')
+      .addSelect('COUNT(*)', 'cnt')
+      .where('s.ruleId = :ruleId', { ruleId })
+      .andWhere('a.userId IN (:...ids)', { ids: userIds })
+      .andWhere('a.status NOT IN (:...excluded)', {
+        excluded: [
+          CleaningAssignmentStatus.CANCELED,
+          CleaningAssignmentStatus.NON_COMPLIANT,
+        ],
+      })
+      .groupBy('a.userId')
+      .getRawMany<{ userId: number; cnt: string }>();
+
+    const map = new Map<number, number>(userIds.map((id) => [id, 0]));
+    for (const row of rows) map.set(Number(row.userId), Number(row.cnt));
+    return map;
+  }
+}
+
+function localTodayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function localToday(): Date {
+  const d = new Date();
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function parseLocalDate(dateStr: string): Date {
+  const [y, m, day] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, day);
+}
+
+function toDateStr(date: Date | string): string {
+  if (!(date instanceof Date)) return String(date);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function getDatesInRange(
+  start: Date,
+  end: Date | null,
+  daysOfWeek: number[],
+): string[] {
+  const daySet = new Set(daysOfWeek);
+  const dates: string[] = [];
+  const cur = new Date(start);
+  const limit = end ?? new Date(start.getFullYear() + 1, start.getMonth(), start.getDate());
+  while (cur <= limit) {
+    if (daySet.has(cur.getDay())) dates.push(toDateStr(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return dates;
+}
+
+function nextDayAfter(date: Date, daysOfWeek: number[]): Date {
+  const daySet = new Set(daysOfWeek);
+  const next = new Date(date);
+  next.setDate(next.getDate() + 1);
+  while (!daySet.has(next.getDay())) next.setDate(next.getDate() + 1);
+  return next;
+}
+
+function getNDates(start: Date, daysOfWeek: number[], n: number): string[] {
+  const daySet = new Set(daysOfWeek);
+  const dates: string[] = [];
+  const cur = new Date(start);
+  // 시작일이 요일에 맞지 않으면 다음 해당 요일로
+  while (!daySet.has(cur.getDay())) cur.setDate(cur.getDate() + 1);
+  while (dates.length < n) {
+    dates.push(toDateStr(cur));
+    cur.setDate(cur.getDate() + 1);
+    while (!daySet.has(cur.getDay())) cur.setDate(cur.getDate() + 1);
+  }
+  return dates;
+}

--- a/src/cleaning/view/cleaning-schedule.view.ts
+++ b/src/cleaning/view/cleaning-schedule.view.ts
@@ -1,0 +1,342 @@
+import type { View } from '@slack/types';
+import { ruleInfoText } from './cleaning-rule.view';
+import { RuleWithDetails } from '../service/cleaning-rule.service';
+import { ScheduleWithAssignees } from '../service/cleaning-schedule.service';
+import { CleaningScheduleStatus } from '../entity/cleaning-schedule.entity';
+import { CleaningAssignmentStatus } from '../entity/cleaning-assignment.entity';
+
+export class CleaningScheduleView {
+  // 규칙을 먼저 선택한 뒤 예정/지난 일정 목록으로 진입한다.
+  static scheduleManageListModal(rules: RuleWithDetails[]): View {
+    const blocks: View['blocks'] = [];
+
+    if (rules.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '등록된 청소 규칙이 없습니다.' },
+      });
+    } else {
+      for (const rule of rules) {
+        blocks.push(
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: ruleInfoText(rule) },
+          },
+          {
+            type: 'actions',
+            elements: [
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '예정 일정' },
+                action_id: 'cleaning:schedule:open-upcoming',
+                value: String(rule.id),
+              },
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '지난 일정' },
+                action_id: 'cleaning:schedule:open-past',
+                value: String(rule.id),
+              },
+            ],
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:schedule-manage-list',
+      title: { type: 'plain_text', text: '일정 관리' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  // 예정 일정은 active 배정자만, 지난 일정은 완료/미실시 상태까지 함께 보여준다.
+  static scheduleDetailModal(
+    schedules: ScheduleWithAssignees[],
+    ruleLabel: string,
+    ruleId: number,
+    filter: 'upcoming' | 'past',
+  ): View {
+    const today = new Date().toISOString().split('T')[0];
+    const isPast = filter === 'past';
+
+    const filtered = isPast
+      ? [...schedules]
+          .filter((s) => s.cleaningDate < today)
+          .sort((a, b) => b.cleaningDate.localeCompare(a.cleaningDate))
+      : schedules.filter((s) => s.cleaningDate >= today);
+
+    const blocks: View['blocks'] = [
+      {
+        type: 'context',
+        elements: [{ type: 'mrkdwn', text: `*${ruleLabel}*` }],
+      },
+    ];
+
+    if (filtered.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: isPast ? '지난 일정이 없습니다.' : '예정된 일정이 없습니다.',
+        },
+      });
+    } else {
+      for (const s of filtered) {
+        const assignedAssignees = s.assignees.filter(
+          (a) => a.status === CleaningAssignmentStatus.ASSIGNED,
+        );
+        const assigneeText = isPast
+          ? s.assignees.length > 0
+            ? s.assignees
+                .map((a) =>
+                  a.status !== CleaningAssignmentStatus.ASSIGNED
+                    ? `${a.userName} (${a.status})`
+                    : a.userName,
+                )
+                .join(', ')
+            : '미배정'
+          : assignedAssignees.length > 0
+            ? assignedAssignees.map((a) => a.userName).join(', ')
+            : '미배정';
+        blocks.push(
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*${s.cleaningDate}* | ${s.status} | ${s.needPeoples}명\n담당: ${assigneeText}`,
+            },
+          },
+          {
+            type: 'actions',
+            elements: [
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '수정' },
+                action_id: 'cleaning:schedule:open-edit',
+                value: String(s.id),
+              },
+              ...(!isPast
+                ? [
+                    {
+                      type: 'button' as const,
+                      text: { type: 'plain_text' as const, text: '전원 배정' },
+                      action_id: 'cleaning:schedule:assign-all',
+                      value: String(s.id),
+                    },
+                  ]
+                : []),
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '배정 상태' },
+                action_id: 'cleaning:schedule:open-assignment-status',
+                value: String(s.id),
+              },
+              {
+                type: 'button',
+                text: { type: 'plain_text', text: '삭제' },
+                action_id: 'cleaning:schedule:open-delete',
+                value: String(s.id),
+                style: 'danger',
+              },
+            ],
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:schedule-detail',
+      private_metadata: JSON.stringify({ ruleId, filter }),
+      title: { type: 'plain_text', text: isPast ? '지난 일정' : '예정 일정' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  // 개별 배정의 수행 결과를 관리자가 일정 단위로 변경하는 모달.
+  static assignmentStatusModal(schedule: ScheduleWithAssignees): View {
+    const statusOptions = [
+      {
+        text: { type: 'plain_text' as const, text: '배정' },
+        value: CleaningAssignmentStatus.ASSIGNED,
+      },
+      {
+        text: { type: 'plain_text' as const, text: '미실시' },
+        value: CleaningAssignmentStatus.NON_COMPLIANT,
+      },
+    ];
+
+    const blocks: View['blocks'] = [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: `날짜: *${schedule.cleaningDate}*` },
+      },
+    ];
+
+    if (schedule.assignees.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '배정된 인원이 없습니다.' },
+      });
+    } else {
+      for (const a of schedule.assignees) {
+        const initialOption = statusOptions.find((o) => o.value === a.status);
+        blocks.push({
+          type: 'input',
+          block_id: `assignment_${a.assignmentId}`,
+          label: {
+            type: 'plain_text',
+            text: `${a.userName}${a.status === CleaningAssignmentStatus.COMPLETED ? ' ✅' : ''}`,
+          },
+          optional: true,
+          element: {
+            type: 'static_select',
+            action_id: 'status_select',
+            placeholder: { type: 'plain_text', text: '변경할 상태 선택' },
+            options: statusOptions,
+            ...(initialOption ? { initial_option: initialOption } : {}),
+          },
+        });
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:assignment-status',
+      private_metadata: String(schedule.id),
+      title: { type: 'plain_text', text: '배정 상태 관리' },
+      submit:
+        schedule.assignees.length > 0
+          ? { type: 'plain_text', text: '저장' }
+          : undefined,
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  // 지난 일정은 기록 보존을 위해 필요 인원 수정을 막고 상태만 관리한다.
+  static scheduleEditModal(
+    schedule: ScheduleWithAssignees,
+    ruleId: number,
+    filter: 'upcoming' | 'past',
+  ): View {
+    const statusOptions = [
+      {
+        text: { type: 'plain_text' as const, text: '예정' },
+        value: CleaningScheduleStatus.SCHEDULED,
+      },
+      {
+        text: { type: 'plain_text' as const, text: '취소' },
+        value: CleaningScheduleStatus.CANCELED,
+      },
+    ];
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:schedule-edit',
+      private_metadata: JSON.stringify({
+        scheduleId: schedule.id,
+        ruleId,
+        filter,
+      }),
+      title: { type: 'plain_text', text: '일정 수정' },
+      submit: { type: 'plain_text', text: '저장' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'input',
+          block_id: 'cleaning_date_block',
+          label: { type: 'plain_text', text: '날짜' },
+          element: {
+            type: 'datepicker',
+            action_id: 'cleaning_date_input',
+            initial_date: schedule.cleaningDate,
+          },
+        },
+        ...(filter === 'upcoming'
+          ? [
+              {
+                type: 'input' as const,
+                block_id: 'need_peoples_block',
+                label: { type: 'plain_text' as const, text: '필요 인원 (명)' },
+                element: {
+                  type: 'plain_text_input' as const,
+                  action_id: 'need_peoples_input',
+                  initial_value: String(schedule.needPeoples),
+                },
+              },
+            ]
+          : [
+              {
+                type: 'section' as const,
+                text: {
+                  type: 'mrkdwn' as const,
+                  text: `필요 인원: *${schedule.needPeoples}명* (지난 일정은 수정 불가)`,
+                },
+              },
+            ]),
+        {
+          type: 'input',
+          block_id: 'status_block',
+          label: { type: 'plain_text', text: '상태' },
+          element: {
+            type: 'static_select',
+            action_id: 'status_select',
+            options: statusOptions,
+            initial_option: statusOptions.find(
+              (o) => o.value === schedule.status,
+            ),
+          },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: '⚠️ 상태를 *취소* 로 변경하면 이 일정의 배정이 모두 취소됩니다.',
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  static scheduleDeleteConfirmModal(
+    scheduleId: number,
+    ruleId: number,
+    filter: 'upcoming' | 'past',
+    cleaningDate: string,
+    errorMessage?: string,
+  ): View {
+    const blocks: View['blocks'] = [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${cleaningDate}* 일정을 삭제하시겠습니까?\n배정된 인원이 모두 취소됩니다.`,
+        },
+      },
+    ];
+    if (errorMessage) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: `:warning: ${errorMessage}` },
+      });
+    }
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:schedule-delete',
+      private_metadata: JSON.stringify({ scheduleId, ruleId, filter }),
+      title: { type: 'plain_text', text: '일정 삭제' },
+      submit: { type: 'plain_text', text: '삭제' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks,
+    };
+  }
+}


### PR DESCRIPTION
## 개요
청소 규칙을 기반으로 청소를 배정하고, 청소 일정을 관리하는 기능을 구현했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->

## 주요 변경 사항
### 청소 배정 및 일정 생성
- 청소 규칙의 요일, 필요 인원, 담당자 목록을 기준으로 청소 일정을 생성합니다.
- 시작일/종료일이 입력된 경우 해당 기간 내 청소 요일만 골라 일정을 생성합니다.
- 기간이 입력되지 않은 경우 마지막 일정 이후부터 담당자 전체 1사이클 분량의 일정을 생성합니다.
- 담당자별 기존 배정 횟수를 카운트해서 배정 횟수가 적은 인원이 우선 배정되도록 처리했습니다.
### 청소 일정 관리
- 규칙별 예정 일정과 지난 일정을 조회할 수 있도록 관리 slack home에 ui를 추가했습니다.
- 청소 일정의 날짜, 상태, 필요 인원 수를 수정할 수 있도록 했습니다.
- 일정 삭제 시 연결된 배정과 교환 요청 상태를 함께 처리하도록 했습니다.
- 지난 일정은 기록 보존을 위해 필요 인원 수정을 제한했습니다.
<!-- 변경 항목마다 ### 제목으로 구분하고 하위 내용을 작성해주세요
### 변경한 기능 또는 파일
- 세부 내용
-->

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [✅] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)
https://natural-suit-4f1.notion.site/36638f10521c80c084bdcedf56d9d1ab?source=copy_link
<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
