### PR TITLE
feat(slack-ai): 스트리밍 응답 및 모니터링 개선

### DIFF
--- a/src/common/metrics/app.metrics.ts
+++ b/src/common/metrics/app.metrics.ts
@@ -31,6 +31,13 @@ export class AppMetrics implements OnModuleInit {
     registers: [this.registry],
   });
 
+  readonly aiSlackUpdatesPerMessage = new Histogram({
+    name: 'ai_slack_updates_per_message',
+    help: 'AI 메시지 처리 중 Slack chat.update 호출 횟수',
+    buckets: [5, 8, 10, 15, 20, 30, 50, 100],
+    registers: [this.registry],
+  });
+
   readonly aiProcessingCurrent = new Gauge({
     name: 'ai_processing_current',
     help: '현재 AI 메시지 처리 중인 수',

--- a/src/slack-ai/slack-ai.handler.ts
+++ b/src/slack-ai/slack-ai.handler.ts
@@ -117,14 +117,27 @@ export class SlackAiHandler {
 
     await this.slackAiService.setProcessing(slackId);
     try {
+      let lastStreamedText = '';
+
       const reply = await this.slackAiService.handleMessage(
         slackId,
         text,
         async (msg) => {
+          const displayText = lastStreamedText
+            ? `${lastStreamedText}\n\n${msg}`
+            : msg;
           await client.chat.update({
             channel,
             ts: loadingMsg.ts as string,
-            text: msg,
+            text: displayText,
+          });
+        },
+        async (chunk) => {
+          lastStreamedText = chunk;
+          await client.chat.update({
+            channel,
+            ts: loadingMsg.ts as string,
+            text: chunk + ' ▌',
           });
         },
       );

--- a/src/slack-ai/slack-ai.handler.ts
+++ b/src/slack-ai/slack-ai.handler.ts
@@ -4,6 +4,7 @@ import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from '@slack/bolt';
 import type { KnownBlock } from '@slack/types';
 import { SlackAiService } from './slack-ai.service';
 import { UserService } from '../user/service/user.service';
+import { AppMetrics } from '../common/metrics/app.metrics';
 
 function toSlackMrkdwn(text: string): string {
   return text
@@ -24,6 +25,7 @@ export class SlackAiHandler {
   constructor(
     private readonly slackAiService: SlackAiService,
     private readonly userService: UserService,
+    private readonly appMetrics: AppMetrics,
   ) {}
 
   @Message(/.*/)
@@ -118,11 +120,13 @@ export class SlackAiHandler {
     await this.slackAiService.setProcessing(slackId);
     try {
       let lastStreamedText = '';
+      let updateCount = 0;
 
-      const reply = await this.slackAiService.handleMessage(
+      const { reply, rounds } = await this.slackAiService.handleMessage(
         slackId,
         text,
         async (msg) => {
+          updateCount++;
           const displayText = lastStreamedText
             ? `${lastStreamedText}\n\n${msg}`
             : msg;
@@ -133,6 +137,7 @@ export class SlackAiHandler {
           });
         },
         async (chunk) => {
+          updateCount++;
           lastStreamedText = chunk;
           await client.chat.update({
             channel,
@@ -140,6 +145,11 @@ export class SlackAiHandler {
             text: chunk + ' ▌',
           });
         },
+      );
+      updateCount++;
+      this.appMetrics.aiSlackUpdatesPerMessage.observe(updateCount);
+      this.logger.log(
+        `[handleDm] 완료 code=${user.code} rounds=${rounds} slackUpdates=${updateCount} length=${reply.length}`,
       );
       await client.chat.update({
         channel,
@@ -154,7 +164,7 @@ export class SlackAiHandler {
       });
     } catch (e) {
       this.logger.error(
-        `[handleDm] slackId=${slackId} error=${String(e)}`,
+        `[handleDm] code=${user.code} error=${String(e)}`,
         e instanceof Error ? e.stack : undefined,
       );
       await client.chat.update({

--- a/src/slack-ai/slack-ai.module.ts
+++ b/src/slack-ai/slack-ai.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ToolsModule } from '../tools/tools.module';
 import { UserModule } from '../user/user.module';
+import { MetricsModule } from '../common/metrics/metrics.module';
 import { SlackAiService } from './slack-ai.service';
 import { SlackAiHandler } from './slack-ai.handler';
 
 @Module({
-  imports: [ToolsModule, UserModule],
+  imports: [ToolsModule, UserModule, MetricsModule],
   controllers: [SlackAiHandler],
   providers: [SlackAiService],
 })

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -103,12 +103,13 @@ export class SlackAiService {
     slackId: string,
     text: string,
     onProgress?: (msg: string) => Promise<void>,
+    onChunk?: (text: string) => Promise<void>,
   ): Promise<string> {
     this.appMetrics.aiMessagesTotal.inc();
     this.appMetrics.aiProcessingCurrent.inc();
     const endTimer = this.appMetrics.aiMessageDurationSeconds.startTimer();
     try {
-      return await this._handleMessage(slackId, text, onProgress);
+      return await this._handleMessage(slackId, text, onProgress, onChunk);
     } finally {
       endTimer();
       this.appMetrics.aiProcessingCurrent.dec();
@@ -119,6 +120,7 @@ export class SlackAiService {
     slackId: string,
     text: string,
     onProgress?: (msg: string) => Promise<void>,
+    onChunk?: (text: string) => Promise<void>,
   ): Promise<string> {
     const tools = this.toolsService
       .getDefinitions()
@@ -134,13 +136,26 @@ export class SlackAiService {
 
     const MAX_ROUNDS = 10;
     for (let round = 0; round < MAX_ROUNDS; round++) {
-      const response = await this.anthropic.messages.create({
+      const stream = this.anthropic.messages.stream({
         model: MODEL,
         max_tokens: 2048,
         system: systemPrompt,
         tools,
         messages,
       });
+
+      let streamedText = '';
+      for await (const event of stream) {
+        if (
+          event.type === 'content_block_delta' &&
+          event.delta.type === 'text_delta'
+        ) {
+          streamedText += event.delta.text;
+          if (onChunk) await onChunk(streamedText);
+        }
+      }
+
+      const response = await stream.finalMessage();
 
       this.appMetrics.aiTokensTotal.inc(
         { type: 'input' },

--- a/src/slack-ai/slack-ai.service.ts
+++ b/src/slack-ai/slack-ai.service.ts
@@ -104,7 +104,7 @@ export class SlackAiService {
     text: string,
     onProgress?: (msg: string) => Promise<void>,
     onChunk?: (text: string) => Promise<void>,
-  ): Promise<string> {
+  ): Promise<{ reply: string; rounds: number }> {
     this.appMetrics.aiMessagesTotal.inc();
     this.appMetrics.aiProcessingCurrent.inc();
     const endTimer = this.appMetrics.aiMessageDurationSeconds.startTimer();
@@ -121,7 +121,7 @@ export class SlackAiService {
     text: string,
     onProgress?: (msg: string) => Promise<void>,
     onChunk?: (text: string) => Promise<void>,
-  ): Promise<string> {
+  ): Promise<{ reply: string; rounds: number }> {
     const tools = this.toolsService
       .getDefinitions()
       .filter((t) => t.name !== 'get_current_time'); // 프롬프트에 시간이 있으므로 툴 제외
@@ -173,10 +173,7 @@ export class SlackAiService {
           { role: 'assistant', content: replyText },
         ]);
         this.appMetrics.aiMessageRounds.observe(round + 1);
-        this.logger.log(
-          `[handleMessage] 완료 (${round + 1}라운드) length=${replyText.length}`,
-        );
-        return replyText;
+        return { reply: replyText, rounds: round + 1 };
       }
 
       const toolResults: Anthropic.ToolResultBlockParam[] = [];
@@ -209,7 +206,11 @@ export class SlackAiService {
       );
     }
 
-    return '요청 처리 중 오류가 발생했습니다. 다시 시도해 주세요.';
+    return {
+      reply:
+        '요청이 너무 복잡해서 한 번에 처리하지 못했어요 😅 일부 작업이 진행됐을 수 있으니 현황을 확인 후 다시 시도해 주세요!',
+      rounds: MAX_ROUNDS,
+    };
   }
 
   private extractText(content: Anthropic.ContentBlock[]): string {


### PR DESCRIPTION
## 개요

Slack AI DM 응답에 스트리밍을 적용해 텍스트가 생성되는 즉시 사용자에게 보여주고, 툴 실행 중 이전 텍스트를 유지하도록 개선했습니다. 또한 메시지 처리 통계 메트릭과 통합 로그를 추가했습니다.

## 주요 변경 사항

### 스트리밍 응답 적용 (`slack-ai.service.ts`)
- `anthropic.messages.create()` → `anthropic.messages.stream()`으로 전환
- 텍스트 델타를 누적해 `onChunk` 콜백으로 실시간 Slack 메시지 업데이트
- `handleMessage` 반환 타입을 `string` → `{ reply, rounds }`로 변경

### 툴 진행 상태 표시 개선 (`slack-ai.handler.ts`)
- 툴 실행 중 이전 스트리밍 텍스트를 유지하고 아래에 진행 라벨 추가
- 다음 라운드 스트리밍 시작 시 자연스럽게 초기화

### Slack 업데이트 횟수 메트릭 추가 (`app.metrics.ts`, `slack-ai.module.ts`)
- `ai_slack_updates_per_message` 히스토그램 추가 (버킷: 5~50)
- 메시지 처리 완료 시 `code/rounds/slackUpdates/length` 통합 로그 기록

### MAX_ROUNDS 초과 안내 메시지 개선
- 기존: "요청 처리 중 오류가 발생했습니다. 다시 시도해 주세요."
- 변경: "요청이 너무 복잡해서 한 번에 처리하지 못했어요 😅 일부 작업이 진행됐을 수 있으니 현황을 확인 후 다시 시도해 주세요!"

## 관련 이슈

없음

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인
- [x] 단순 질문 시 스트리밍 텍스트 점진적 표시 확인
- [x] 예약 요청 시 툴 라벨 + 스트리밍 텍스트 순서 확인
- [x] 로그에 `code/rounds/slackUpdates/length` 정상 출력 확인

## 스크린샷 (선택)

없음