### PR TITLE
feat(google): Google Calendar API rate limiter 및 메트릭 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@nestjs/typeorm": "^11.0.0",
         "@slack/bolt": "^4.6.0",
         "@slack/types": "^2.19.0",
+        "bottleneck": "^2.19.5",
         "cache-manager": "^7.2.8",
         "googleapis": "^170.1.0",
         "nest-winston": "^1.10.2",
@@ -4774,6 +4775,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "@slack/bolt": "^4.6.0",
     "@slack/types": "^2.19.0",
+    "bottleneck": "^2.19.5",
     "cache-manager": "^7.2.8",
     "googleapis": "^170.1.0",
     "nest-winston": "^1.10.2",

--- a/src/common/metrics/app.metrics.ts
+++ b/src/common/metrics/app.metrics.ts
@@ -78,9 +78,30 @@ export class AppMetrics implements OnModuleInit {
     registers: [this.registry],
   });
 
+  readonly googleApiRequestsTotal = new Counter({
+    name: 'google_api_requests_total',
+    help: 'Google Calendar API 요청 횟수',
+    labelNames: ['operation'] as const,
+    registers: [this.registry],
+  });
+
   readonly googleApiErrorsTotal = new Counter({
     name: 'google_api_errors_total',
     help: 'Google Calendar API 에러 횟수',
+    labelNames: ['operation'] as const,
+    registers: [this.registry],
+  });
+
+  readonly googleApiRateLimitTotal = new Counter({
+    name: 'google_api_rate_limit_total',
+    help: 'Google Calendar API Rate Limit(429) 발생 횟수',
+    labelNames: ['operation'] as const,
+    registers: [this.registry],
+  });
+
+  readonly googleApiRetryTotal = new Counter({
+    name: 'google_api_retry_total',
+    help: 'Google Calendar API 재시도 횟수',
     labelNames: ['operation'] as const,
     registers: [this.registry],
   });

