### PR TITLE
feat/MCP tool metadata 및 structuredContent 추가

### DIFF
--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -296,11 +296,7 @@ export class McpService {
     );
 
     server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: this.toolsService.getDefinitions().map((t) => ({
-        name: t.name,
-        description: t.description ?? '',
-        inputSchema: t.input_schema,
-      })),
+      tools: this.toolsService.getMcpDefinitions(),
     }));
 
     server.setRequestHandler(CallToolRequestSchema, async (req) => {
@@ -313,8 +309,13 @@ export class McpService {
         );
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: this.toolsService.toStructuredContent(result),
         };
       } catch (e) {
+        const structuredContent = {
+          success: false,
+          error: e instanceof Error ? e.message : String(e),
+        };
         this.logger.error(
           `Tool execution failed — tool=${tool} slackId=${slackId} error=${e instanceof Error ? e.message : String(e)}`,
         );
@@ -322,12 +323,10 @@ export class McpService {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify({
-                success: false,
-                error: e instanceof Error ? e.message : String(e),
-              }),
+              text: JSON.stringify(structuredContent),
             },
           ],
+          structuredContent,
           isError: true,
         };
       }

--- a/src/tools/tools.service.spec.ts
+++ b/src/tools/tools.service.spec.ts
@@ -1,0 +1,84 @@
+import { ToolsService } from './tools.service';
+
+describe('ToolsService MCP metadata', () => {
+  function createService() {
+    return new ToolsService(
+      {
+        definitions: [
+          {
+            name: 'get_my_bookings',
+            description: 'List bookings',
+            input_schema: { type: 'object', properties: {}, required: [] },
+          },
+          {
+            name: 'book_room',
+            description: 'Book a room',
+            input_schema: { type: 'object', properties: {}, required: [] },
+          },
+        ],
+        execute: jest.fn(),
+      } as never,
+      {
+        definitions: [
+          {
+            name: 'get_current_time',
+            description: 'Read current time',
+            input_schema: { type: 'object', properties: {}, required: [] },
+          },
+        ],
+        execute: jest.fn(),
+      } as never,
+      {
+        toolExecutionsTotal: {
+          inc: jest.fn(),
+        },
+      } as never,
+    );
+  }
+
+  it('keeps Anthropic definitions free of MCP-only metadata', () => {
+    const definitions = createService().getDefinitions();
+
+    expect(definitions).toEqual([
+      expect.objectContaining({ name: 'get_my_bookings' }),
+      expect.objectContaining({ name: 'book_room' }),
+      expect.objectContaining({ name: 'get_current_time' }),
+    ]);
+    expect(definitions[0]).not.toHaveProperty('annotations');
+    expect(definitions[0]).not.toHaveProperty('outputSchema');
+  });
+
+  it('adds MCP annotations and output schemas for clients', () => {
+    const definitions = createService().getMcpDefinitions();
+    const bookings = definitions.find(
+      (tool) => tool.name === 'get_my_bookings',
+    );
+    const bookRoom = definitions.find((tool) => tool.name === 'book_room');
+
+    expect(bookings).toMatchObject({
+      title: 'Get My Bookings',
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      outputSchema: { type: 'object', additionalProperties: true },
+    });
+    expect(bookRoom).toMatchObject({
+      title: 'Book Room',
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    });
+  });
+
+  it('wraps non-object results as structured content', () => {
+    const service = createService();
+
+    expect(service.toStructuredContent([{ id: 1 }])).toEqual({
+      result: [{ id: 1 }],
+    });
+    expect(service.toStructuredContent({ success: true })).toEqual({
+      success: true,
+    });
+  });
+});

--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -1,9 +1,70 @@
 import { Injectable } from '@nestjs/common';
 import type Anthropic from '@anthropic-ai/sdk';
