### PR TITLE
feat/MCP prompts/resources 및 문서 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,116 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# Bannote Slack App
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Bannote is a NestJS Slack app for GSC schedules, Google Calendar integration,
+resource management, and study room bookings. It also exposes a remote MCP
+server so MCP-capable clients can use the same booking tools outside Slack.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
-
-## Description
-
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
-## Project setup
+## Local Setup
 
 ```bash
-$ npm install
+npm install
+npm run build
+npm run test
 ```
 
-## Compile and run the project
+Run the app locally:
 
 ```bash
-# development
-$ npm run start
-
-# watch mode
-$ npm run start:dev
-
-# production mode
-$ npm run start:prod
+npm run start:dev
 ```
 
-## Run tests
+For local Postgres and Redis:
 
 ```bash
-# unit tests
-$ npm run test
-
-# e2e tests
-$ npm run test:e2e
-
-# test coverage
-$ npm run test:cov
+make db
 ```
+
+## Remote MCP
+
+The MCP endpoint is:
+
+```text
+https://<app-domain>/mcp
+```
+
+The server advertises OAuth metadata from:
+
+```text
+https://<app-domain>/.well-known/oauth-authorization-server
+https://<app-domain>/.well-known/oauth-protected-resource/mcp
+```
+
+MCP authentication uses dynamic client registration, authorization code +
+PKCE, and Google OAuth. The Google account email must match an existing
+Bannote user.
+
+### MCP Environment
+
+| Variable                  | Purpose                                                          |
+| ------------------------- | ---------------------------------------------------------------- |
+| `MCP_BASE_URL`            | Public base URL used in OAuth and protected resource metadata.   |
+| `MCP_GOOGLE_REDIRECT_URI` | Google OAuth callback URL for MCP auth.                          |
+| `MCP_ALLOWED_ORIGINS`     | Optional comma-separated browser origins allowed to call `/mcp`. |
+
+If `MCP_ALLOWED_ORIGINS` is empty, requests without an `Origin` header are
+accepted and browser requests must match `MCP_BASE_URL`.
+
+### MCP Tools
+
+| Tool                      | Type  | Purpose                                            |
+| ------------------------- | ----- | -------------------------------------------------- |
+| `get_current_time`        | read  | Get current Asia/Seoul time.                       |
+| `get_my_bookings`         | read  | List the authenticated user's study room bookings. |
+| `find_user`               | read  | Find active users by name, code, or email.         |
+| `get_study_rooms`         | read  | List study room IDs, names, and aliases.           |
+| `check_room_availability` | read  | Check room availability for a time range.          |
+| `book_room`               | write | Create a study room booking.                       |
+| `cancel_booking`          | write | Cancel an existing booking.                        |
+| `modify_booking`          | write | Modify an existing booking.                        |
+
+Tools include MCP annotations and structured output so clients can distinguish
+read-only lookups from booking mutations.
+
+### MCP Prompts And Resources
+
+Prompts:
+
+- `reserve_study_room`
+- `change_study_room_booking`
+- `cancel_study_room_booking`
+- `find_available_study_room`
+
+Resources:
+
+- `bannote://guide/study-room-booking`
+- `bannote://guide/tool-workflows`
+- `bannote://rooms`
+- `bannote://me/bookings`
+
+These provide workflow guidance and user-specific context without adding
+client-specific skills.
+
+## Verification
+
+Targeted checks for MCP changes:
+
+```bash
+npm run test -- src/mcp/mcp.service.spec.ts src/mcp/mcp.controller.spec.ts src/tools/tools.service.spec.ts
+npm run build
+```
+
+Health check:
+
+```bash
+curl -i https://<app-domain>/health
+```
+
+Unauthenticated MCP requests should return `401` with a `WWW-Authenticate`
+challenge that points to the MCP protected resource metadata.
 
 ## Deployment
 
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
+Production infrastructure is defined in `terraform/`. The production app domain
+is configured through `app_domain`, and the ECS task sets:
 
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
-
-```bash
-$ npm install -g @nestjs/mau
-$ mau deploy
-```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+- `MCP_BASE_URL=https://${app_domain}`
+- `MCP_GOOGLE_REDIRECT_URI=https://${app_domain}/mcp/auth/callback`

