### PR TITLE
Feat/청소 배정 교환 기능 구현

### DIFF
--- a/src/cleaning/controller/cleaning-trade.controller.ts
+++ b/src/cleaning/controller/cleaning-trade.controller.ts
@@ -1,0 +1,462 @@
+import { Controller } from '@nestjs/common';
+import { Action, View } from 'nestjs-slack-bolt';
+import type {
+  AllMiddlewareArgs,
+  SlackActionMiddlewareArgs,
+  SlackViewMiddlewareArgs,
+  BlockAction,
+} from '@slack/bolt';
+import { CleaningTradeService } from '../service/cleaning-trade.service';
+import { CleaningRuleService } from '../service/cleaning-rule.service';
+import { CleaningTradeView } from '../view/cleaning-trade.view';
+import { PermissionService } from '../../user/service/permission.service';
+import { UserService } from '../../user/service/user.service';
+import { UserRole } from '../../user/user.entity';
+import { formatClassLabel } from '../../common/class-label.util';
+import { StudentClassStatus } from '../../student-class/student-class.entity';
+import { BusinessError, CleaningErrorCode } from '../../common/errors';
+
+@Controller()
+export class CleaningTradeController {
+  constructor(
+    private readonly cleaningTradeService: CleaningTradeService,
+    private readonly cleaningRuleService: CleaningRuleService,
+    private readonly permissionService: PermissionService,
+    private readonly userService: UserService,
+  ) {}
+
+  // 사용자의 예정 청소 배정 목록을 연다.
+  @Action('cleaning:my:open')
+  async openMyAssignments({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.userService.findBySlackId(body.user.id);
+    if (!user) return;
+
+    const assignments = await this.cleaningTradeService.getMyAssignments(
+      user.id,
+    );
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: CleaningTradeView.myAssignmentsModal(assignments),
+    });
+  }
+
+  // 사용자가 보낸 대기 중 교환 요청 목록을 연다.
+  @Action('cleaning:trade:open-requests')
+  async openPendingRequests({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.userService.findBySlackId(body.user.id);
+    if (!user) return;
+
+    const requests = await this.cleaningTradeService.getMyPendingRequests(
+      user.id,
+    );
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: CleaningTradeView.myPendingRequestsModal(requests),
+    });
+  }
+
+  @Action('cleaning:trade:cancel')
+  async cancelTrade({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { value: string };
+    const tradeId = parseInt(action.value, 10);
+    const user = await this.userService.findBySlackId(body.user.id);
+    if (!user) return;
+
+    await this.cleaningTradeService.cancelTrade(tradeId, user.id);
+
+    const requests = await this.cleaningTradeService.getMyPendingRequests(
+      user.id,
+    );
+    if (body.view?.id) {
+      await client.views.update({
+        view_id: body.view.id,
+        view: CleaningTradeView.myPendingRequestsModal(requests),
+      });
+    }
+  }
+
+  @Action('cleaning:trade:open')
+  async openTradeTarget({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { value: string };
+    const assignmentId = parseInt(action.value, 10);
+    const user = await this.userService.findBySlackId(body.user.id);
+    if (!user) return;
+
+    const [myAssignment, targets] = await Promise.all([
+      this.cleaningTradeService.getAssignmentDetail(assignmentId),
+      this.cleaningTradeService.getTradeTargets(assignmentId, user.id),
+    ]);
+    if (!myAssignment) return;
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningTradeView.tradeTargetModal(myAssignment, targets),
+    });
+  }
+
+  // 사용자가 선택한 상대 배정으로 교환 요청을 만들고 양쪽에 알린다.
+  @View('cleaning:modal:trade')
+  async handleTrade({
+    ack,
+    view,
+    body,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const myAssignmentId = parseInt(view.private_metadata, 10);
+    const targetAssignmentId = parseInt(
+      view.state.values.target_block.target_select.selected_option?.value ?? '',
+      10,
+    );
+
+    if (isNaN(targetAssignmentId)) {
+      await ack({
+        response_action: 'errors',
+        errors: { target_block: '대상을 선택해주세요.' },
+      });
+      return;
+    }
+
+    const user = await this.userService.findBySlackId(body.user.id);
+    if (!user) {
+      await ack();
+      return;
+    }
+
+    let tradeId: number;
+    try {
+      const trade = await this.cleaningTradeService.requestTrade(
+        myAssignmentId,
+        targetAssignmentId,
+      );
+      tradeId = trade.id;
+    } catch (e) {
+      if (
+        e instanceof BusinessError &&
+        e.code === CleaningErrorCode.TRADE_ALREADY_PENDING
+      ) {
+        await ack({
+          response_action: 'errors',
+          errors: { target_block: e.message },
+        });
+        return;
+      }
+      throw e;
+    }
+
+    await ack();
+
+    const details = await this.cleaningTradeService.getTradeWithDetails(
+      tradeId,
+    );
+    if (details) {
+      await Promise.allSettled([
+        client.chat.postMessage({
+          channel: details.target.userSlackId,
+          text: '청소 교환 요청이 도착했습니다.',
+          blocks: CleaningTradeView.tradeRequestBlocks(
+            details.requester,
+            details.target,
+            tradeId,
+          ),
+        }),
+        client.chat.postMessage({
+          channel: details.requester.userSlackId,
+          text: `교환 요청을 보냈습니다. *${details.target.cleaningDate}* (${details.target.resourceName}) — <@${details.target.userSlackId}>\n수락을 기다리는 중입니다.`,
+        }),
+      ]);
+    }
+
+    logger.info(`Trade ${tradeId} requested by ${body.user.id}`);
+  }
+
+  // 교환 요청 수락 시 실제 배정을 맞바꾸고 양쪽 메시지를 갱신한다.
+  @Action('cleaning:trade:accept')
+  async acceptTrade({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { value: string };
+    const tradeId = parseInt(action.value, 10);
+    const user = await this.userService.findBySlackId(body.user.id);
+    if (!user) return;
+
+    const details = await this.cleaningTradeService.getTradeWithDetails(
+      tradeId,
+    );
+
+    try {
+      await this.cleaningTradeService.respondTrade(tradeId, user.id, true);
+    } catch (e) {
+      if (
+        e instanceof BusinessError &&
+        (e.code === CleaningErrorCode.TRADE_FORBIDDEN ||
+          e.code === CleaningErrorCode.TRADE_NOT_PENDING ||
+          e.code === CleaningErrorCode.TRADE_DUPLICATE_ASSIGNEE)
+      ) {
+        await updateMessageOnError(client, body);
+        return;
+      }
+      throw e;
+    }
+
+    if (details) {
+      const { requester, target } = details;
+      const resultBlocks = CleaningTradeView.tradeResultBlocks(
+        requester,
+        target,
+        true,
+      );
+      const ch = (body as any).channel?.id;
+      const ts = (body as any).message?.ts;
+      await Promise.allSettled([
+        ch && ts
+          ? client.chat.update({
+              channel: ch,
+              ts,
+              text: '교환 수락됨 ✅',
+              blocks: resultBlocks,
+            })
+          : Promise.resolve(),
+        client.chat.postMessage({
+          channel: requester.userSlackId,
+          text: '교환 요청이 수락되었습니다.',
+          blocks: CleaningTradeView.tradeResultBlocks(requester, target, true, 'requester'),
+        }),
+      ]);
+    }
+  }
+
+  // 교환 요청 거절 시 요청자에게 결과를 알리고 원본 메시지를 갱신한다.
+  @Action('cleaning:trade:reject')
+  async rejectTrade({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const action = body.actions[0] as { value: string };
+    const tradeId = parseInt(action.value, 10);
+    const user = await this.userService.findBySlackId(body.user.id);
+    if (!user) return;
+
+    const details = await this.cleaningTradeService.getTradeWithDetails(
+      tradeId,
+    );
+
+    try {
+      await this.cleaningTradeService.respondTrade(tradeId, user.id, false);
+    } catch (e) {
+      if (
+        e instanceof BusinessError &&
+        (e.code === CleaningErrorCode.TRADE_FORBIDDEN ||
+          e.code === CleaningErrorCode.TRADE_NOT_PENDING)
+      ) {
+        await updateMessageOnError(client, body);
+        return;
+      }
+      throw e;
+    }
+
+    if (details) {
+      const { requester, target } = details;
+      const resultBlocks = CleaningTradeView.tradeResultBlocks(
+        requester,
+        target,
+        false,
+      );
+      const ch = (body as any).channel?.id;
+      const ts = (body as any).message?.ts;
+      await Promise.allSettled([
+        ch && ts
+          ? client.chat.update({
+              channel: ch,
+              ts,
+              text: '교환 거절됨 ❌',
+              blocks: resultBlocks,
+            })
+          : Promise.resolve(),
+        client.chat.postMessage({
+          channel: requester.userSlackId,
+          text: '교환 요청이 거절되었습니다.',
+          blocks: CleaningTradeView.tradeResultBlocks(requester, target, false, 'requester', target.userSlackId),
+        }),
+      ]);
+    }
+  }
+
+  @Action('cleaning:swap:open')
+  async openSwapManageList({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireAdminOrClassRep(
+      body.user.id,
+    );
+    const classId =
+      user.role === UserRole.CLASS_REP ? user.studentClassId : undefined;
+    const rules = await this.cleaningRuleService.findAllWithDetails(classId);
+
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: CleaningTradeView.swapManageListModal(rules),
+    });
+  }
+
+  @Action('cleaning:swap:open-select')
+  async openSwapSelect({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    await this.permissionService.requireAdminOrClassRep(body.user.id);
+    const action = body.actions[0] as { value: string };
+    const ruleId = parseInt(action.value, 10);
+
+    const [rule, assignments] = await Promise.all([
+      this.cleaningRuleService.findOneWithDetails(ruleId),
+      this.cleaningTradeService.getAssignmentsByRule(ruleId),
+    ]);
+    if (!rule) return;
+
+    const ruleLabel = formatClassLabel({
+      admissionYear: rule.studentClass.admissionYear,
+      section: rule.studentClass.section,
+      graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+    });
+
+    await client.views.push({
+      trigger_id: body.trigger_id,
+      view: CleaningTradeView.swapSelectModal(assignments, ruleLabel),
+    });
+  }
+
+  // 관리자가 두 배정을 직접 맞바꾸고 당사자에게 알린다.
+  @View('cleaning:modal:swap')
+  async handleSwap({
+    ack,
+    view,
+    body,
+    client,
+    logger,
+  }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
+    const firstId = parseInt(
+      view.state.values.first_block.first_select.selected_option?.value ?? '',
+      10,
+    );
+    const secondId = parseInt(
+      view.state.values.second_block.second_select.selected_option?.value ?? '',
+      10,
+    );
+
+    if (isNaN(firstId) || isNaN(secondId)) {
+      await ack({
+        response_action: 'errors',
+        errors: { first_block: '배정을 선택해주세요.' },
+      });
+      return;
+    }
+    if (firstId === secondId) {
+      await ack({
+        response_action: 'errors',
+        errors: { second_block: '서로 다른 배정을 선택하세요.' },
+      });
+      return;
+    }
+
+    const [a1, a2] = await Promise.all([
+      this.cleaningTradeService.getAssignmentDetail(firstId),
+      this.cleaningTradeService.getAssignmentDetail(secondId),
+    ]);
+
+    try {
+      await this.cleaningTradeService.swapAssignments(firstId, secondId);
+    } catch (e) {
+      if (
+        e instanceof BusinessError &&
+        (e.code === CleaningErrorCode.TRADE_SAME_SCHEDULE ||
+          e.code === CleaningErrorCode.TRADE_DUPLICATE_ASSIGNEE)
+      ) {
+        await ack({
+          response_action: 'errors',
+          errors: { second_block: e.message },
+        });
+        return;
+      }
+      throw e;
+    }
+
+    await ack();
+
+    if (a1 && a2) {
+      await Promise.allSettled([
+        client.chat.postMessage({
+          channel: a1.userSlackId,
+          text: `🔄 *${a1.cleaningDate}* → *${a2.cleaningDate}* | ${a1.resourceName}\n관리자에 의해 청소 배정이 교환되었습니다.`,
+        }),
+        client.chat.postMessage({
+          channel: a2.userSlackId,
+          text: `🔄 *${a2.cleaningDate}* → *${a1.cleaningDate}* | ${a2.resourceName}\n관리자에 의해 청소 배정이 교환되었습니다.`,
+        }),
+      ]);
+    }
+
+    logger.info(
+      `Swap executed by ${body.user.id}: assignment ${firstId} <-> ${secondId}`,
+    );
+  }
+}
+
+async function updateMessageOnError(client: any, body: any): Promise<void> {
+  const ch = body.channel?.id;
+  const ts = body.message?.ts;
+  if (ch && ts) {
+    await client.chat.update({
+      channel: ch,
+      ts,
+      text: '청소 배정이 변경되어 교환 요청을 처리할 수 없습니다.',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '청소 배정이 변경되어 교환 요청을 처리할 수 없습니다.',
+          },
+        },
+      ],
+    });
+  }
+}

