### PR TITLE
feat(ci): main 브랜치 수동 배포 workflow_dispatch 추가

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,7 @@ on:
       - dev
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -37,6 +38,7 @@ jobs:
           tags: |
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -50,7 +52,7 @@ jobs:
     name: Deploy to ECS
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## 개요

핫픽스 등 main 병합 후 즉시 배포가 필요한 경우, GitHub Actions에서 수동으로 배포를 트리거할 수 있도록 `workflow_dispatch`를 추가합니다.

## 주요 변경 사항

### `docker-publish.yml`
- `workflow_dispatch` 트리거 추가
- `main`에서 수동 실행 시 `:latest` 태그로 이미지 빌드 및 푸시
- `main`에서 수동 실행 시에만 ECS 배포 및 모니터링 스택 배포 실행 (다른 브랜치에서 실행해도 배포 안 됨)

## 관련 이슈

없음

## 테스트

- [ ] `main` 브랜치에서 Actions → "Build and Push Docker Image" → "Run workflow" 실행 후 `:latest` 이미지 푸시 및 ECS 배포 확인