--- a/src/mcp/mcp.service.spec.ts
+++ b/src/mcp/mcp.service.spec.ts
@@ -28,6 +28,10 @@ describe('McpService auth hardening', () => {
     exchangeCodeForTokens: jest.Mock;
     getGoogleUserInfo: jest.Mock;
   };
+  let toolsService: {
+    getDefinitions: jest.Mock;
+    execute: jest.Mock;
+  };
   let userService: {
     findByEmail: jest.Mock;
   };
@@ -48,9 +52,13 @@ describe('McpService auth hardening', () => {
     userService = {
       findByEmail: jest.fn(async () => ({ slackId: 'U123' })),
     };
+    toolsService = {
+      getDefinitions: jest.fn(),
+      execute: jest.fn(),
+    };
 
     service = new McpService(
-      { getDefinitions: jest.fn(), execute: jest.fn() } as never,
+      toolsService as never,
       userService as never,
       googleOAuthService as never,
       cache as unknown as Cache,
@@ -183,5 +191,71 @@ describe('McpService auth hardening', () => {
       service.isOriginAllowed('https://chat.openai.com/session', baseUrl),
     ).toBe(true);
     delete process.env.MCP_ALLOWED_ORIGINS;
+  });
+
+  it('lists and renders booking workflow prompts', () => {
+    expect(service.listPrompts().prompts.map((prompt) => prompt.name)).toEqual([
+      'reserve_study_room',
+      'change_study_room_booking',
+      'cancel_study_room_booking',
+      'find_available_study_room',
+    ]);
+
+    expect(
+      service.getPrompt('reserve_study_room', {
+        date: 'tomorrow',
+        start_time: '14:00',
+      }),
+    ).toMatchObject({
+      description: 'Reserve Study Room',
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: expect.stringContaining('check_room_availability'),
+          },
+        },
+      ],
+    });
+  });
+
+  it('lists and reads guide and user resources', async () => {
+    toolsService.execute.mockImplementation(async (name: string) => {
+      if (name === 'get_study_rooms') return [{ id: 1, name: 'Room A' }];
+      if (name === 'get_my_bookings') return [{ eventId: 'event-1' }];
+      return null;
+    });
+
+    expect(
+      service.listResources().resources.map((resource) => resource.uri),
+    ).toEqual([
+      'bannote://guide/study-room-booking',
+      'bannote://guide/tool-workflows',
+      'bannote://rooms',
+      'bannote://me/bookings',
+    ]);
+
+    await expect(
+      service.readResource('bannote://guide/study-room-booking', 'U123'),
+    ).resolves.toMatchObject({
+      contents: [
+        {
+          mimeType: 'text/markdown',
+          text: expect.stringContaining('get_current_time'),
+        },
+      ],
+    });
+
+    await expect(
+      service.readResource('bannote://rooms', 'U123'),
+    ).resolves.toMatchObject({
+      contents: [
+        {
+          mimeType: 'application/json',
+          text: expect.stringContaining('Room A'),
+        },
+      ],
+    });
   });
 });

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -5,7 +5,19 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
+  ErrorCode,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  McpError,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type {
+  GetPromptResult,
+  ListPromptsResult,
+  ListResourcesResult,
+  ReadResourceResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
@@ -54,6 +66,35 @@ const REFRESH_TOKEN_TTL = 365 * 24 * 60 * 60 * 1000; // 365일
 const PKCE_TTL = 10 * 60 * 1000; // 10분
 const AUTH_CODE_TTL = 5 * 60 * 1000; // 5분
 const CLIENT_TTL = 365 * 24 * 60 * 60 * 1000; // 365일
+
+const BOOKING_GUIDE = `# Bannote study room booking guide
+
+- Interpret all dates and times in Asia/Seoul.
+- Call get_current_time before relative date/time work.
+- Call get_study_rooms before using a roomId.
+- Call check_room_availability before creating or changing a booking.
+- Use find_user to resolve attendee Slack IDs.
+- Booking start and end times must be 15-minute aligned.
+- Do not expose calendarId or eventId to the user unless the client needs them for a tool call.`;
+
+const TOOL_WORKFLOW_GUIDE = `# Bannote MCP workflow guide
+
+Reserve a room:
+1. get_current_time
+2. get_study_rooms
+3. check_room_availability
+4. find_user, when attendees are named
+5. book_room
+
+Change a booking:
+1. get_my_bookings
+2. get_study_rooms, if changing rooms
+3. check_room_availability, if changing time or room
+4. modify_booking
+
+Cancel a booking:
+1. get_my_bookings
+2. cancel_booking after the user confirms the target booking.`;
 
 @Injectable()
 export class McpService {
@@ -292,7 +333,7 @@ export class McpService {
   private buildServer(slackId: string): Server {
     const server = new Server(
       { name: 'gsc-slack-app', version: '1.0.0' },
-      { capabilities: { tools: {} } },
+      { capabilities: { tools: {}, prompts: {}, resources: {} } },
     );
 
     server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -332,7 +373,189 @@ export class McpService {
       }
     });
 
+    server.setRequestHandler(ListPromptsRequestSchema, async () =>
+      this.listPrompts(),
+    );
+
+    server.setRequestHandler(GetPromptRequestSchema, async (req) =>
+      this.getPrompt(req.params.name, req.params.arguments ?? {}),
+    );
+
+    server.setRequestHandler(ListResourcesRequestSchema, async () =>
+      this.listResources(),
+    );
+
+    server.setRequestHandler(ReadResourceRequestSchema, async (req) =>
+      this.readResource(req.params.uri, slackId),
+    );
+
     return server;
+  }
+
+  listPrompts(): ListPromptsResult {
+    return {
+      prompts: [
+        {
+          name: 'reserve_study_room',
+          title: 'Reserve Study Room',
+          description:
+            'Plan and create a study room booking with the required availability checks.',
+          arguments: [
+            { name: 'date', description: 'Requested date', required: false },
+            {
+              name: 'start_time',
+              description: 'Requested start time',
+              required: false,
+            },
+            {
+              name: 'end_time',
+              description: 'Requested end time',
+              required: false,
+            },
+            {
+              name: 'room_preference',
+              description: 'Preferred room name or alias',
+              required: false,
+            },
+            {
+              name: 'attendees',
+              description: 'Comma-separated attendee names, codes, or emails',
+              required: false,
+            },
+            {
+              name: 'title',
+              description: 'Booking title or purpose',
+              required: false,
+            },
+          ],
+        },
+        {
+          name: 'change_study_room_booking',
+          title: 'Change Study Room Booking',
+          description:
+            'Find an existing booking and safely change its time, room, title, or attendees.',
+        },
+        {
+          name: 'cancel_study_room_booking',
+          title: 'Cancel Study Room Booking',
+          description:
+            'Find an existing booking and cancel it after user confirmation.',
+        },
+        {
+          name: 'find_available_study_room',
+          title: 'Find Available Study Room',
+          description:
+            'Search room availability for a requested date and time window.',
+        },
+      ],
+    };
+  }
+
+  getPrompt(name: string, args: Record<string, string>): GetPromptResult {
+    const argLines = Object.entries(args)
+      .filter(([, value]) => value.trim().length > 0)
+      .map(([key, value]) => `- ${key}: ${value}`)
+      .join('\n');
+    const context = argLines ? `\n\nUser-provided details:\n${argLines}` : '';
+    const workflows: Record<string, { title: string; body: string }> = {
+      reserve_study_room: {
+        title: 'Reserve Study Room',
+        body: 'Help the user reserve a study room. Use get_current_time first for relative dates, then get_study_rooms, check_room_availability, find_user when attendees are named, and finally book_room only after the target room and time are clear.',
+      },
+      change_study_room_booking: {
+        title: 'Change Study Room Booking',
+        body: 'Help the user change an existing study room booking. Use get_my_bookings to identify the target booking. If the room or time changes, use get_study_rooms and check_room_availability before calling modify_booking.',
+      },
+      cancel_study_room_booking: {
+        title: 'Cancel Study Room Booking',
+        body: 'Help the user cancel an existing study room booking. Use get_my_bookings to identify the target booking and call cancel_booking only after the user confirms which booking should be cancelled.',
+      },
+      find_available_study_room: {
+        title: 'Find Available Study Room',
+        body: 'Help the user find an available study room. Use get_current_time for relative dates, get_study_rooms to understand room IDs, and check_room_availability for the requested time window.',
+      },
+    };
+    const prompt = workflows[name];
+    if (!prompt) {
+      throw new McpError(ErrorCode.InvalidParams, `Unknown prompt: ${name}`);
+    }
+
+    return {
+      description: prompt.title,
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: `${prompt.body}${context}`,
+          },
+        },
+      ],
+    };
+  }
+
+  listResources(): ListResourcesResult {
+    return {
+      resources: [
+        {
+          uri: 'bannote://guide/study-room-booking',
+          name: 'study-room-booking-guide',
+          title: 'Study Room Booking Guide',
+          description: 'Rules and tool ordering guidance for booking rooms.',
+          mimeType: 'text/markdown',
+        },
+        {
+          uri: 'bannote://guide/tool-workflows',
+          name: 'tool-workflows-guide',
+          title: 'Tool Workflow Guide',
+          description: 'Recommended MCP tool call order for common tasks.',
+          mimeType: 'text/markdown',
+        },
+        {
+          uri: 'bannote://rooms',
+          name: 'study-room-catalog',
+          title: 'Study Room Catalog',
+          description: 'Current study room IDs, names, and aliases.',
+          mimeType: 'application/json',
+        },
+        {
+          uri: 'bannote://me/bookings',
+          name: 'my-bookings',
+          title: 'My Bookings',
+          description: 'Current user study room bookings.',
+          mimeType: 'application/json',
+        },
+      ],
+    };
+  }
+
+  async readResource(
+    uri: string,
+    slackId: string,
+  ): Promise<ReadResourceResult> {
+    if (uri === 'bannote://guide/study-room-booking') {
+      return this.textResource(uri, 'text/markdown', BOOKING_GUIDE);
+    }
+    if (uri === 'bannote://guide/tool-workflows') {
+      return this.textResource(uri, 'text/markdown', TOOL_WORKFLOW_GUIDE);
+    }
+    if (uri === 'bannote://rooms') {
+      const rooms = await this.toolsService.execute(
+        'get_study_rooms',
+        {},
+        slackId,
+      );
+      return this.textResource(uri, 'application/json', rooms);
+    }
+    if (uri === 'bannote://me/bookings') {
+      const bookings = await this.toolsService.execute(
+        'get_my_bookings',
+        {},
+        slackId,
+      );
+      return this.textResource(uri, 'application/json', bookings);
+    }
+    throw new McpError(ErrorCode.InvalidParams, `Unknown resource: ${uri}`);
   }
 
   async handleRequest(
@@ -456,5 +679,22 @@ export class McpService {
           return false;
         }
       });
