### PR TITLE
fix(terraform): 모니터링 EC2 AMI 버전 고정

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -91,7 +91,7 @@ data "aws_ami" "amazon_linux" {
 }
 
 resource "aws_instance" "monitoring" {
-  ami                         = data.aws_ami.amazon_linux.id
+  ami                         = var.monitoring_ami_id
   instance_type               = var.monitoring_instance_type
   subnet_id                   = aws_subnet.public[0].id
   vpc_security_group_ids      = [aws_security_group.monitoring.id]

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -20,6 +20,7 @@ cache_node_type = "cache.t4g.micro"
 grafana_domain           = "grafana.gsc-lab.io"
 monitoring_instance_type = "t3.small"
 monitoring_key_name      = "monitoring-key"
+monitoring_ami_id        = "ami-09016cd26e0149709"
 
 # Optional: comma-separated browser origins for remote MCP calls.
 # Requests without an Origin header and requests from app_domain are allowed by default.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -97,6 +97,11 @@ variable "secrets_arn" {
 }
 
 # Monitoring EC2
+variable "monitoring_ami_id" {
+  description = "AMI ID for monitoring EC2 instance (pin to avoid unintended replacement)"
+  type        = string
+}
+
 variable "monitoring_instance_type" {
   description = "EC2 instance type for monitoring stack"
   type        = string


### PR DESCRIPTION
## 개요

AWS가 Amazon Linux AMI를 업데이트하면서 `terraform plan` 시 모니터링 EC2 인스턴스 교체가 발생했습니다. `prevent_destroy`로 인해 apply가 불가능하고, 인스턴스를 교체하면 Grafana 대시보드와 Loki 로그 데이터가 손실되므로 현재 AMI ID를 명시적으로 고정합니다.

## 주요 변경 사항

### AMI 고정 (`ec2.tf`, `variables.tf`, `prod.tfvars`)
- `monitoring_ami_id` 변수 추가
- `aws_instance.monitoring`의 `ami`를 `data.aws_ami` 동적 조회 → `var.monitoring_ami_id` 참조로 변경
- `prod.tfvars`에 현재 실행 중인 AMI ID(`ami-09016cd26e0149709`) 고정

## 관련 이슈

없음

## 향후 계획

Grafana/Loki 데이터를 EBS 볼륨으로 이전한 후 AMI를 업데이트할 예정입니다.

## 테스트

- [x] `terraform plan` 실행 후 `No changes` 확인