### PR TITLE
fix: 일정 조회 페이지네이션 구현

### DIFF
--- a/src/cleaning/controller/cleaning-schedule.controller.ts
+++ b/src/cleaning/controller/cleaning-schedule.controller.ts
@@ -7,7 +7,10 @@ import type {
   BlockAction,
 } from '@slack/bolt';
 import { CleaningRuleService } from '../service/cleaning-rule.service';
-import { CleaningScheduleService } from '../service/cleaning-schedule.service';
+import {
+  CleaningScheduleService,
+  ScheduleWithAssignees,
+} from '../service/cleaning-schedule.service';
 import { CleaningScheduleView } from '../view/cleaning-schedule.view';
 import { PermissionService } from '../../user/service/permission.service';
 import { formatClassLabel } from '../../common/class-label.util';
@@ -16,6 +19,8 @@ import { UserRole } from '../../user/user.entity';
 import { BusinessError, CleaningErrorCode } from '../../common/errors';
 import { CleaningAssignmentStatus } from '../entity/cleaning-assignment.entity';
 import { CleaningScheduleStatus } from '../entity/cleaning-schedule.entity';
+
+const SCHEDULES_PER_PAGE = 4;
 
 @Controller()
 export class CleaningScheduleController {
@@ -61,6 +66,66 @@ export class CleaningScheduleController {
     return this.openScheduleDetail(args, 'past');
   }
 
+  @Action('cleaning:schedule:previous-page')
+  async openPreviousSchedulePage(
+    args: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs,
+  ) {
+    return this.changeSchedulePage(args);
+  }
+
+  @Action('cleaning:schedule:next-page')
+  async openNextSchedulePage(
+    args: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs,
+  ) {
+    return this.changeSchedulePage(args);
+  }
+
+  private async changeSchedulePage({
+    ack,
+    client,
+    body,
+  }: SlackActionMiddlewareArgs<BlockAction> & AllMiddlewareArgs) {
+    await ack();
+
+    const user = await this.permissionService.requireAdminOrClassRep(
+      body.user.id,
+    );
+    const action = body.actions[0] as { value: string };
+    const page = parseInt(action.value, 10);
+    const { ruleId, filter } = JSON.parse(
+      body.view?.private_metadata ?? '{}',
+    ) as { ruleId: number; filter: 'upcoming' | 'past' };
+
+    const rule = await this.cleaningRuleService.findOneWithDetails(ruleId);
+    if (!rule || !body.view?.id) return;
+    if (
+      user.role === UserRole.CLASS_REP &&
+      rule.studentClassId !== user.studentClassId
+    )
+      return;
+
+    const schedules =
+      await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+    const schedulePage = paginateSchedules(schedules, filter, page);
+    const label = formatClassLabel({
+      admissionYear: rule.studentClass.admissionYear,
+      section: rule.studentClass.section,
+      graduated: rule.studentClass.status === StudentClassStatus.GRADUATED,
+    });
+
+    await client.views.update({
+      view_id: body.view.id,
+      view: CleaningScheduleView.scheduleDetailModal(
+        schedulePage.schedules,
+        label,
+        ruleId,
+        filter,
+        schedulePage.page,
+        schedulePage.totalPages,
+      ),
+    });
+  }
+
   // 예정/지난 일정 상세 목록 렌더링을 공통 처리한다.
   private async openScheduleDetail(
     {
@@ -89,6 +154,7 @@ export class CleaningScheduleController {
 
     const schedules =
       await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+    const schedulePage = paginateSchedules(schedules, filter, 0);
     const label = formatClassLabel({
       admissionYear: rule.studentClass.admissionYear,
       section: rule.studentClass.section,
@@ -98,10 +164,12 @@ export class CleaningScheduleController {
     await client.views.push({
       trigger_id: body.trigger_id,
       view: CleaningScheduleView.scheduleDetailModal(
-        schedules,
+        schedulePage.schedules,
         label,
         ruleId,
         filter,
+        schedulePage.page,
+        schedulePage.totalPages,
       ),
     });
   }
@@ -117,9 +185,15 @@ export class CleaningScheduleController {
     await this.permissionService.requireAdminOrClassRep(body.user.id);
     const action = body.actions[0] as { value: string };
     const scheduleId = parseInt(action.value, 10);
-    const { ruleId, filter } = JSON.parse(
-      body.view?.private_metadata ?? '{}',
-    ) as { ruleId: number; filter: 'upcoming' | 'past' };
+    const {
+      ruleId,
+      filter,
+      page = 0,
+    } = JSON.parse(body.view?.private_metadata ?? '{}') as {
+      ruleId: number;
+      filter: 'upcoming' | 'past';
+      page?: number;
+    };
 
     const schedule =
       await this.cleaningScheduleService.findOneScheduleWithAssignees(
@@ -129,7 +203,12 @@ export class CleaningScheduleController {
 
     await client.views.push({
       trigger_id: body.trigger_id,
-      view: CleaningScheduleView.scheduleEditModal(schedule, ruleId, filter),
+      view: CleaningScheduleView.scheduleEditModal(
+        schedule,
+        ruleId,
+        filter,
+        page,
+      ),
     });
   }
 
@@ -144,9 +223,15 @@ export class CleaningScheduleController {
     await this.permissionService.requireAdminOrClassRep(body.user.id);
     const action = body.actions[0] as { value: string };
     const scheduleId = parseInt(action.value, 10);
-    const { ruleId, filter } = JSON.parse(
-      body.view?.private_metadata ?? '{}',
-    ) as { ruleId: number; filter: 'upcoming' | 'past' };
+    const {
+      ruleId,
+      filter,
+      page = 0,
+    } = JSON.parse(body.view?.private_metadata ?? '{}') as {
+      ruleId: number;
+      filter: 'upcoming' | 'past';
+      page?: number;
+    };
 
     const schedule =
       await this.cleaningScheduleService.findOneScheduleWithAssignees(
@@ -161,6 +246,7 @@ export class CleaningScheduleController {
         ruleId,
         filter,
         schedule.cleaningDate,
+        page,
       ),
     });
   }
@@ -173,9 +259,17 @@ export class CleaningScheduleController {
     body,
     client,
   }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
-    const { scheduleId, ruleId, filter } = JSON.parse(
-      view.private_metadata,
-    ) as { scheduleId: number; ruleId: number; filter: 'upcoming' | 'past' };
+    const {
+      scheduleId,
+      ruleId,
+      filter,
+      page = 0,
+    } = JSON.parse(view.private_metadata) as {
+      scheduleId: number;
+      ruleId: number;
+      filter: 'upcoming' | 'past';
+      page?: number;
+    };
 
     const [scheduleBefore, rule] = await Promise.all([
       this.cleaningScheduleService.findOneScheduleWithAssignees(scheduleId),
@@ -198,6 +292,7 @@ export class CleaningScheduleController {
             ruleId,
             filter,
             scheduleBefore?.cleaningDate ?? '',
+            page,
             e.message,
           ),
         } as any);
@@ -226,6 +321,7 @@ export class CleaningScheduleController {
     if (rule && body.view?.previous_view_id) {
       const schedules =
         await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+      const schedulePage = paginateSchedules(schedules, filter, page);
       const label = formatClassLabel({
         admissionYear: rule.studentClass.admissionYear,
         section: rule.studentClass.section,
@@ -234,10 +330,12 @@ export class CleaningScheduleController {
       await client.views.update({
         view_id: body.view.previous_view_id,
         view: CleaningScheduleView.scheduleDetailModal(
-          schedules,
+          schedulePage.schedules,
           label,
           ruleId,
           filter,
+          schedulePage.page,
+          schedulePage.totalPages,
         ),
       });
     }
@@ -255,9 +353,15 @@ export class CleaningScheduleController {
     await this.permissionService.requireAdminOrClassRep(body.user.id);
     const action = body.actions[0] as { value: string };
     const scheduleId = parseInt(action.value, 10);
-    const { ruleId, filter } = JSON.parse(
-      body.view?.private_metadata ?? '{}',
-    ) as { ruleId: number; filter: 'upcoming' | 'past' };
+    const {
+      ruleId,
+      filter,
+      page = 0,
+    } = JSON.parse(body.view?.private_metadata ?? '{}') as {
+      ruleId: number;
+      filter: 'upcoming' | 'past';
+      page?: number;
+    };
 
     const [scheduleBefore, rule] = await Promise.all([
       this.cleaningScheduleService.findOneScheduleWithAssignees(scheduleId),
@@ -298,6 +402,7 @@ export class CleaningScheduleController {
     if (rule && body.view?.id) {
       const schedules =
         await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+      const schedulePage = paginateSchedules(schedules, filter, page);
       const label = formatClassLabel({
         admissionYear: rule.studentClass.admissionYear,
         section: rule.studentClass.section,
@@ -306,10 +411,12 @@ export class CleaningScheduleController {
       await client.views.update({
         view_id: body.view.id,
         view: CleaningScheduleView.scheduleDetailModal(
-          schedules,
+          schedulePage.schedules,
           label,
           ruleId,
           filter,
+          schedulePage.page,
+          schedulePage.totalPages,
         ),
       });
     }
@@ -353,7 +460,12 @@ export class CleaningScheduleController {
       .flatMap(([blockId, field]) => {
         const value = field.status_select.selected_option?.value;
         if (!value) return [];
-        return [{ id: parseInt(blockId.replace('assignment_', ''), 10), status: value as CleaningAssignmentStatus }];
+        return [
+          {
+            id: parseInt(blockId.replace('assignment_', ''), 10),
+            status: value as CleaningAssignmentStatus,
+          },
+        ];
       });
 
     await this.cleaningScheduleService.updateAssignmentStatuses(updates);
@@ -371,9 +483,17 @@ export class CleaningScheduleController {
     view,
     logger,
   }: SlackViewMiddlewareArgs & AllMiddlewareArgs) {
-    const { scheduleId, ruleId, filter } = JSON.parse(
-      view.private_metadata,
-    ) as { scheduleId: number; ruleId: number; filter: 'upcoming' | 'past' };
+    const {
+      scheduleId,
+      ruleId,
+      filter,
+      page = 0,
+    } = JSON.parse(view.private_metadata) as {
+      scheduleId: number;
+      ruleId: number;
+      filter: 'upcoming' | 'past';
+      page?: number;
+    };
     const values = view.state.values;
 
     const cleaningDate =
@@ -455,6 +575,7 @@ export class CleaningScheduleController {
 
     const schedules =
       await this.cleaningScheduleService.findSchedulesByRule(ruleId);
+    const schedulePage = paginateSchedules(schedules, filter, page);
 
     if (rule && view.previous_view_id) {
       const label = formatClassLabel({
@@ -465,10 +586,12 @@ export class CleaningScheduleController {
       await client.views.update({
         view_id: view.previous_view_id,
         view: CleaningScheduleView.scheduleDetailModal(
-          schedules,
+          schedulePage.schedules,
           label,
           ruleId,
           filter,
+          schedulePage.page,
+          schedulePage.totalPages,
         ),
       });
     }
@@ -481,11 +604,36 @@ export class CleaningScheduleController {
   }
 }
 
+function paginateSchedules(
+  schedules: ScheduleWithAssignees[],
+  filter: 'upcoming' | 'past',
+  page: number,
+) {
+  const today = new Date().toISOString().split('T')[0];
+  const filtered =
+    filter === 'past'
+      ? schedules
+          .filter((schedule) => schedule.cleaningDate < today)
+          .sort((a, b) => b.cleaningDate.localeCompare(a.cleaningDate))
+      : schedules.filter((schedule) => schedule.cleaningDate >= today);
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filtered.length / SCHEDULES_PER_PAGE),
+  );
+  const currentPage = Math.min(Math.max(page, 0), totalPages - 1);
+  const start = currentPage * SCHEDULES_PER_PAGE;
+
+  return {
+    schedules: filtered.slice(start, start + SCHEDULES_PER_PAGE),
+    page: currentPage,
+    totalPages,
+  };
+}
+
 function dayLabel(dateStr: string): string {
   const [y, m, d] = dateStr.split('-').map(Number);
   return (
-    ['일', '월', '화', '수', '목', '금', '토'][
-      new Date(y, m - 1, d).getDay()
-    ] + '요일'
+    ['일', '월', '화', '수', '목', '금', '토'][new Date(y, m - 1, d).getDay()] +
+    '요일'
   );
 }

--- a/src/cleaning/view/cleaning-schedule.view.ts
+++ b/src/cleaning/view/cleaning-schedule.view.ts
@@ -59,15 +59,10 @@ export class CleaningScheduleView {
     ruleLabel: string,
     ruleId: number,
     filter: 'upcoming' | 'past',
+    page: number,
+    totalPages: number,
   ): View {
-    const today = new Date().toISOString().split('T')[0];
     const isPast = filter === 'past';
-
-    const filtered = isPast
-      ? [...schedules]
-          .filter((s) => s.cleaningDate < today)
-          .sort((a, b) => b.cleaningDate.localeCompare(a.cleaningDate))
-      : schedules.filter((s) => s.cleaningDate >= today);
 
     const blocks: View['blocks'] = [
       {
@@ -76,7 +71,7 @@ export class CleaningScheduleView {
       },
     ];
 
-    if (filtered.length === 0) {
+    if (schedules.length === 0) {
       blocks.push({
         type: 'section',
         text: {
@@ -85,7 +80,7 @@ export class CleaningScheduleView {
         },
       });
     } else {
-      for (const s of filtered) {
+      for (const s of schedules) {
         const assignedAssignees = s.assignees.filter(
           (a) => a.status === CleaningAssignmentStatus.ASSIGNED,
         );
@@ -149,10 +144,49 @@ export class CleaningScheduleView {
       }
     }
 
+    if (totalPages > 1) {
+      blocks.push(
+        {
+          type: 'actions',
+          elements: [
+            ...(page > 0
+              ? [
+                  {
+                    type: 'button' as const,
+                    text: { type: 'plain_text' as const, text: '이전' },
+                    action_id: 'cleaning:schedule:previous-page',
+                    value: String(page - 1),
+                  },
+                ]
+              : []),
+            ...(page < totalPages - 1
+              ? [
+                  {
+                    type: 'button' as const,
+                    text: { type: 'plain_text' as const, text: '다음' },
+                    action_id: 'cleaning:schedule:next-page',
+                    value: String(page + 1),
+                  },
+                ]
+              : []),
+          ],
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: page + 1 + ' / ' + totalPages + ' 페이지',
+            },
+          ],
+        },
+      );
+    }
+
     return {
       type: 'modal',
       callback_id: 'cleaning:modal:schedule-detail',
-      private_metadata: JSON.stringify({ ruleId, filter }),
+      private_metadata: JSON.stringify({ ruleId, filter, page }),
       title: { type: 'plain_text', text: isPast ? '지난 일정' : '예정 일정' },
       close: { type: 'plain_text', text: '닫기' },
       blocks,
@@ -225,6 +259,7 @@ export class CleaningScheduleView {
     schedule: ScheduleWithAssignees,
     ruleId: number,
     filter: 'upcoming' | 'past',
+    page: number,
   ): View {
     const statusOptions = [
       {
@@ -244,6 +279,7 @@ export class CleaningScheduleView {
         scheduleId: schedule.id,
         ruleId,
         filter,
+        page,
       }),
       title: { type: 'plain_text', text: '일정 수정' },
       submit: { type: 'plain_text', text: '저장' },
@@ -312,6 +348,7 @@ export class CleaningScheduleView {
     ruleId: number,
     filter: 'upcoming' | 'past',
     cleaningDate: string,
+    page: number,
     errorMessage?: string,
   ): View {
     const blocks: View['blocks'] = [
@@ -332,7 +369,7 @@ export class CleaningScheduleView {
     return {
       type: 'modal',
       callback_id: 'cleaning:modal:schedule-delete',
-      private_metadata: JSON.stringify({ scheduleId, ruleId, filter }),
+      private_metadata: JSON.stringify({ scheduleId, ruleId, filter, page }),
       title: { type: 'plain_text', text: '일정 삭제' },
       submit: { type: 'plain_text', text: '삭제' },
       close: { type: 'plain_text', text: '취소' },


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
청소 일정 조회 모달창을 페이지로 구분하여 조회하도록 변경
## 주요 변경 사항

<!-- 변경 항목마다 ### 제목으로 구분하고 하위 내용을 작성해주세요
### 변경한 기능 또는 파일
- 세부 내용
-->
### cleaning-schedule.controller.ts
- 일정 필터링, 이전/다음 버튼 처리, 수정, 삭제 후 페이지 유지
### cleaning-schedule.view.ts
-  이전/다음 버튼과 페이지 번호 표시
## 관련 이슈
모달창 블록 수 100개 초과시 에러 발생
<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- ✅ 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)
<img width="505" height="622" alt="image" src="https://github.com/user-attachments/assets/4565e563-7fa1-4363-a97f-1548f937c639" />

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