+  }
+
+  private textResource(
+    uri: string,
+    mimeType: string,
+    value: unknown,
+  ): ReadResourceResult {
+    return {
+      contents: [
+        {
+          uri,
+          mimeType,
+          text:
+            typeof value === 'string' ? value : JSON.stringify(value, null, 2),
+        },
+      ],
+    };
   }
 }


### PR DESCRIPTION
## 개요

MCP client가 Bannote의 스터디룸 예약 workflow를 더 잘 사용할 수 있도록 prompts, resources, README 문서를 추가합니다.

## 주요 변경 사항

### MCP prompts 추가

- `reserve_study_room`
- `change_study_room_booking`
- `cancel_study_room_booking`
- `find_available_study_room`

### MCP resources 추가

- `bannote://guide/study-room-booking`
- `bannote://guide/tool-workflows`
- `bannote://rooms`
- `bannote://me/bookings`

### README 정리

- Nest starter README를 Bannote 중심 문서로 교체
- local setup, remote MCP endpoint, OAuth metadata, tools, prompts/resources, verification 내용을 정리

## Stack

- #201, #202 위에 쌓인 변경입니다.
- upstream branch 생성 권한이 없어 GitHub상 base는 `main`으로 열려 있습니다.
- #201/#202 merge 후 rebase/retarget해서 리뷰하는 것을 권장합니다.

## 관련 이슈

없음

## 테스트

- [x] `npm run test -- src/mcp/mcp.service.spec.ts src/tools/tools.service.spec.ts`
- [x] `npm test`
- [x] `npm run build`