--- a/src/google/calendar/acl.service.ts
+++ b/src/google/calendar/acl.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
 import { GoogleCalendarBaseService } from './base.service';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 
 export interface CalendarAclEntry {
   email: string;
@@ -19,19 +21,25 @@ export class GoogleAclService extends GoogleCalendarBaseService {
   private readonly ACL_CACHE_KEY = (id: string) => `google:acl:${id}`;
   private readonly ACL_TTL_MS = 15 * 60 * 1000;
 
-  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {
-    super();
+  constructor(
+    limiter: GoogleApiLimiter,
+    appMetrics: AppMetrics,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+  ) {
+    super(limiter, appMetrics);
   }
 
   async shareCalendar(options: ShareCalendarOptions): Promise<void> {
     const calendar = this.getCalendarClient();
-    await calendar.acl.insert({
-      calendarId: options.calendarId,
-      requestBody: {
-        role: options.role,
-        scope: { type: 'user', value: options.email },
-      },
-    });
+    await this.callApi('shareCalendar', () =>
+      calendar.acl.insert({
+        calendarId: options.calendarId,
+        requestBody: {
+          role: options.role,
+          scope: { type: 'user', value: options.email },
+        },
+      }),
+    );
     await this.cache.del(this.ACL_CACHE_KEY(options.calendarId));
   }
 
@@ -39,7 +47,9 @@ export class GoogleAclService extends GoogleCalendarBaseService {
     const calendar = this.getCalendarClient();
     const ruleId = `user:${email}`;
     try {
-      await calendar.acl.delete({ calendarId, ruleId });
+      await this.callApi('unshareCalendar', () =>
+        calendar.acl.delete({ calendarId, ruleId }),
+      );
     } catch (error: any) {
       if (error.code === 404) {
         await this.cache.del(this.ACL_CACHE_KEY(calendarId));
@@ -52,13 +62,15 @@ export class GoogleAclService extends GoogleCalendarBaseService {
 
   async makeCalendarPublic(calendarId: string): Promise<void> {
     const calendar = this.getCalendarClient();
-    await calendar.acl.insert({
-      calendarId,
-      requestBody: {
-        role: 'reader',
-        scope: { type: 'default' },
-      },
-    });
+    await this.callApi('makeCalendarPublic', () =>
+      calendar.acl.insert({
+        calendarId,
+        requestBody: {
+          role: 'reader',
+          scope: { type: 'default' },
+        },
+      }),
+    );
   }
 
   // Redis 15분 캐싱
@@ -76,7 +88,9 @@ export class GoogleAclService extends GoogleCalendarBaseService {
     calendarId: string,
   ): Promise<CalendarAclEntry[]> {
     const calendar = this.getCalendarClient();
-    const response = await calendar.acl.list({ calendarId });
+    const response = await this.callApi('fetchCalendarAcl', () =>
+      calendar.acl.list({ calendarId }),
+    );
     const items = response.data.items ?? [];
 
     return items

--- a/src/google/calendar/base.service.spec.ts
+++ b/src/google/calendar/base.service.spec.ts
@@ -1,0 +1,178 @@
+import { GaxiosError } from 'gaxios';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
+import { GoogleCalendarBaseService } from './base.service';
+
+function makeGaxiosError(status: number, retryAfter?: string): GaxiosError {
+  const err = Object.create(GaxiosError.prototype) as GaxiosError;
+  err.message = 'error';
+  err.response = {
+    status,
+    data: {},
+    headers: retryAfter ? { 'retry-after': retryAfter } : {},
+    config: {} as never,
+    request: {} as never,
+  } as never;
+  return err;
+}
+
+class TestService extends GoogleCalendarBaseService {
+  retry<T>(fn: () => Promise<T>, op: string, maxRetries?: number) {
+    return this.withRetry(fn, op, maxRetries);
+  }
+}
+
+describe('GoogleCalendarBaseService.withRetry', () => {
+  let service: TestService;
+  let metrics: {
+    googleApiRateLimitTotal: { inc: jest.Mock };
+    googleApiRetryTotal: { inc: jest.Mock };
+    googleApiRequestsTotal: { inc: jest.Mock };
+    googleApiErrorsTotal: { inc: jest.Mock };
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    metrics = {
+      googleApiRateLimitTotal: { inc: jest.fn() },
+      googleApiRetryTotal: { inc: jest.fn() },
+      googleApiRequestsTotal: { inc: jest.fn() },
+      googleApiErrorsTotal: { inc: jest.fn() },
+    };
+    service = new TestService(new GoogleApiLimiter(), metrics as never);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('성공 시 바로 결과를 반환한다', async () => {
+    const fn = jest.fn(async () => 'ok');
+    await expect(service.retry(fn, 'op')).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('429 발생 시 재시도 후 성공한다', async () => {
+    let attempt = 0;
+    const fn = jest.fn(async () => {
+      if (attempt++ < 2) throw makeGaxiosError(429);
+      return 'ok';
+    });
+
+    const promise = service.retry(fn, 'op');
+    await jest.runAllTimersAsync();
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(metrics.googleApiRateLimitTotal.inc).toHaveBeenCalledTimes(2);
+    expect(metrics.googleApiRetryTotal.inc).toHaveBeenCalledTimes(2);
+  });
+
+  it('재시도 중인 태스크가 다음 태스크보다 먼저 완료된다', async () => {
+    const order: string[] = [];
+    let attempt = 0;
+    const sharedLimiter = new GoogleApiLimiter();
+
+    const task1 = sharedLimiter.schedule({}, () =>
+      service.retry(async () => {
+        if (attempt++ < 1) throw makeGaxiosError(429);
+        order.push('task1');
+        return 'ok';
+      }, 'op'),
+    );
+    const task2 = sharedLimiter.schedule({}, () =>
+      service.retry(async () => {
+        order.push('task2');
+        return 'ok';
+      }, 'op'),
+    );
+
+    await jest.runAllTimersAsync();
+    await Promise.all([task1, task2]);
+
+    expect(order).toEqual(['task1', 'task2']);
+  });
+
+  it('retry-after 헤더가 있으면 해당 시간만큼 대기한다', async () => {
+    let attempt = 0;
+    const fn = jest.fn(async () => {
+      if (attempt++ < 1) throw makeGaxiosError(429, '2');
+      return 'ok';
+    });
+
+    const promise = service.retry(fn, 'op');
+    await jest.advanceTimersByTimeAsync(2000);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('exponential backoff로 대기한다 (1s → 2s → 4s)', async () => {
+    const delays: number[] = [];
+    const originalSetTimeout = global.setTimeout;
+    jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((fn, delay, ...args) => {
+        if (typeof delay === 'number' && delay > 0) delays.push(delay);
+        return originalSetTimeout(fn, 0, ...args);
+      });
+
+    let attempt = 0;
+    const fn = jest.fn(async () => {
+      if (attempt++ < 3) throw makeGaxiosError(500);
+      return 'ok';
+    });
+
+    const promise = service.retry(fn, 'op');
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(delays).toEqual([1000, 2000, 4000]);
+  });
+
+  it('maxRetries 초과 시 에러를 던진다', async () => {
+    const fn = jest.fn(async () => {
+      throw makeGaxiosError(429);
+    });
+
+    const promise = service.retry(fn, 'op', 2);
+    const assertion = expect(promise).rejects.toThrow(GaxiosError);
+    await jest.runAllTimersAsync();
+    await assertion;
+
+    expect(fn).toHaveBeenCalledTimes(3); // 최초 1회 + 재시도 2회
+  });
+
+  it.each([500, 503])('%i 에러도 재시도 후 성공한다', async (status) => {
+    let attempt = 0;
+    const fn = jest.fn(async () => {
+      if (attempt++ < 1) throw makeGaxiosError(status);
+      return 'ok';
+    });
+
+    const promise = service.retry(fn, 'op');
+    await jest.runAllTimersAsync();
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(metrics.googleApiRetryTotal.inc).toHaveBeenCalledTimes(1);
+  });
+
+  it('재시도 불가 에러(404)는 즉시 던진다', async () => {
+    const fn = jest.fn(async () => {
+      throw makeGaxiosError(404);
+    });
+
+    await expect(service.retry(fn, 'op')).rejects.toThrow(GaxiosError);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(metrics.googleApiRetryTotal.inc).not.toHaveBeenCalled();
+  });
+
+  it('GaxiosError가 아닌 에러는 즉시 던진다', async () => {
+    const fn = jest.fn(async () => {
+      throw new Error('unexpected');
+    });
+
+    await expect(service.retry(fn, 'op')).rejects.toThrow('unexpected');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/google/calendar/base.service.ts
+++ b/src/google/calendar/base.service.ts
@@ -1,8 +1,24 @@
+import { Injectable } from '@nestjs/common';
 import { google, calendar_v3 } from 'googleapis';
+import { GaxiosError } from 'gaxios';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 
 const SCOPES = ['https://www.googleapis.com/auth/calendar'];
 
+// 사용자 액션은 크론보다 높은 우선순위
+export const API_PRIORITY = {
+  USER: 5,
+  CRON: 9,
+} as const;
+
+@Injectable()
 export abstract class GoogleCalendarBaseService {
+  constructor(
+    protected readonly limiter: GoogleApiLimiter,
+    protected readonly appMetrics: AppMetrics,
+  ) {}
+
   protected getServiceAccountAuth() {
     const email = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
     const privateKey = process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY?.replace(
@@ -48,5 +64,51 @@ export abstract class GoogleCalendarBaseService {
       version: 'v3',
       auth: this.getUserAuth(refreshToken),
     });
+  }
+
+  protected async withRetry<T>(
+    fn: () => Promise<T>,
+    operation: string,
+    maxRetries = 3,
+  ): Promise<T> {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await fn();
+      } catch (err) {
+        if (!(err instanceof GaxiosError)) throw err;
+
+        const status = err.response?.status;
+        const isRetryable = status === 429 || status === 500 || status === 503;
+
+        if (!isRetryable || attempt === maxRetries) throw err;
+
+        if (status === 429) {
+          this.appMetrics.googleApiRateLimitTotal.inc({ operation });
+        }
+        this.appMetrics.googleApiRetryTotal.inc({ operation });
+
+        const retryAfterHeader = err.response?.headers['retry-after'];
+        const delayMs = retryAfterHeader
+          ? parseInt(retryAfterHeader as string, 10) * 1000
+          : 1000 * 2 ** attempt; // 1s → 2s → 4s
+
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+    throw new Error('unreachable');
+  }
+
+  protected async callApi<T>(
+    operation: string,
+    fn: () => Promise<T>,
+    priority: number = API_PRIORITY.USER,
+  ): Promise<T> {
+    this.appMetrics.googleApiRequestsTotal.inc({ operation });
+    return this.limiter.schedule({ priority }, () =>
+      this.withRetry(fn, operation).catch((err) => {
+        this.appMetrics.googleApiErrorsTotal.inc({ operation });
+        throw err;
+      }),
+    );
   }
 }

--- a/src/google/calendar/calendar-list.service.ts
+++ b/src/google/calendar/calendar-list.service.ts
@@ -1,15 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { GoogleCalendarBaseService } from './base.service';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 
 @Injectable()
 export class GoogleCalendarListService extends GoogleCalendarBaseService {
+  constructor(limiter: GoogleApiLimiter, appMetrics: AppMetrics) {
+    super(limiter, appMetrics);
+  }
+
   async addCalendarToUserList(
     calendarId: string,
     userRefreshToken: string,
   ): Promise<void> {
     const calendar = this.getUserCalendarClient(userRefreshToken);
     try {
-      await calendar.calendarList.insert({ requestBody: { id: calendarId } });
+      await this.callApi('addCalendarToUserList', () =>
+        calendar.calendarList.insert({ requestBody: { id: calendarId } }),
+      );
     } catch (error: unknown) {
       const err = error as { code?: number };
       if (err.code === 409) return; // 이미 추가된 경우 무시
@@ -23,7 +31,9 @@ export class GoogleCalendarListService extends GoogleCalendarBaseService {
   ): Promise<void> {
     const calendar = this.getUserCalendarClient(userRefreshToken);
     try {
-      await calendar.calendarList.delete({ calendarId });
+      await this.callApi('removeCalendarFromUserList', () =>
+        calendar.calendarList.delete({ calendarId }),
+      );
     } catch (error: unknown) {
       const err = error as { code?: number };
       if (err.code === 404) return; // 이미 제거된 경우 무시
@@ -37,10 +47,12 @@ export class GoogleCalendarListService extends GoogleCalendarBaseService {
     let pageToken: string | undefined;
 
     do {
-      const res = await calendar.calendarList.list({
-        maxResults: 250,
-        pageToken,
-      });
+      const res = await this.callApi('getUserCalendarIds', () =>
+        calendar.calendarList.list({
+          maxResults: 250,
+          pageToken,
+        }),
+      );
       for (const item of res.data.items ?? []) {
         if (item.id) ids.add(item.id);
       }

--- a/src/google/calendar/calendars.service.ts
+++ b/src/google/calendar/calendars.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { calendar_v3 } from 'googleapis';
 import { GoogleCalendarBaseService } from './base.service';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 
 export interface CreateCalendarResult {
   calendarId: string;
@@ -9,14 +11,20 @@ export interface CreateCalendarResult {
 
 @Injectable()
 export class GoogleCalendarsService extends GoogleCalendarBaseService {
+  constructor(limiter: GoogleApiLimiter, appMetrics: AppMetrics) {
+    super(limiter, appMetrics);
+  }
+
   async createCalendar(
     summary: string,
     description?: string,
   ): Promise<CreateCalendarResult> {
     const calendar = this.getCalendarClient();
-    const response = await calendar.calendars.insert({
-      requestBody: { summary, description, timeZone: 'Asia/Seoul' },
-    });
+    const response = await this.callApi('createCalendar', () =>
+      calendar.calendars.insert({
+        requestBody: { summary, description, timeZone: 'Asia/Seoul' },
+      }),
+    );
 
     if (!response.data.id) throw new Error('Failed to create calendar');
 
@@ -28,7 +36,9 @@ export class GoogleCalendarsService extends GoogleCalendarBaseService {
 
   async deleteCalendar(calendarId: string): Promise<void> {
     const calendar = this.getCalendarClient();
-    await calendar.calendars.delete({ calendarId });
+    await this.callApi('deleteCalendar', () =>
+      calendar.calendars.delete({ calendarId }),
+    );
   }
 
   async getCalendar(
@@ -36,7 +46,9 @@ export class GoogleCalendarsService extends GoogleCalendarBaseService {
   ): Promise<calendar_v3.Schema$Calendar | null> {
     const calendar = this.getCalendarClient();
     try {
-      const response = await calendar.calendars.get({ calendarId });
+      const response = await this.callApi('getCalendar', () =>
+        calendar.calendars.get({ calendarId }),
+      );
       return response.data;
     } catch (error: any) {
       if (error.code === 404) return null;
@@ -50,9 +62,11 @@ export class GoogleCalendarsService extends GoogleCalendarBaseService {
     description?: string,
   ): Promise<void> {
     const calendar = this.getCalendarClient();
-    await calendar.calendars.update({
-      calendarId,
-      requestBody: { summary, description },
-    });
+    await this.callApi('updateCalendar', () =>
+      calendar.calendars.update({
+        calendarId,
+        requestBody: { summary, description },
+      }),
+    );
   }
 }

--- a/src/google/calendar/channels.service.ts
+++ b/src/google/calendar/channels.service.ts
@@ -1,8 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { GoogleCalendarBaseService } from './base.service';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 
 @Injectable()
 export class GoogleChannelsService extends GoogleCalendarBaseService {
+  constructor(limiter: GoogleApiLimiter, appMetrics: AppMetrics) {
+    super(limiter, appMetrics);
+  }
+
   isWatchConfigured(): boolean {
     return !!process.env.GOOGLE_WEBHOOK_URL;
   }
@@ -15,15 +21,17 @@ export class GoogleChannelsService extends GoogleCalendarBaseService {
     const watchDurationMs = 7 * 24 * 60 * 60 * 1000;
     const calendar = this.getCalendarClient();
 
-    const response = await calendar.events.watch({
-      calendarId,
-      requestBody: {
-        id: channelId,
-        type: 'web_hook',
-        address: callbackUrl,
-        expiration: String(Date.now() + watchDurationMs),
-      },
-    });
+    const response = await this.callApi('watchCalendarEvents', () =>
+      calendar.events.watch({
+        calendarId,
+        requestBody: {
+          id: channelId,
+          type: 'web_hook',
+          address: callbackUrl,
+          expiration: String(Date.now() + watchDurationMs),
+        },
+      }),
+    );
 
     if (!response.data.resourceId) {
       throw new Error(
@@ -40,9 +48,11 @@ export class GoogleChannelsService extends GoogleCalendarBaseService {
   ): Promise<void> {
     const calendar = this.getCalendarClient();
     try {
-      await calendar.channels.stop({
-        requestBody: { id: channelId, resourceId },
-      });
+      await this.callApi('stopCalendarWatch', () =>
+        calendar.channels.stop({
+          requestBody: { id: channelId, resourceId },
+        }),
+      );
     } catch (error: any) {
       if (error.code === 404 || error.code === 400) return;
       throw error;

--- a/src/google/calendar/events.service.ts
+++ b/src/google/calendar/events.service.ts
@@ -1,25 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { calendar_v3 } from 'googleapis';
-import { GoogleCalendarBaseService } from './base.service';
+import { GoogleCalendarBaseService, API_PRIORITY } from './base.service';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
 import { AppMetrics } from '../../common/metrics/app.metrics';
 
 @Injectable()
 export class GoogleEventsService extends GoogleCalendarBaseService {
-  constructor(private readonly appMetrics: AppMetrics) {
-    super();
+  constructor(limiter: GoogleApiLimiter, appMetrics: AppMetrics) {
+    super(limiter, appMetrics);
   }
 
-  private async callApi<T>(
-    operation: string,
-    fn: () => Promise<T>,
-  ): Promise<T> {
-    try {
-      return await fn();
-    } catch (error) {
-      this.appMetrics.googleApiErrorsTotal.inc({ operation });
-      throw error;
-    }
-  }
   // ========== 서비스 계정 기반 이벤트 ==========
 
   async createEventAsServiceAccount(
@@ -62,14 +52,16 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     let pageToken: string | undefined;
 
     do {
-      const response = await calendar.events.list({
-        calendarId,
-        privateExtendedProperty: [`groupId=${groupId}`],
-        showDeleted: false,
-        singleEvents: true,
-        maxResults: 2500,
-        ...(pageToken ? { pageToken } : {}),
-      });
+      const response = await this.callApi('listEventsByGroupId', () =>
+        calendar.events.list({
+          calendarId,
+          privateExtendedProperty: [`groupId=${groupId}`],
+          showDeleted: false,
+          singleEvents: true,
+          maxResults: 2500,
+          ...(pageToken ? { pageToken } : {}),
+        }),
+      );
       events.push(...(response.data.items ?? []));
       pageToken = response.data.nextPageToken ?? undefined;
     } while (pageToken);
@@ -123,12 +115,14 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     privateProps: Record<string, string>,
   ): Promise<void> {
     const calendar = this.getCalendarClient();
-    await calendar.events.patch({
-      calendarId,
-      eventId,
-      sendUpdates: 'none',
-      requestBody: { extendedProperties: { private: privateProps } },
-    });
+    await this.callApi('patchEventExtendedProperty', () =>
+      calendar.events.patch({
+        calendarId,
+        eventId,
+        sendUpdates: 'none',
+        requestBody: { extendedProperties: { private: privateProps } },
+      }),
+    );
   }
 
   async searchByExtendedProperty(
@@ -137,12 +131,14 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     value: string,
   ): Promise<calendar_v3.Schema$Event[]> {
     const calendar = this.getCalendarClient();
-    const response = await calendar.events.list({
-      calendarId,
-      privateExtendedProperty: [`${key}=${value}`],
-      maxResults: 1,
-      showDeleted: false,
-    });
+    const response = await this.callApi('searchByExtendedProperty', () =>
+      calendar.events.list({
+        calendarId,
+        privateExtendedProperty: [`${key}=${value}`],
+        maxResults: 1,
+        showDeleted: false,
+      }),
+    );
     return response.data.items ?? [];
   }
 
@@ -158,18 +154,20 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     },
   ): Promise<string> {
     const calendar = this.getCalendarClient();
-    const response = await calendar.events.insert({
-      calendarId,
-      sendUpdates: 'none',
-      requestBody: {
-        summary: params.summary,
-        description: params.description,
-        location: params.location,
-        start: { dateTime: params.startDateTime, timeZone: 'Asia/Seoul' },
-        end: { dateTime: params.endDateTime, timeZone: 'Asia/Seoul' },
-        extendedProperties: params.extendedProperties,
-      },
-    });
+    const response = await this.callApi('createMirrorEvent', () =>
+      calendar.events.insert({
+        calendarId,
+        sendUpdates: 'none',
+        requestBody: {
+          summary: params.summary,
+          description: params.description,
+          location: params.location,
+          start: { dateTime: params.startDateTime, timeZone: 'Asia/Seoul' },
+          end: { dateTime: params.endDateTime, timeZone: 'Asia/Seoul' },
+          extendedProperties: params.extendedProperties,
+        },
+      }),
+    );
     if (!response.data.id)
       throw new Error('Failed to create mirror calendar event');
     return response.data.id;
@@ -198,12 +196,14 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
       body.end = { dateTime: params.endDateTime, timeZone: 'Asia/Seoul' };
     if (params.extendedProperties)
       body.extendedProperties = params.extendedProperties;
-    await calendar.events.patch({
-      calendarId,
-      eventId,
-      sendUpdates: 'none',
-      requestBody: body,
-    });
+    await this.callApi('updateMirrorEvent', () =>
+      calendar.events.patch({
+        calendarId,
+        eventId,
+        sendUpdates: 'none',
+        requestBody: body,
+      }),
+    );
   }
 
   // ========== 공통 조회 ==========
@@ -214,7 +214,9 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
   ): Promise<calendar_v3.Schema$Event | null> {
     const calendar = this.getCalendarClient();
     try {
-      const response = await calendar.events.get({ calendarId, eventId });
+      const response = await this.callApi('getEvent', () =>
+        calendar.events.get({ calendarId, eventId }),
+      );
       return response.data;
     } catch (error: any) {
       if (error.code === 404 || error.code === 410) return null;
@@ -232,15 +234,20 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     let pageToken: string | undefined;
 
     while (true) {
-      const response = await calendar.events.list({
-        calendarId,
-        timeMin: timeMin.toISOString(),
-        timeMax: timeMax.toISOString(),
-        showDeleted: false,
-        singleEvents: true,
-        maxResults: 2500,
-        ...(pageToken ? { pageToken } : {}),
-      });
+      const response = await this.callApi(
+        'listEventsInRange',
+        () =>
+          calendar.events.list({
+            calendarId,
+            timeMin: timeMin.toISOString(),
+            timeMax: timeMax.toISOString(),
+            showDeleted: false,
+            singleEvents: true,
+            maxResults: 2500,
+            ...(pageToken ? { pageToken } : {}),
+          }),
+        API_PRIORITY.CRON,
+      );
       events.push(...(response.data.items ?? []));
       if (!response.data.nextPageToken) break;
       pageToken = response.data.nextPageToken;
@@ -259,16 +266,21 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     let pageToken: string | undefined;
 
     while (true) {
-      const response = await calendar.events.list({
-        calendarId,
-        timeMin: timeMin.toISOString(),
-        timeMax: timeMax.toISOString(),
-        privateExtendedProperty: ['mirroredBy=gsc-bot'],
-        showDeleted: false,
-        singleEvents: true,
-        maxResults: 2500,
-        ...(pageToken ? { pageToken } : {}),
-      });
+      const response = await this.callApi(
+        'listMirrorEventsInRange',
+        () =>
+          calendar.events.list({
+            calendarId,
+            timeMin: timeMin.toISOString(),
+            timeMax: timeMax.toISOString(),
+            privateExtendedProperty: ['mirroredBy=gsc-bot'],
+            showDeleted: false,
+            singleEvents: true,
+            maxResults: 2500,
+            ...(pageToken ? { pageToken } : {}),
+          }),
+        API_PRIORITY.CRON,
+      );
       events.push(...(response.data.items ?? []));
       if (!response.data.nextPageToken) break;
       pageToken = response.data.nextPageToken;
@@ -282,13 +294,15 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
   ): Promise<calendar_v3.Schema$Event[]> {
     const calendar = this.getCalendarClient();
     const updatedMin = new Date(Date.now() - 30_000);
-    const response = await calendar.events.list({
-      calendarId,
-      updatedMin: updatedMin.toISOString(),
-      showDeleted: true,
-      singleEvents: true,
-      maxResults: 10,
-    });
+    const response = await this.callApi('getRecentChangedEvents', () =>
+      calendar.events.list({
+        calendarId,
+        updatedMin: updatedMin.toISOString(),
+        showDeleted: true,
+        singleEvents: true,
+        maxResults: 10,
+      }),
+    );
     return response.data.items ?? [];
   }
 
@@ -299,13 +313,18 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     let pageToken: string | undefined;
 
     while (true) {
-      const response = await calendar.events.list({
-        calendarId,
-        showDeleted: true,
-        singleEvents: true,
-        maxResults: 2500,
-        ...(pageToken ? { pageToken } : {}),
-      });
+      const response = await this.callApi(
+        'getInitialSyncToken',
+        () =>
+          calendar.events.list({
+            calendarId,
+            showDeleted: true,
+            singleEvents: true,
+            maxResults: 2500,
+            ...(pageToken ? { pageToken } : {}),
+          }),
+        API_PRIORITY.CRON,
+      );
 
       if (response.data.nextSyncToken) return response.data.nextSyncToken;
       if (!response.data.nextPageToken)
@@ -322,12 +341,17 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
   ): Promise<{ events: calendar_v3.Schema$Event[]; nextSyncToken: string }> {
     const calendar = this.getCalendarClient();
     try {
-      const response = await calendar.events.list({
-        calendarId,
-        syncToken,
-        showDeleted: true,
-        singleEvents: true,
-      });
+      const response = await this.callApi(
+        'getChangedEventsBySyncToken',
+        () =>
+          calendar.events.list({
+            calendarId,
+            syncToken,
+            showDeleted: true,
+            singleEvents: true,
+          }),
+        API_PRIORITY.CRON,
+      );
       return {
         events: response.data.items ?? [],
         nextSyncToken: response.data.nextSyncToken!,
@@ -356,21 +380,26 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     },
   ): Promise<string> {
     const calendar = this.getUserCalendarClient(refreshToken);
-    const response = await calendar.events.insert({
-      calendarId,
-      sendUpdates: 'none',
-      requestBody: {
-        summary: params.summary,
-        description: params.description,
-        location: params.location,
-        start: {
-          dateTime: params.startTime.toISOString(),
-          timeZone: 'Asia/Seoul',
+    const response = await this.callApi('createUserEvent', () =>
+      calendar.events.insert({
+        calendarId,
+        sendUpdates: 'none',
+        requestBody: {
+          summary: params.summary,
+          description: params.description,
+          location: params.location,
+          start: {
+            dateTime: params.startTime.toISOString(),
+            timeZone: 'Asia/Seoul',
+          },
+          end: {
+            dateTime: params.endTime.toISOString(),
+            timeZone: 'Asia/Seoul',
+          },
+          attendees: params.attendeeEmails?.map((email) => ({ email })),
         },
-        end: { dateTime: params.endTime.toISOString(), timeZone: 'Asia/Seoul' },
-        attendees: params.attendeeEmails?.map((email) => ({ email })),
-      },
-    });
+      }),
+    );
 
     if (!response.data.id) throw new Error('Failed to create calendar event');
     return response.data.id;
@@ -382,7 +411,9 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     eventId: string,
   ): Promise<void> {
     const calendar = this.getUserCalendarClient(refreshToken);
-    await calendar.events.delete({ calendarId, eventId, sendUpdates: 'none' });
+    await this.callApi('deleteUserEvent', () =>
+      calendar.events.delete({ calendarId, eventId, sendUpdates: 'none' }),
+    );
   }
 
   // primary 캘린더에서 삭제하고 교수에게 취소 알림 발송
@@ -391,11 +422,13 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     eventId: string,
   ): Promise<void> {
     const calendar = this.getUserCalendarClient(refreshToken);
-    await calendar.events.delete({
-      calendarId: 'primary',
-      eventId,
-      sendUpdates: 'all',
-    });
+    await this.callApi('cancelConsultationEvent', () =>
+      calendar.events.delete({
+        calendarId: 'primary',
+        eventId,
+        sendUpdates: 'all',
+      }),
+    );
   }
 
   async updateEvent(
@@ -430,12 +463,14 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     if (params.attendeeEmails !== undefined)
       requestBody.attendees = params.attendeeEmails.map((email) => ({ email }));
 
-    await calendar.events.update({
-      calendarId,
-      eventId,
-      sendUpdates: 'none',
-      requestBody,
-    });
+    await this.callApi('updateUserEvent', () =>
+      calendar.events.update({
+        calendarId,
+        eventId,
+        sendUpdates: 'none',
+        requestBody,
+      }),
+    );
   }
 
   async listUserPrimaryEvents(
@@ -448,15 +483,17 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
     let pageToken: string | undefined;
 
     while (true) {
-      const response = await calendar.events.list({
-        calendarId: 'primary',
-        timeMin: timeMin.toISOString(),
-        timeMax: timeMax.toISOString(),
-        showDeleted: false,
-        singleEvents: true,
-        maxResults: 2500,
-        ...(pageToken ? { pageToken } : {}),
-      });
+      const response = await this.callApi('listUserPrimaryEvents', () =>
+        calendar.events.list({
+          calendarId: 'primary',
+          timeMin: timeMin.toISOString(),
+          timeMax: timeMax.toISOString(),
+          showDeleted: false,
+          singleEvents: true,
+          maxResults: 2500,
+          ...(pageToken ? { pageToken } : {}),
+        }),
+      );
       events.push(...(response.data.items ?? []));
       if (!response.data.nextPageToken) break;
       pageToken = response.data.nextPageToken;
@@ -478,13 +515,15 @@ export class GoogleEventsService extends GoogleCalendarBaseService {
 
     await Promise.all(
       calendarIds.map(async (calendarId) => {
-        const response = await calendar.events.list({
-          calendarId,
-          q: userEmail,
-          timeMin: now,
-          singleEvents: true,
-          orderBy: 'startTime',
-        });
+        const response = await this.callApi('getUserBookings', () =>
+          calendar.events.list({
+            calendarId,
+            q: userEmail,
+            timeMin: now,
+            singleEvents: true,
+            orderBy: 'startTime',
+          }),
+        );
         for (const event of response.data.items ?? []) {
           if (event.attendees?.some((a) => a.email === userEmail)) {
             results.push({ calendarId, event });

--- a/src/google/calendar/freebusy.service.ts
+++ b/src/google/calendar/freebusy.service.ts
@@ -1,11 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { GoogleCalendarBaseService } from './base.service';
+import { GoogleApiLimiter } from '../google-api-limiter.service';
+import { AppMetrics } from '../../common/metrics/app.metrics';
 import { GoogleEventsService } from './events.service';
 
 @Injectable()
 export class GoogleFreebusyService extends GoogleCalendarBaseService {
-  constructor(private readonly eventsService: GoogleEventsService) {
-    super();
+  constructor(
+    limiter: GoogleApiLimiter,
+    appMetrics: AppMetrics,
+    private readonly eventsService: GoogleEventsService,
+  ) {
+    super(limiter, appMetrics);
   }
 
   async isTimeSlotBusy(
@@ -15,14 +21,16 @@ export class GoogleFreebusyService extends GoogleCalendarBaseService {
     endTime: Date,
   ): Promise<boolean> {
     const calendar = this.getUserCalendarClient(refreshToken);
-    const response = await calendar.freebusy.query({
-      requestBody: {
-        timeMin: startTime.toISOString(),
-        timeMax: endTime.toISOString(),
-        timeZone: 'Asia/Seoul',
-        items: [{ id: calendarId }],
-      },
-    });
+    const response = await this.callApi('freebusyQuery', () =>
+      calendar.freebusy.query({
+        requestBody: {
+          timeMin: startTime.toISOString(),
+          timeMax: endTime.toISOString(),
+          timeZone: 'Asia/Seoul',
+          items: [{ id: calendarId }],
+        },
+      }),
+    );
     const busy = response.data.calendars?.[calendarId]?.busy ?? [];
     return busy.length > 0;
   }

--- a/src/google/google-api-limiter.service.spec.ts
+++ b/src/google/google-api-limiter.service.spec.ts
@@ -1,0 +1,96 @@
+import { GoogleApiLimiter } from './google-api-limiter.service';
+
+describe('GoogleApiLimiter', () => {
+  let limiter: GoogleApiLimiter;
+
+  beforeEach(() => {
+    limiter = new GoogleApiLimiter();
+  });
+
+  it('동시 요청을 순서대로 실행한다', async () => {
+    const results: number[] = [];
+
+    await Promise.all(
+      [1, 2, 3].map((i) =>
+        limiter.schedule({}, async () => {
+          results.push(i);
+        }),
+      ),
+    );
+
+    expect(results).toEqual([1, 2, 3]);
+  });
+
+  it('요청 사이에 minTime(100ms) 간격을 지킨다', async () => {
+    const timestamps: number[] = [];
+
+    await Promise.all(
+      [1, 2, 3].map(() =>
+        limiter.schedule({}, async () => {
+          timestamps.push(Date.now());
+        }),
+      ),
+    );
+
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i] - timestamps[i - 1]).toBeGreaterThanOrEqual(90);
+    }
+  }, 10000);
+
+  it('우선순위가 낮은 요청보다 높은 요청을 먼저 실행한다', async () => {
+    const results: string[] = [];
+
+    // 첫 번째 작업을 먼저 점유시키고, 나머지를 큐에 쌓음
+    const first = limiter.schedule({ priority: 5 }, async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      results.push('first');
+    });
+
+    // 첫 번째 실행 중에 큐에 등록
+    await new Promise((r) => setTimeout(r, 10));
+    const low = limiter.schedule({ priority: 9 }, async () => {
+      results.push('low');
+    });
+    const high = limiter.schedule({ priority: 1 }, async () => {
+      results.push('high');
+    });
+
+    await Promise.all([first, high, low]);
+
+    expect(results).toEqual(['first', 'high', 'low']);
+  }, 10000);
+
+  it('한 작업이 실패해도 큐에 남은 작업이 계속 실행된다', async () => {
+    const results: string[] = [];
+
+    const failing = limiter.schedule({}, async () => {
+      throw new Error('fail');
+    });
+    const next = limiter.schedule({}, async () => {
+      results.push('next');
+    });
+
+    await expect(failing).rejects.toThrow('fail');
+    await next;
+
+    expect(results).toEqual(['next']);
+  }, 10000);
+
+  it('동시에 2개 이상 실행되지 않는다 (maxConcurrent=1)', async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    await Promise.all(
+      [1, 2, 3].map(() =>
+        limiter.schedule({}, async () => {
+          concurrent++;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          await new Promise((r) => setTimeout(r, 20));
+          concurrent--;
+        }),
+      ),
+    );
+
+    expect(maxConcurrent).toBe(1);
+  }, 10000);
+});

--- a/src/google/google-api-limiter.service.ts
+++ b/src/google/google-api-limiter.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import Bottleneck from 'bottleneck';
+
+@Injectable()
+export class GoogleApiLimiter {
+  private readonly limiter = new Bottleneck({
+    maxConcurrent: 1,
+    minTime: 100,
+  });
+
+  schedule<T>(
+    options: { priority?: number },
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    return this.limiter.schedule(options, fn);
+  }
+}

--- a/src/google/google.module.ts
+++ b/src/google/google.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { MetricsModule } from '../common/metrics/metrics.module';
 import { GoogleCalendarsService } from './calendar/calendars.service';
 import { GoogleAclService } from './calendar/acl.service';
 import { GoogleCalendarListService } from './calendar/calendar-list.service';
@@ -6,8 +7,10 @@ import { GoogleEventsService } from './calendar/events.service';
 import { GoogleChannelsService } from './calendar/channels.service';
 import { GoogleFreebusyService } from './calendar/freebusy.service';
 import { GoogleOAuthService } from './oauth/google-oauth.service';
+import { GoogleApiLimiter } from './google-api-limiter.service';
 
 const services = [
+  GoogleApiLimiter,
   GoogleCalendarsService,
   GoogleAclService,
   GoogleCalendarListService,
@@ -18,6 +21,7 @@ const services = [
 ];
 
 @Module({
+  imports: [MetricsModule],
   providers: services,
   exports: services,
 })


### PR DESCRIPTION
## 개요

Google Calendar API 호출을 rate limiter로 제어하고, 실패 시 exponential backoff 재시도 로직을 추가했습니다. 또한 요청 횟수, 에러, rate limit, 재시도 메트릭을 추가해 Grafana에서 모니터링할 수 있습니다.

## 주요 변경 사항

### Rate Limiter 추가 (`google-api-limiter.service.ts`)
- `maxConcurrent: 1`, `minTime: 100ms` 설정으로 동시성 및 속도 제어
- 우선순위 지원 (`API_PRIORITY.USER`, `API_PRIORITY.CRON`)

### Retry 로직 추가 (`base.service.ts`)
- 429/500/503 에러 시 최대 3회 재시도
- `retry-after` 헤더 존재 시 해당 시간만큼 대기, 없으면 exponential backoff (1s → 2s → 4s)
- 재시도 중인 태스크는 큐의 다음 태스크보다 먼저 완료 보장

### 메트릭 추가 (`app.metrics.ts`)
- `google_api_requests_total` — operation별 요청 횟수
- `google_api_errors_total` — operation별 에러 횟수
- `google_api_rate_limit_total` — operation별 429 발생 횟수
- `google_api_retry_total` — operation별 재시도 횟수

### 단위 테스트 추가
- `google-api-limiter.service.spec.ts`: 순서 보장, minTime, 우선순위, 동시성, 에러 격리
- `base.service.spec.ts`: 성공, 429/500/503 재시도, retry-after, exponential backoff, maxRetries 초과, 비재시도 에러, 재시도 순서

## 관련 이슈

없음

## 테스트

- [x] 단위 테스트 14개 통과
- [x] 로컬에서 Slack 봇 실행 후 예약 동작 확인