### PR TITLE
Fix: 청소일정 기간 입력 검증

### DIFF
--- a/src/cleaning/controller/cleaning-rule.controller.ts
+++ b/src/cleaning/controller/cleaning-rule.controller.ts
@@ -479,6 +479,21 @@ export class CleaningRuleController {
     const endDate =
       values.end_date_block?.end_date_input?.selected_date ?? undefined;
 
+    if (startDate && !endDate) {
+      await ack({
+        response_action: 'errors',
+        errors: { end_date_block: '시작일과 종료일을 모두 입력해주세요.' },
+      });
+      return;
+    }
+    if (!startDate && endDate) {
+      await ack({
+        response_action: 'errors',
+        errors: { start_date_block: '시작일과 종료일을 모두 입력해주세요.' },
+      });
+      return;
+    }
+
     const today = new Date();
     const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
 

--- a/src/cleaning/controller/cleaning-rule.controller.ts
+++ b/src/cleaning/controller/cleaning-rule.controller.ts
@@ -577,8 +577,7 @@ export class CleaningRuleController {
 function dayLabel(dateStr: string): string {
   const [y, m, d] = dateStr.split('-').map(Number);
   return (
-    ['일', '월', '화', '수', '목', '금', '토'][
-      new Date(y, m - 1, d).getDay()
-    ] + '요일'
+    ['일', '월', '화', '수', '목', '금', '토'][new Date(y, m - 1, d).getDay()] +
+    '요일'
   );
 }

--- a/src/cleaning/service/cleaning-schedule.service.ts
+++ b/src/cleaning/service/cleaning-schedule.service.ts
@@ -12,7 +12,10 @@ import {
 } from '../entity/cleaning-assignment.entity';
 import { CleaningRule } from '../entity/cleaning-rule.entity';
 import { CleaningRuleUser } from '../entity/cleaning-rule-user.entity';
-import { CleaningTrade, CleaningTradeStatus } from '../entity/cleaning-trade.entity';
+import {
+  CleaningTrade,
+  CleaningTradeStatus,
+} from '../entity/cleaning-trade.entity';
 import { BusinessError, CleaningErrorCode } from '../../common/errors';
 
 export interface ScheduleWithAssignees {
@@ -66,7 +69,9 @@ export class CleaningScheduleService {
       order: { cleaningDate: 'DESC' },
     });
     // 같은 규칙/날짜 unique 제약을 피하기 위해 이미 생성된 날짜는 제외한다.
-    const existingDates = new Set(existing.map((s) => toDateStr(s.cleaningDate)));
+    const existingDates = new Set(
+      existing.map((s) => toDateStr(s.cleaningDate)),
+    );
 
     // 배정 횟수가 적은 사람부터 배정해 장기적으로 담당 횟수를 맞춘다.
     const assignmentCounts = await this.getAssignmentCounts(
@@ -83,7 +88,11 @@ export class CleaningScheduleService {
     let si = 0;
     while (si < usersByCnt.length) {
       let ei = si;
-      while (ei < usersByCnt.length && usersByCnt[ei].count === usersByCnt[si].count) ei++;
+      while (
+        ei < usersByCnt.length &&
+        usersByCnt[ei].count === usersByCnt[si].count
+      )
+        ei++;
       for (let k = ei - 1; k > si; k--) {
         const r = si + Math.floor(Math.random() * (k - si + 1));
         [usersByCnt[k], usersByCnt[r]] = [usersByCnt[r], usersByCnt[k]];
@@ -104,7 +113,10 @@ export class CleaningScheduleService {
       // 마지막 일정 이후부터 전원 1사이클 생성
       const lastSchedule = existing[0];
       const startFrom = lastSchedule
-        ? nextDayAfter(parseLocalDate(toDateStr(lastSchedule.cleaningDate)), rule.daysOfWeek)
+        ? nextDayAfter(
+            parseLocalDate(toDateStr(lastSchedule.cleaningDate)),
+            rule.daysOfWeek,
+          )
         : localToday();
       const totalSchedules = Math.ceil(sortedUserIds.length / rule.needPeoples);
       cleaningDates = getNDates(startFrom, rule.daysOfWeek, totalSchedules);
@@ -123,7 +135,10 @@ export class CleaningScheduleService {
       if (schedulesInCycle > 0 && schedulesInCycle % cycleSchedules === 0) {
         for (let k = sortedUserIds.length - 1; k > 0; k--) {
           const r = Math.floor(Math.random() * (k + 1));
-          [sortedUserIds[k], sortedUserIds[r]] = [sortedUserIds[r], sortedUserIds[k]];
+          [sortedUserIds[k], sortedUserIds[r]] = [
+            sortedUserIds[r],
+            sortedUserIds[k],
+          ];
         }
         userIndex = 0;
       }
@@ -168,9 +183,7 @@ export class CleaningScheduleService {
     return this.attachAssignees(schedules);
   }
 
-  async findSchedulesByIds(
-    ids: number[],
-  ): Promise<ScheduleWithAssignees[]> {
+  async findSchedulesByIds(ids: number[]): Promise<ScheduleWithAssignees[]> {
     if (ids.length === 0) return [];
     const schedules = await this.scheduleRepo.find({ where: { id: In(ids) } });
     return this.attachAssignees(schedules);
@@ -277,7 +290,9 @@ export class CleaningScheduleService {
           where: { scheduleId, status: CleaningAssignmentStatus.CANCELED },
         });
         const canceledByUser = new Map(canceled.map((a) => [a.userId, a.id]));
-        const candidates = ruleUsers.filter((ru) => !assignedUserIds.has(ru.userId));
+        const candidates = ruleUsers.filter(
+          (ru) => !assignedUserIds.has(ru.userId),
+        );
 
         let added = 0;
         for (const ru of candidates) {
@@ -305,7 +320,9 @@ export class CleaningScheduleService {
     updates: { id: number; status: CleaningAssignmentStatus }[],
   ): Promise<void> {
     await Promise.all(
-      updates.map(({ id, status }) => this.assignmentRepo.update(id, { status })),
+      updates.map(({ id, status }) =>
+        this.assignmentRepo.update(id, { status }),
+      ),
     );
   }
 
@@ -348,7 +365,9 @@ export class CleaningScheduleService {
       }
     }
 
-    await this.scheduleRepo.update(scheduleId, { needPeoples: ruleUsers.length });
+    await this.scheduleRepo.update(scheduleId, {
+      needPeoples: ruleUsers.length,
+    });
   }
 
   // 대기 중인 교환 요청이 있으면 삭제를 막아 배정 교환 흐름이 꼬이지 않게 한다.
@@ -400,7 +419,9 @@ export class CleaningScheduleService {
     const today = localTodayStr();
 
     for (const ruleId of ruleIds) {
-      const remainingUsers = await this.ruleUserRepo.find({ where: { ruleId } });
+      const remainingUsers = await this.ruleUserRepo.find({
+        where: { ruleId },
+      });
       if (remainingUsers.length === 0) continue;
 
       const remainingUserIds = remainingUsers.map((ru) => ru.userId);
@@ -410,9 +431,13 @@ export class CleaningScheduleService {
         .innerJoin('a.schedule', 's')
         .where('a.userId = :userId', { userId })
         .andWhere('s.ruleId = :ruleId', { ruleId })
-        .andWhere('s.status = :sStatus', { sStatus: CleaningScheduleStatus.SCHEDULED })
+        .andWhere('s.status = :sStatus', {
+          sStatus: CleaningScheduleStatus.SCHEDULED,
+        })
         .andWhere('s.cleaningDate >= :today', { today })
-        .andWhere('a.status = :aStatus', { aStatus: CleaningAssignmentStatus.ASSIGNED })
+        .andWhere('a.status = :aStatus', {
+          aStatus: CleaningAssignmentStatus.ASSIGNED,
+        })
         .select(['a.id AS id', 'a.scheduleId AS "scheduleId"'])
         .getRawMany<{ id: number; scheduleId: number }>();
 
@@ -430,18 +455,28 @@ export class CleaningScheduleService {
       for (const fa of futureAssignments) {
         // 같은 일정에 이미 배정된 사람을 제외하고 가장 적게 배정된 담당자를 대체자로 고른다.
         const alreadyAssigned = await this.assignmentRepo.find({
-          where: { scheduleId: fa.scheduleId, status: CleaningAssignmentStatus.ASSIGNED },
+          where: {
+            scheduleId: fa.scheduleId,
+            status: CleaningAssignmentStatus.ASSIGNED,
+          },
           select: ['userId'],
         });
         const assignedSet = new Set(alreadyAssigned.map((a) => a.userId));
 
         const canceledRecords = await this.assignmentRepo.find({
-          where: { scheduleId: fa.scheduleId, status: CleaningAssignmentStatus.CANCELED },
+          where: {
+            scheduleId: fa.scheduleId,
+            status: CleaningAssignmentStatus.CANCELED,
+          },
           select: ['id', 'userId'],
         });
-        const canceledByUser = new Map(canceledRecords.map((a) => [a.userId, a.id]));
+        const canceledByUser = new Map(
+          canceledRecords.map((a) => [a.userId, a.id]),
+        );
 
-        const candidates = remainingUserIds.filter((uid) => !assignedSet.has(uid));
+        const candidates = remainingUserIds.filter(
+          (uid) => !assignedSet.has(uid),
+        );
         if (candidates.length === 0) continue;
 
         const replacement = candidates.reduce((best, uid) =>
@@ -472,18 +507,25 @@ export class CleaningScheduleService {
   async completePastSchedules(): Promise<void> {
     const today = localTodayStr();
     const toComplete = await this.scheduleRepo.find({
-      where: { status: CleaningScheduleStatus.SCHEDULED, cleaningDate: LessThan(today) },
+      where: {
+        status: CleaningScheduleStatus.SCHEDULED,
+        cleaningDate: LessThan(today),
+      },
       select: ['id'],
     });
     if (toComplete.length > 0) {
       const ids = toComplete.map((s) => s.id);
-      await this.scheduleRepo.update(ids, { status: CleaningScheduleStatus.COMPLETED });
+      await this.scheduleRepo.update(ids, {
+        status: CleaningScheduleStatus.COMPLETED,
+      });
       await this.assignmentRepo.update(
         { scheduleId: In(ids), status: CleaningAssignmentStatus.ASSIGNED },
         { status: CleaningAssignmentStatus.COMPLETED },
       );
     }
-    this.logger.log(`completePastSchedules: ${toComplete.length} schedules completed`);
+    this.logger.log(
+      `completePastSchedules: ${toComplete.length} schedules completed`,
+    );
   }
 
   private async cancelPendingTradesForAssignments(

--- a/src/cleaning/service/cleaning-schedule.service.ts
+++ b/src/cleaning/service/cleaning-schedule.service.ts
@@ -51,6 +51,10 @@ export class CleaningScheduleService {
     startDateStr?: string,
     endDateStr?: string,
   ): Promise<{ count: number; scheduleIds: number[] }> {
+    if (!!startDateStr !== !!endDateStr) {
+      return { count: 0, scheduleIds: [] };
+    }
+
     const rule = await this.ruleRepo.findOne({ where: { id: ruleId } });
     if (!rule) return { count: 0, scheduleIds: [] };
 
@@ -91,10 +95,10 @@ export class CleaningScheduleService {
 
     let cleaningDates: string[];
 
-    if (startDateStr || endDateStr) {
+    if (startDateStr && endDateStr) {
       // 관리자가 기간을 지정하면 해당 기간 안의 청소 요일만 골라 생성한다.
-      const start = startDateStr ? parseLocalDate(startDateStr) : localToday();
-      const end = endDateStr ? parseLocalDate(endDateStr) : null;
+      const start = parseLocalDate(startDateStr);
+      const end = parseLocalDate(endDateStr);
       cleaningDates = getDatesInRange(start, end, rule.daysOfWeek);
     } else {
       // 마지막 일정 이후부터 전원 1사이클 생성
@@ -596,14 +600,13 @@ function toDateStr(date: Date | string): string {
 
 function getDatesInRange(
   start: Date,
-  end: Date | null,
+  end: Date,
   daysOfWeek: number[],
 ): string[] {
   const daySet = new Set(daysOfWeek);
   const dates: string[] = [];
   const cur = new Date(start);
-  const limit = end ?? new Date(start.getFullYear() + 1, start.getMonth(), start.getDate());
-  while (cur <= limit) {
+  while (cur <= end) {
     if (daySet.has(cur.getDay())) dates.push(toDateStr(cur));
     cur.setDate(cur.getDate() + 1);
   }


### PR DESCRIPTION
## 개요

<!-- 이 PR에서 무엇을 변경했는지 간략히 설명해주세요 -->
청소 일정 생성 시 시작일과 종료일 입력 검증 및 1년 기본 생성 제거
## 주요 변경 사항

<!-- 변경 항목마다 ### 제목으로 구분하고 하위 내용을 작성해주세요
### 변경한 기능 또는 파일
- 세부 내용
-->
###  cleaning-rule.controller.ts
- 시작일 또는 종료일 하나만 선택 시 모달 오류를 발생시키도록 변경
### cleaning-schedule.service.ts
- 시작일만 입력하고 종료일을 입력하지않은 경우 1년치 일정을 생성하던 코드 제거
- 날짜 범위 생성은 시작일과 종료일 둘 다 입력했을 때 작동하도록 변경
## 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요 (예: Closes #123) -->

## 테스트

- ✅ 로컬에서 Slack 봇 실행 후 동작 확인

## 스크린샷 (선택)
<img width="510" height="431" alt="image" src="https://github.com/user-attachments/assets/f72823de-897e-49bc-a65c-8c4c6904893e" />

<!-- Slack UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