--- a/src/cleaning/service/cleaning-trade.service.ts
+++ b/src/cleaning/service/cleaning-trade.service.ts
@@ -1,0 +1,455 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  CleaningAssignment,
+  CleaningAssignmentStatus,
+} from '../entity/cleaning-assignment.entity';
+import { CleaningTrade, CleaningTradeStatus } from '../entity/cleaning-trade.entity';
+import { CleaningSchedule, CleaningScheduleStatus } from '../entity/cleaning-schedule.entity';
+import { CleaningRule } from '../entity/cleaning-rule.entity';
+import { CleaningRuleUser } from '../entity/cleaning-rule-user.entity';
+import { BusinessError, CleaningErrorCode } from '../../common/errors';
+
+export interface AssignmentDetail {
+  id: number;
+  scheduleId: number;
+  userId: number;
+  userName: string;
+  userCode?: string;
+  userSlackId: string;
+  cleaningDate: string;
+  resourceName: string;
+  coAssignees?: string[];
+}
+
+@Injectable()
+export class CleaningTradeService {
+  constructor(
+    @InjectRepository(CleaningAssignment)
+    private readonly assignmentRepo: Repository<CleaningAssignment>,
+    @InjectRepository(CleaningTrade)
+    private readonly tradeRepo: Repository<CleaningTrade>,
+    @InjectRepository(CleaningSchedule)
+    private readonly scheduleRepo: Repository<CleaningSchedule>,
+    @InjectRepository(CleaningRule)
+    private readonly ruleRepo: Repository<CleaningRule>,
+    @InjectRepository(CleaningRuleUser)
+    private readonly ruleUserRepo: Repository<CleaningRuleUser>,
+  ) {}
+
+  // 내 예정 배정만 조회하고, 같은 일정의 다른 담당자 이름도 함께 보여준다.
+  async getMyAssignments(userId: number): Promise<AssignmentDetail[]> {
+    const today = localTodayStr();
+    const rows = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .innerJoin('a.schedule', 's')
+      .innerJoin('s.rule', 'r')
+      .innerJoin('a.user', 'u')
+      .leftJoin('r.ruleResource', 'rr')
+      .leftJoin('rr.resource', 'res')
+      .select([
+        'a.id AS id',
+        'a.scheduleId AS "scheduleId"',
+        'a.userId AS "userId"',
+        'u.name AS "userName"',
+        'u.code AS "userCode"',
+        'u.slackId AS "userSlackId"',
+        's.cleaningDate AS "cleaningDate"',
+        'res.name AS "resourceName"',
+      ])
+      .where('a.userId = :userId', { userId })
+      .andWhere('a.status = :status', { status: CleaningAssignmentStatus.ASSIGNED })
+      .andWhere('s.cleaningDate >= :today', { today })
+      .andWhere('s.status = :schedStatus', { schedStatus: CleaningScheduleStatus.SCHEDULED })
+      .andWhere('r.deletedAt IS NULL')
+      .orderBy('s.cleaningDate', 'ASC')
+      .getRawMany<{
+        id: number;
+        scheduleId: number;
+        userId: number;
+        userName: string;
+        userCode: string;
+        userSlackId: string;
+        cleaningDate: string;
+        resourceName: string;
+      }>();
+
+    const result: AssignmentDetail[] = [];
+    for (const row of rows) {
+      const coAssignees = await this.getCoAssigneeNames(row.scheduleId, userId);
+      result.push({
+        id: Number(row.id),
+        scheduleId: Number(row.scheduleId),
+        userId: Number(row.userId),
+        userName: row.userName,
+        userCode: row.userCode ?? undefined,
+        userSlackId: row.userSlackId,
+        cleaningDate: toDateStr(row.cleaningDate),
+        resourceName: row.resourceName ?? '미지정',
+        coAssignees,
+      });
+    }
+    return result;
+  }
+
+  // 요청자가 보낸 PENDING 교환만 모아 요청/대상 배정 정보를 함께 반환한다.
+  async getMyPendingRequests(userId: number): Promise<
+    {
+      trade: { id: number };
+      myAssignment: AssignmentDetail;
+      targetAssignment: AssignmentDetail;
+    }[]
+  > {
+    const trades = await this.tradeRepo
+      .createQueryBuilder('t')
+      .innerJoin('t.requesterAssignment', 'ra')
+      .where('ra.userId = :userId', { userId })
+      .andWhere('t.status = :status', { status: CleaningTradeStatus.PENDING })
+      .select('t.id')
+      .getRawMany<{ t_id: number }>();
+
+    const result: { trade: { id: number }; myAssignment: AssignmentDetail; targetAssignment: AssignmentDetail }[] = [];
+    for (const { t_id } of trades) {
+      const detail = await this.getTradeWithDetails(t_id);
+      if (detail)
+        result.push({
+          trade: { id: t_id },
+          myAssignment: detail.requester,
+          targetAssignment: detail.target,
+        });
+    }
+    return result;
+  }
+
+  // 이미 같은 일정에 있는 유저나 대기 중인 교환 배정은 교환 후보에서 제외한다.
+  async getTradeTargets(
+    assignmentId: number,
+    myUserId: number,
+  ): Promise<AssignmentDetail[]> {
+    const myAssignment = await this.assignmentRepo.findOne({
+      where: { id: assignmentId },
+    });
+    if (!myAssignment) return [];
+
+    const today = localTodayStr();
+
+    // 요청자의 일정에 이미 있는 유저 ID 목록
+    const myScheduleUsers = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .select('a.userId', 'userId')
+      .where('a.scheduleId = :schedId', { schedId: myAssignment.scheduleId })
+      .andWhere('a.status != :canceled', { canceled: CleaningAssignmentStatus.CANCELED })
+      .getRawMany<{ userId: number }>();
+    const myScheduleUserIds = new Set(myScheduleUsers.map((r) => Number(r.userId)));
+
+    // 이미 처리 대기 중인 배정은 중복 교환 요청을 막기 위해 후보에서 제외한다.
+    const pendingTrades = await this.tradeRepo
+      .createQueryBuilder('t')
+      .select(['t.requesterAssignmentId', 't.targetAssignmentId'])
+      .where('t.status = :status', { status: CleaningTradeStatus.PENDING })
+      .getRawMany<{ t_requesterAssignmentId: number; t_targetAssignmentId: number }>();
+    const pendingIds = new Set<number>();
+    for (const { t_requesterAssignmentId, t_targetAssignmentId } of pendingTrades) {
+      pendingIds.add(Number(t_requesterAssignmentId));
+      pendingIds.add(Number(t_targetAssignmentId));
+    }
+
+    const rows = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .innerJoin('a.schedule', 's')
+      .innerJoin('s.rule', 'r')
+      .innerJoin('a.user', 'u')
+      .leftJoin('r.ruleResource', 'rr')
+      .leftJoin('rr.resource', 'res')
+      .select([
+        'a.id AS id',
+        'a.scheduleId AS "scheduleId"',
+        'a.userId AS "userId"',
+        'u.name AS "userName"',
+        'u.code AS "userCode"',
+        'u.slackId AS "userSlackId"',
+        's.cleaningDate AS "cleaningDate"',
+        'res.name AS "resourceName"',
+      ])
+      .where('a.status = :status', { status: CleaningAssignmentStatus.ASSIGNED })
+      .andWhere('a.scheduleId != :mySchedule', { mySchedule: myAssignment.scheduleId })
+      .andWhere('s.cleaningDate >= :today', { today })
+      .andWhere('s.status = :schedStatus', { schedStatus: CleaningScheduleStatus.SCHEDULED })
+      .andWhere('r.deletedAt IS NULL')
+      .orderBy('s.cleaningDate', 'ASC')
+      .getRawMany<{
+        id: number;
+        scheduleId: number;
+        userId: number;
+        userName: string;
+        userCode: string;
+        userSlackId: string;
+        cleaningDate: string;
+        resourceName: string;
+      }>();
+
+    return rows
+      .filter(
+        (r) =>
+          !pendingIds.has(Number(r.id)) &&
+          // 교환 후 내 일정에 같은 사람이 중복 배정되는 후보도 제외한다.
+          !myScheduleUserIds.has(Number(r.userId)),
+      )
+      .map((r) => ({
+        id: Number(r.id),
+        scheduleId: Number(r.scheduleId),
+        userId: Number(r.userId),
+        userName: r.userName,
+        userCode: r.userCode ?? undefined,
+        userSlackId: r.userSlackId,
+        cleaningDate: toDateStr(r.cleaningDate),
+        resourceName: r.resourceName ?? '미지정',
+      }));
+  }
+
+  // 같은 대상에 대해 이미 대기 중인 요청이 있으면 중복 요청을 만들지 않는다.
+  async requestTrade(
+    requesterAssignmentId: number,
+    targetAssignmentId: number,
+  ): Promise<CleaningTrade> {
+    const existing = await this.tradeRepo.findOne({
+      where: {
+        requesterAssignmentId,
+        targetAssignmentId,
+        status: CleaningTradeStatus.PENDING,
+      },
+    });
+    if (existing) throw new BusinessError(CleaningErrorCode.TRADE_ALREADY_PENDING);
+
+    return this.tradeRepo.save(
+      this.tradeRepo.create({
+        requesterAssignmentId,
+        targetAssignmentId,
+        status: CleaningTradeStatus.PENDING,
+      }),
+    );
+  }
+
+  // 수락 시 실제 배정의 userId를 맞바꾸고, 거절 시 요청 상태만 변경한다.
+  async respondTrade(
+    tradeId: number,
+    targetUserId: number,
+    accept: boolean,
+  ): Promise<void> {
+    const trade = await this.tradeRepo.findOne({ where: { id: tradeId } });
+    if (!trade) throw new BusinessError(CleaningErrorCode.TRADE_NOT_FOUND);
+    if (trade.status !== CleaningTradeStatus.PENDING)
+      throw new BusinessError(CleaningErrorCode.TRADE_NOT_PENDING);
+
+    // 대상 배정의 담당자만 수락/거절할 수 있다.
+    const targetAssignment = await this.assignmentRepo.findOne({
+      where: { id: trade.targetAssignmentId },
+    });
+    if (!targetAssignment || targetAssignment.userId !== targetUserId)
+      throw new BusinessError(CleaningErrorCode.TRADE_FORBIDDEN);
+
+    if (!accept) {
+      await this.tradeRepo.update(tradeId, { status: CleaningTradeStatus.REJECTED });
+      return;
+    }
+
+    await this.swapAssignments(
+      trade.requesterAssignmentId,
+      trade.targetAssignmentId,
+    );
+    await this.tradeRepo.update(tradeId, { status: CleaningTradeStatus.ACCEPTED });
+  }
+
+  // 두 배정의 담당자를 바꾸기 전에 같은 일정/중복 담당자 충돌을 먼저 막는다.
+  async swapAssignments(id1: number, id2: number): Promise<void> {
+    const [a1, a2] = await Promise.all([
+      this.assignmentRepo.findOne({ where: { id: id1 } }),
+      this.assignmentRepo.findOne({ where: { id: id2 } }),
+    ]);
+    if (!a1 || !a2) throw new BusinessError(CleaningErrorCode.ASSIGNMENT_NOT_FOUND);
+    if (a1.scheduleId === a2.scheduleId)
+      throw new BusinessError(CleaningErrorCode.TRADE_SAME_SCHEDULE);
+
+    // 스왑 후 같은 일정에 같은 유저가 두 번 배정되는지 체크한다.
+    const [conflict1, conflict2] = await Promise.all([
+      this.assignmentRepo.findOne({
+        where: { scheduleId: a2.scheduleId, userId: a1.userId },
+      }),
+      this.assignmentRepo.findOne({
+        where: { scheduleId: a1.scheduleId, userId: a2.userId },
+      }),
+    ]);
+    if (conflict1 || conflict2)
+      throw new BusinessError(CleaningErrorCode.TRADE_DUPLICATE_ASSIGNEE);
+
+    // 두 배정과 관련된 다른 PENDING 교환은 스왑 이후 의미가 없어져 취소한다.
+    await this.tradeRepo
+      .createQueryBuilder()
+      .update(CleaningTrade)
+      .set({ status: CleaningTradeStatus.CANCELED })
+      .where('status = :status', { status: CleaningTradeStatus.PENDING })
+      .andWhere(
+        '(requesterAssignmentId IN (:...ids) OR targetAssignmentId IN (:...ids))',
+        { ids: [id1, id2] },
+      )
+      .execute();
+
+    // assignment 자체는 유지하고 담당 userId만 교환한다.
+    await Promise.all([
+      this.assignmentRepo.update(id1, { userId: a2.userId }),
+      this.assignmentRepo.update(id2, { userId: a1.userId }),
+    ]);
+  }
+
+  // 알림/모달에서 공통으로 쓰는 배정 상세 정보를 조인해서 가져온다.
+  async getAssignmentDetail(
+    assignmentId: number,
+  ): Promise<AssignmentDetail | null> {
+    const row = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .innerJoin('a.schedule', 's')
+      .innerJoin('a.user', 'u')
+      .leftJoin('s.rule', 'r')
+      .leftJoin('r.ruleResource', 'rr')
+      .leftJoin('rr.resource', 'res')
+      .select([
+        'a.id AS id',
+        'a.scheduleId AS "scheduleId"',
+        'a.userId AS "userId"',
+        'u.name AS "userName"',
+        'u.code AS "userCode"',
+        'u.slackId AS "userSlackId"',
+        's.cleaningDate AS "cleaningDate"',
+        'res.name AS "resourceName"',
+      ])
+      .where('a.id = :id', { id: assignmentId })
+      .getRawOne<{
+        id: number;
+        scheduleId: number;
+        userId: number;
+        userName: string;
+        userCode: string;
+        userSlackId: string;
+        cleaningDate: string;
+        resourceName: string;
+      }>();
+
+    if (!row) return null;
+    return {
+      id: Number(row.id),
+      scheduleId: Number(row.scheduleId),
+      userId: Number(row.userId),
+      userName: row.userName,
+      userCode: row.userCode ?? undefined,
+      userSlackId: row.userSlackId,
+      cleaningDate: toDateStr(row.cleaningDate),
+      resourceName: row.resourceName ?? '미지정',
+    };
+  }
+
+  // 관리자가 직접 교환할 수 있도록 특정 규칙의 예정 배정만 조회한다.
+  async getAssignmentsByRule(ruleId: number): Promise<AssignmentDetail[]> {
+    const today = localTodayStr();
+    const rows = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .innerJoin('a.schedule', 's')
+      .innerJoin('a.user', 'u')
+      .innerJoin('s.rule', 'r')
+      .leftJoin('r.ruleResource', 'rr')
+      .leftJoin('rr.resource', 'res')
+      .select([
+        'a.id AS id',
+        'a.scheduleId AS "scheduleId"',
+        'a.userId AS "userId"',
+        'u.name AS "userName"',
+        'u.code AS "userCode"',
+        'u.slackId AS "userSlackId"',
+        's.cleaningDate AS "cleaningDate"',
+        'res.name AS "resourceName"',
+      ])
+      .where('s.ruleId = :ruleId', { ruleId })
+      .andWhere('a.status = :status', { status: CleaningAssignmentStatus.ASSIGNED })
+      .andWhere('s.cleaningDate >= :today', { today })
+      .andWhere('s.status = :schedStatus', { schedStatus: CleaningScheduleStatus.SCHEDULED })
+      .orderBy('s.cleaningDate', 'ASC')
+      .getRawMany<{
+        id: number;
+        scheduleId: number;
+        userId: number;
+        userName: string;
+        userCode: string;
+        userSlackId: string;
+        cleaningDate: string;
+        resourceName: string;
+      }>();
+
+    return rows.map((r) => ({
+      id: Number(r.id),
+      scheduleId: Number(r.scheduleId),
+      userId: Number(r.userId),
+      userName: r.userName,
+      userCode: r.userCode ?? undefined,
+      userSlackId: r.userSlackId,
+      cleaningDate: toDateStr(r.cleaningDate),
+      resourceName: r.resourceName ?? '미지정',
+    }));
+  }
+
+  async getTradeWithDetails(
+    tradeId: number,
+  ): Promise<{ requester: AssignmentDetail; target: AssignmentDetail } | null> {
+    const trade = await this.tradeRepo.findOne({ where: { id: tradeId } });
+    if (!trade) return null;
+
+    const [requester, target] = await Promise.all([
+      this.getAssignmentDetail(trade.requesterAssignmentId),
+      this.getAssignmentDetail(trade.targetAssignmentId),
+    ]);
+    if (!requester || !target) return null;
+    return { requester, target };
+  }
+
+  async cancelTrade(tradeId: number, userId: number): Promise<void> {
+    const trade = await this.tradeRepo.findOne({ where: { id: tradeId } });
+    if (!trade) throw new BusinessError(CleaningErrorCode.TRADE_NOT_FOUND);
+    if (trade.status !== CleaningTradeStatus.PENDING)
+      throw new BusinessError(CleaningErrorCode.TRADE_NOT_PENDING);
+
+    const requester = await this.assignmentRepo.findOne({
+      where: { id: trade.requesterAssignmentId },
+    });
+    if (!requester || requester.userId !== userId)
+      throw new BusinessError(CleaningErrorCode.TRADE_FORBIDDEN);
+
+    await this.tradeRepo.update(tradeId, { status: CleaningTradeStatus.CANCELED });
+  }
+
+  private async getCoAssigneeNames(
+    scheduleId: number,
+    excludeUserId: number,
+  ): Promise<string[]> {
+    const rows = await this.assignmentRepo
+      .createQueryBuilder('a')
+      .innerJoin('a.user', 'u')
+      .select('u.name', 'name')
+      .where('a.scheduleId = :scheduleId', { scheduleId })
+      .andWhere('a.userId != :excludeUserId', { excludeUserId })
+      .andWhere('a.status = :status', { status: CleaningAssignmentStatus.ASSIGNED })
+      .getRawMany<{ name: string }>();
+    return rows.map((r) => r.name);
+  }
+}
+
+function toDateStr(date: Date | string): string {
+  if (!(date instanceof Date)) return String(date);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function localTodayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/src/cleaning/view/cleaning-trade.view.ts
+++ b/src/cleaning/view/cleaning-trade.view.ts
@@ -1,0 +1,386 @@
+import type { View, KnownBlock } from '@slack/types';
+import { DAY_LABELS, ruleInfoText } from './cleaning-rule.view';
+import { AssignmentDetail } from '../service/cleaning-trade.service';
+import { RuleWithDetails } from '../service/cleaning-rule.service';
+
+export class CleaningTradeView {
+  // 일반 사용자가 자신의 예정 배정을 확인하고 교환 요청으로 진입하는 모달.
+  static myAssignmentsModal(assignments: AssignmentDetail[]): View {
+    const blocks: View['blocks'] = [];
+
+    if (assignments.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '배정된 청소 일정이 없습니다.' },
+      });
+    } else {
+      for (const a of assignments) {
+        const [year, month, day] = a.cleaningDate.split('-').map(Number);
+        const dayOfWeek = DAY_LABELS[new Date(year, month - 1, day).getDay()];
+        const coText =
+          a.coAssignees && a.coAssignees.length > 0
+            ? `\n함께하는 인원: ${a.coAssignees.join(', ')}`
+            : '';
+        blocks.push(
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*${a.cleaningDate} (${dayOfWeek})* | ${a.resourceName}${coText}`,
+            },
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: '교환 요청' },
+              action_id: 'cleaning:trade:open',
+              value: String(a.id),
+            },
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:my-assignments',
+      title: { type: 'plain_text', text: '내 청소 배정' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  static myPendingRequestsModal(
+    requests: {
+      trade: { id: number };
+      myAssignment: AssignmentDetail;
+      targetAssignment: AssignmentDetail;
+    }[],
+  ): View {
+    const blocks: View['blocks'] = [];
+
+    if (requests.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '대기 중인 교환 요청이 없습니다.' },
+      });
+    } else {
+      for (const { trade, myAssignment, targetAssignment } of requests) {
+        const [myY, myM, myD] = myAssignment.cleaningDate.split('-').map(Number);
+        const [tgtY, tgtM, tgtD] = targetAssignment.cleaningDate
+          .split('-')
+          .map(Number);
+        const myDay = DAY_LABELS[new Date(myY, myM - 1, myD).getDay()];
+        const tgtDay = DAY_LABELS[new Date(tgtY, tgtM - 1, tgtD).getDay()];
+
+        blocks.push(
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: [
+                `*내 배정:* ${myAssignment.cleaningDate} (${myDay}) — ${myAssignment.resourceName}`,
+                `*상대방:* ${targetAssignment.userName}${targetAssignment.userCode ? ` (${targetAssignment.userCode})` : ''} | ${targetAssignment.cleaningDate} (${tgtDay})`,
+              ].join('\n'),
+            },
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: '취소' },
+              action_id: 'cleaning:trade:cancel',
+              value: String(trade.id),
+              style: 'danger',
+              confirm: {
+                title: { type: 'plain_text', text: '요청 취소' },
+                text: {
+                  type: 'mrkdwn',
+                  text: '이 교환 요청을 취소하시겠습니까?',
+                },
+                confirm: { type: 'plain_text', text: '취소하기' },
+                deny: { type: 'plain_text', text: '닫기' },
+              },
+            },
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:pending-requests',
+      title: { type: 'plain_text', text: '교환 요청 현황' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  // 현재 배정과 교환 가능한 다른 배정만 선택지로 노출한다.
+  static tradeTargetModal(
+    myAssignment: AssignmentDetail,
+    targets: AssignmentDetail[],
+  ): View {
+    if (targets.length === 0) {
+      return {
+        type: 'modal',
+        callback_id: 'cleaning:modal:trade-no-target',
+        title: { type: 'plain_text', text: '교환 요청' },
+        close: { type: 'plain_text', text: '닫기' },
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*${myAssignment.cleaningDate}* (${myAssignment.resourceName}) 날짜와 교환 가능한 배정이 없습니다.`,
+            },
+          },
+        ],
+      };
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:trade',
+      private_metadata: String(myAssignment.id),
+      title: { type: 'plain_text', text: '교환 요청' },
+      submit: { type: 'plain_text', text: '요청 보내기' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `내 배정: *${myAssignment.cleaningDate}* (${myAssignment.resourceName})\n교환할 상대방의 배정을 선택하세요.`,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'target_block',
+          label: { type: 'plain_text', text: '교환 대상' },
+          element: {
+            type: 'static_select',
+            action_id: 'target_select',
+            placeholder: { type: 'plain_text', text: '배정을 선택하세요' },
+            options: targets.map((t) => ({
+              text: {
+                type: 'plain_text' as const,
+                text: `${t.cleaningDate} — ${t.userName}${t.userCode ? ` (${t.userCode})` : ''}`,
+              },
+              value: String(t.id),
+            })),
+          },
+        },
+      ],
+    };
+  }
+
+  static tradeRequestBlocks(
+    requester: AssignmentDetail,
+    target: AssignmentDetail,
+    tradeId: number,
+  ): KnownBlock[] {
+    return [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: [
+            `*청소 교환 요청*`,
+            `<@${requester.userSlackId}>님이 청소 배정 교환을 요청했습니다.`,
+            ``,
+            `*요청자 날짜:* ${requester.cleaningDate} (${requester.resourceName})`,
+            `*내 날짜:* ${target.cleaningDate} (${target.resourceName})`,
+          ].join('\n'),
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '수락' },
+            style: 'primary',
+            action_id: 'cleaning:trade:accept',
+            value: String(tradeId),
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '거절' },
+            style: 'danger',
+            action_id: 'cleaning:trade:reject',
+            value: String(tradeId),
+          },
+        ],
+      },
+    ];
+  }
+
+  // 요청자/대상자 관점에 따라 교환 결과 메시지의 기준 날짜를 바꿔 보여준다.
+  static tradeResultBlocks(
+    requester: AssignmentDetail,
+    target: AssignmentDetail,
+    accepted: boolean,
+    perspective: 'requester' | 'target' = 'target',
+    rejectorSlackId?: string,
+  ): KnownBlock[] {
+    const status = accepted ? '수락됨 ✅' : '거절됨 ❌';
+    const [myAssignment, otherAssignment, otherLabel] =
+      perspective === 'requester'
+        ? [requester, target, '상대방 날짜']
+        : [target, requester, '요청자 날짜'];
+    const lines = [`*청소 교환 요청 — ${status}*`];
+    if (!accepted) {
+      if (rejectorSlackId) {
+        lines.push(``, `<@${rejectorSlackId}>님이 교환 요청을 거절했습니다.`);
+      }
+    } else {
+      lines.push(
+        ``,
+        `*${myAssignment.cleaningDate}* (${myAssignment.resourceName}) → *${otherAssignment.cleaningDate}* (${otherAssignment.resourceName})`,
+      );
+    }
+    return [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: lines.join('\n') },
+      },
+    ];
+  }
+
+  static swapManageListModal(rules: RuleWithDetails[]): View {
+    const blocks: View['blocks'] = [];
+
+    if (rules.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: '등록된 청소 규칙이 없습니다.' },
+      });
+    } else {
+      for (const rule of rules) {
+        blocks.push(
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: ruleInfoText(rule) },
+            accessory: {
+              type: 'button',
+              text: { type: 'plain_text', text: '교환' },
+              action_id: 'cleaning:swap:open-select',
+              value: String(rule.id),
+            },
+          },
+          { type: 'divider' },
+        );
+      }
+    }
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:swap-list',
+      title: { type: 'plain_text', text: '배정 교환' },
+      close: { type: 'plain_text', text: '닫기' },
+      blocks,
+    };
+  }
+
+  // 관리자 직접 교환은 실제로 충돌 없이 맞바꿀 수 있는 배정만 후보로 보여준다.
+  static swapSelectModal(
+    assignments: AssignmentDetail[],
+    ruleLabel: string,
+  ): View {
+    if (assignments.length < 2) {
+      return {
+        type: 'modal',
+        callback_id: 'cleaning:modal:swap-no-target',
+        title: { type: 'plain_text', text: '배정 교환' },
+        close: { type: 'plain_text', text: '닫기' },
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*${ruleLabel}* 규칙에 교환 가능한 배정이 부족합니다. (최소 2개 필요)`,
+            },
+          },
+        ],
+      };
+    }
+
+    const assignedSet = new Set(
+      assignments.map((a) => `${a.userId}:${a.scheduleId}`),
+    );
+    const isSwappable = (i: AssignmentDetail, j: AssignmentDetail) => {
+      if (i.id === j.id) return false;
+      if (i.scheduleId === j.scheduleId) return false;
+      return (
+        !assignedSet.has(`${i.userId}:${j.scheduleId}`) &&
+        !assignedSet.has(`${j.userId}:${i.scheduleId}`)
+      );
+    };
+    const swappable = assignments.filter((a) =>
+      assignments.some((b) => isSwappable(a, b)),
+    );
+
+    if (swappable.length < 2) {
+      return {
+        type: 'modal',
+        callback_id: 'cleaning:modal:swap-no-target',
+        title: { type: 'plain_text', text: '배정 교환' },
+        close: { type: 'plain_text', text: '닫기' },
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*${ruleLabel}* 규칙에 교환 가능한 배정이 없습니다.`,
+            },
+          },
+        ],
+      };
+    }
+
+    const options = swappable.map((a) => ({
+      text: {
+        type: 'plain_text' as const,
+        text: `${a.cleaningDate} — ${a.userName}${a.userCode ? ` (${a.userCode})` : ''}`,
+      },
+      value: String(a.id),
+    }));
+
+    return {
+      type: 'modal',
+      callback_id: 'cleaning:modal:swap',
+      title: { type: 'plain_text', text: `배정 교환` },
+      submit: { type: 'plain_text', text: '교환' },
+      close: { type: 'plain_text', text: '취소' },
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${ruleLabel}* 규칙에서 교환할 두 배정을 선택하세요.`,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'first_block',
+          label: { type: 'plain_text', text: '첫 번째 배정' },
+          element: {
+            type: 'static_select',
+            action_id: 'first_select',
+            placeholder: { type: 'plain_text', text: '배정을 선택하세요' },
+            options,
+          },
+        },
+        {
+          type: 'input',
+          block_id: 'second_block',
+          label: { type: 'plain_text', text: '두 번째 배정' },
+          element: {
+            type: 'static_select',
+            action_id: 'second_select',
+            placeholder: { type: 'plain_text', text: '배정을 선택하세요' },
+            options,
+          },
+        },
+      ],
+    };
+  }
+}

--- a/src/resource/resource.module.ts
+++ b/src/resource/resource.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Resource } from './resource.entity';
 import { ResourceService } from './service/resource.service';
@@ -13,7 +13,7 @@ import { UserModule } from '../user/user.module';
 import { GoogleModule } from '../google/google.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Resource]), UserModule, GoogleModule],
+  imports: [TypeOrmModule.forFeature([Resource]), forwardRef(() => UserModule), GoogleModule],
   controllers: [
     ResourceController,
     StudyRoomController,

--- a/src/user/controller/user-admin.controller.ts
+++ b/src/user/controller/user-admin.controller.ts
@@ -14,6 +14,7 @@ import { UserRole, UserStatus } from '../user.entity';
 import { BusinessError, UserErrorCode } from '../../common/errors';
 import { StudentClassService } from '../../student-class/student-class.service';
 import { PermissionService } from '../service/permission.service';
+import { CleaningScheduleService } from '../../cleaning/service/cleaning-schedule.service';
 
 const PAGE_SIZE = 10;
 
@@ -25,6 +26,7 @@ export class UserAdminController {
     private readonly slackService: SlackService,
     private readonly studentClassService: StudentClassService,
     private readonly permissionService: PermissionService,
+    private readonly cleaningScheduleService: CleaningScheduleService,
   ) {}
 
   // 승인 대기 목록 모달 열기
@@ -308,6 +310,8 @@ export class UserAdminController {
 
     await ack();
 
+    const userBefore = await this.userService.findBySlackId(targetSlackId);
+
     await this.userAdminService.updateUserInfo(targetSlackId, {
       name,
       code,
@@ -315,6 +319,12 @@ export class UserAdminController {
       studentClassId,
       status,
     });
+
+    // 유저 비활성화 시 예정된 청소 배정도 남은 담당자 기준으로 재조정한다.
+    if (status === UserStatus.INACTIVE && userBefore?.status !== UserStatus.INACTIVE) {
+      const user = await this.userService.findBySlackId(targetSlackId);
+      if (user) await this.cleaningScheduleService.handleUserDeactivation(user.id);
+    }
 
     await client.chat.postMessage({
       channel: targetSlackId,

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserService } from './service/user.service';
 import { UserAdminService } from './service/user-admin.service';
@@ -10,9 +10,11 @@ import { UserClassRepController } from './controller/user-class-rep.controller';
 import { User } from './user.entity';
 import { StudentClassModule } from '../student-class/student-class.module';
 import { GoogleModule } from '../google/google.module';
+import { CleaningModule } from '../cleaning/cleaning.module';
 
+// 유저 비활성화 시 청소 배정 정리를 호출하므로 CleaningModule과 순환 참조가 생긴다.
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), StudentClassModule, GoogleModule],
+  imports: [TypeOrmModule.forFeature([User]), StudentClassModule, GoogleModule, forwardRef(() => CleaningModule)],
   controllers: [UserController, UserAdminController, UserClassRepController],
   providers: [
     UserService,


### PR DESCRIPTION
## 개요
본인의 청소 배정을 다른 사용자와 교환할 수 있도록 기능을 구현했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->

## 주요 변경 사항
### 청소 교환 요청 기능 추가
- 사용자가 본인에게 배정된 청소 일정에 대해 교환 요청을 생성할 수 있도록 구현
- 교환 대상 배정을 선택할 수 있는 Slack 모달 추가
- 이미 진행 중인 교환 요청이 있는 경우 중복 요청을 방지하도록 처리

### 청소 교환 처리 로직 추가
- 교환 요청 수락 시 요청자와 대상자의 청소 배정을 서로 교체하도록 구현
- 교환 요청 거절 및 취소 기능 추가
- 교환 완료 후 관련 요청 상태가 올바르게 변경되도록 처리

### 청소 교환 화면 추가
- Slack Home / 모달에서 청소 교환 목록을 조회할 수 있도록 구현
- 요청 상태에 따라 대기, 수락, 거절, 취소 상태를 표시
- 사용자가 처리 가능한 교환 요청에 대해서만 액션 버튼을 노출

### 예외 처리 추가
- 존재하지 않는 청소 배정 또는 교환 요청에 대한 예외 처리 추가
- 이미 처리된 교환 요청을 다시 처리하지 못하도록 검증 로직 추가
<!-- 변경 항목마다 ### 제목으로 구분하고 하위 내용을 작성해주세요
### 변경한 기능 또는 파일
- 세부 내용
-->

## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- [✅] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)
https://natural-suit-4f1.notion.site/36638f10521c80c084bdcedf56d9d1ab?pvs=74
노션 페이지입니다.
<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
