### PR TITLE
feat(resource): 스터디룸 예약 모달 참석자 기본값에 본인 추가

### DIFF
--- a/src/resource/controller/study-room.controller.ts
+++ b/src/resource/controller/study-room.controller.ts
@@ -102,7 +102,7 @@ export class StudyRoomController {
 
     await client.views.push({
       trigger_id: body.trigger_id,
-      view: StudyRoomView.bookingModal(resource),
+      view: StudyRoomView.bookingModal(resource, undefined, [body.user.id]),
     });
   }
 
@@ -239,10 +239,17 @@ export class StudyRoomController {
     const resource = await this.resourceService.findById(roomId);
     if (!resource) return;
 
+    const currentAttendees =
+      values.attendees_block?.attendees_select?.selected_users ?? [];
+
     await client.views.update({
       view_id: view.id,
       hash: view.hash,
-      view: StudyRoomView.bookingModal(resource, calculatedEndTime),
+      view: StudyRoomView.bookingModal(
+        resource,
+        calculatedEndTime,
+        currentAttendees,
+      ),
     });
   }
 

--- a/src/resource/view/study-room.view.ts
+++ b/src/resource/view/study-room.view.ts
@@ -107,7 +107,11 @@ export class StudyRoomView {
   }
 
   // 스터디룸 예약 입력 모달 (종료 시간 계산값 표시 지원)
-  static bookingModal(resource: Resource, calculatedEndTime?: string): View {
+  static bookingModal(
+    resource: Resource,
+    calculatedEndTime?: string,
+    initialAttendeeSlackIds: string[] = [],
+  ): View {
     return {
       type: 'modal',
       callback_id: 'study-room:modal:book',
@@ -183,6 +187,7 @@ export class StudyRoomView {
           actionId: 'attendees_select',
           label: '참석자',
           placeholder: '참석자를 선택하세요',
+          initialUsers: initialAttendeeSlackIds,
           optional: true,
         }),
       ],


### PR DESCRIPTION
## 개요

스터디룸 예약 모달 최초 진입 시 본인이 참석자에 기본으로 선택된 상태로 표시되도록 변경.
기존에도 서비스 로직에서 본인이 자동 추가되었으나 UI에 반영되지 않아 사용자가 중복으로 본인을 추가하는 문제를 해결.

## 주요 변경 사항

### `StudyRoomView.bookingModal`
- `initialAttendeeSlackIds` 파라미터 추가
- `multiUsersSelectBlock`에 `initialUsers` 전달

### `StudyRoomController.openBookingModal`
- 모달 오픈 시 `body.user.id`를 초기 참석자로 전달

### `StudyRoomController.onTimeInputChanged`
- 시간 변경으로 모달 업데이트 시 현재 선택된 참석자를 읽어 그대로 유지 (기존에는 초기화됨)

## 관련 이슈

없음

## 테스트

- [x] 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->