+import type { Tool, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { BookingTool } from './booking.tool';
 import { TimeTool } from './time.tool';
 import { BusinessError } from '../common/errors/base.error';
 import { AppMetrics } from '../common/metrics/app.metrics';
+
+type McpToolMetadata = {
+  title: string;
+  annotations: ToolAnnotations;
+};
+
+const DEFAULT_OUTPUT_SCHEMA = {
+  type: 'object' as const,
+  additionalProperties: true,
+};
+
+const MCP_TOOL_METADATA: Record<string, McpToolMetadata> = {
+  get_my_bookings: {
+    title: 'Get My Bookings',
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  find_user: {
+    title: 'Find User',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  },
+  get_study_rooms: {
+    title: 'Get Study Rooms',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  },
+  check_room_availability: {
+    title: 'Check Room Availability',
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  book_room: {
+    title: 'Book Room',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  cancel_booking: {
+    title: 'Cancel Booking',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  modify_booking: {
+    title: 'Modify Booking',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  get_current_time: {
+    title: 'Get Current Time',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  },
+};
 
 @Injectable()
 export class ToolsService {
@@ -18,7 +79,32 @@ export class ToolsService {
   }
 
   getDefinitions(): Anthropic.Tool[] {
-    return this.tools.flatMap((t) => t.definitions);
+    return this.tools.flatMap((tool) =>
+      tool.definitions.map((definition) => ({
+        name: definition.name,
+        description: definition.description,
+        input_schema: definition.input_schema,
+      })),
+    );
+  }
+
+  getMcpDefinitions(): Tool[] {
+    return this.tools.flatMap((tool) =>
+      tool.definitions.map((definition) => {
+        const metadata = MCP_TOOL_METADATA[definition.name] ?? {
+          title: definition.name,
+          annotations: {},
+        };
+        return {
+          name: definition.name,
+          title: metadata.title,
+          description: definition.description ?? '',
+          inputSchema: definition.input_schema as Tool['inputSchema'],
+          outputSchema: DEFAULT_OUTPUT_SCHEMA as Tool['outputSchema'],
+          annotations: metadata.annotations,
+        };
+      }),
+    );
   }
 
   async execute(
@@ -51,5 +137,16 @@ export class ToolsService {
         return { success: false, error: e.message };
       throw e;
     }
+  }
+
+  toStructuredContent(result: unknown): Record<string, unknown> {
+    if (
+      result !== null &&
+      typeof result === 'object' &&
+      !Array.isArray(result)
+    ) {
+      return result as Record<string, unknown>;
+    }
+    return { result };
   }
 }


### PR DESCRIPTION
## 개요

MCP 클라이언트가 Bannote tool의 성격을 더 잘 이해할 수 있도록 tool metadata와 structured result를 추가합니다.

## 주요 변경 사항

### MCP tool metadata 추가

- MCP `tools/list` 결과에 `title`, `annotations`, `outputSchema` 추가
- 조회성 tool에는 `readOnlyHint` 추가
- 예약 생성/수정/취소 tool에는 write/destructive/idempotency 성격을 구분하는 annotation 추가

### structuredContent 반환

- MCP `tools/call` 결과에 기존 text content와 함께 `structuredContent` 반환
- Slack AI에서 사용하는 Anthropic tool definition은 기존 형태를 유지하도록 분리

### 테스트 추가

- MCP 전용 metadata가 붙는지 검증
- Anthropic tool definition에는 MCP 전용 metadata가 섞이지 않는지 검증
- non-object 결과가 structured content로 안전하게 wrapping되는지 검증

## Stack

- #201 위에 쌓인 변경입니다.
- upstream branch 생성 권한이 없어 GitHub상 base는 `main`으로 열려 있습니다.
- #201 merge 후 rebase/retarget해서 리뷰하는 것을 권장합니다.

## 관련 이슈

없음

## 테스트

- [x] `npm run test -- src/tools/tools.service.spec.ts src/mcp/mcp.service.spec.ts src/mcp/mcp.controller.spec.ts`
- [x] `npm test`
- [x] `npm run build`
